### PR TITLE
fix: correct unit conversions and add group ride recommendations

### DIFF
--- a/app/api/maps_api.py
+++ b/app/api/maps_api.py
@@ -136,8 +136,8 @@ def get_dashboard_map_data() -> Dict:
                 'opacity': 0.7,
                 'popup_html': f"""
                     <strong>{group.get('name', 'Route')}</strong><br>
-                    Distance: {rep_route.get('distance', 0):.1f} mi<br>
-                    Elevation: {rep_route.get('elevation_gain', 0):.0f} ft<br>
+                    Distance: {rep_route.get('distance', 0) / 1000:.1f} km<br>
+                    Elevation: {rep_route.get('elevation_gain', 0):.0f} m<br>
                     Uses: {group.get('count', 0)}
                 """,
                 'tooltip': group.get('name', 'Route')
@@ -145,7 +145,7 @@ def get_dashboard_map_data() -> Dict:
             'markers': []
         }
         layers.append(layer)
-    
+
     return {
         'status': 'success',
         'center': center,
@@ -226,8 +226,8 @@ def get_commute_map_data() -> Dict:
                 'popup_html': f"""
                     <strong>{group.get('name', 'Route')}</strong><br>
                     {'<span class="badge bg-success">Recommended</span><br>' if is_recommended else ''}
-                    Distance: {rep_route.get('distance', 0):.1f} mi<br>
-                    Elevation: {rep_route.get('elevation_gain', 0):.0f} ft<br>
+                    Distance: {rep_route.get('distance', 0) / 1000:.1f} km<br>
+                    Elevation: {rep_route.get('elevation_gain', 0):.0f} m<br>
                     Uses: {group.get('count', 0)}
                 """,
                 'tooltip': group.get('name', 'Route')
@@ -299,8 +299,8 @@ def get_route_detail_map_data(route_id: str) -> Dict:
         'opacity': 0.8,
         'popup_html': f"""
             <strong>{route_group.get('name', 'Route')}</strong><br>
-            Distance: {rep_route.get('distance', 0):.1f} mi<br>
-            Elevation: {rep_route.get('elevation_gain', 0):.0f} ft<br>
+            Distance: {rep_route.get('distance', 0) / 1000:.1f} km<br>
+            Elevation: {rep_route.get('elevation_gain', 0):.0f} m<br>
             Uses: {route_group.get('count', 0)}
         """,
         'tooltip': route_group.get('name', 'Route')

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -616,7 +616,94 @@ class AnalysisService:
         """
         self._load_from_cache()
         return self._activities if self._activities else []
-    
+
+    def find_group_rides_for_day(self, target_weekday: int,
+                                 min_duration_minutes: int = 0,
+                                 limit: int = 5) -> List[Dict[str, Any]]:
+        """
+        Find recurring non-commute rides for a specific day of week.
+
+        Looks at historical activities, groups by name similarity on the
+        target weekday, and returns the most frequent patterns.
+
+        Args:
+            target_weekday: 0=Monday .. 6=Sunday
+            min_duration_minutes: Minimum ride duration to consider
+            limit: Max results to return
+
+        Returns:
+            List of dicts with ride pattern info, sorted by frequency
+        """
+        from collections import Counter
+        import re
+
+        self._load_from_cache()
+        activities = self._activities or []
+
+        commute_directions = set()
+        if self._route_groups:
+            for rg in self._route_groups:
+                commute_directions.add(rg.direction)
+
+        min_duration_s = min_duration_minutes * 60
+
+        day_rides = []
+        for a in activities:
+            if not a.start_date or a.type not in ('Ride', 'GravelRide', 'EBikeRide'):
+                continue
+            try:
+                dt = datetime.fromisoformat(a.start_date.replace('Z', '+00:00'))
+            except (ValueError, AttributeError):
+                continue
+            if dt.weekday() != target_weekday:
+                continue
+            if a.moving_time < min_duration_s:
+                continue
+            day_rides.append(a)
+
+        if not day_rides:
+            return []
+
+        # Normalize ride names for grouping
+        def normalize(name: str) -> str:
+            name = name.lower().strip()
+            name = re.sub(r'[#\d/\-]+', '', name)
+            name = re.sub(r'\s+', ' ', name).strip()
+            return name
+
+        # Group by normalized name
+        name_groups: Dict[str, List] = {}
+        for a in day_rides:
+            key = normalize(a.name)
+            if not key or key in ('morning ride', 'afternoon ride', 'evening ride',
+                                   'lunch ride', 'ride'):
+                continue
+            name_groups.setdefault(key, []).append(a)
+
+        if not name_groups:
+            return []
+
+        results = []
+        for norm_name, rides in sorted(name_groups.items(),
+                                        key=lambda x: len(x[1]), reverse=True):
+            rides.sort(key=lambda a: a.start_date or '', reverse=True)
+            latest = rides[0]
+            avg_duration = sum(a.moving_time for a in rides) / len(rides)
+            avg_distance = sum(a.distance for a in rides) / len(rides)
+
+            results.append({
+                'name': latest.name,
+                'normalized_name': norm_name,
+                'frequency': len(rides),
+                'avg_duration_minutes': round(avg_duration / 60),
+                'avg_distance_miles': round(avg_distance / 1609.34, 1),
+                'latest_date': latest.start_date,
+                'latest_activity_id': latest.id,
+                'activity_ids': [a.id for a in rides[:10]],
+            })
+
+        return results[:limit]
+
     def get_locations(self) -> Tuple[Optional[Location], Optional[Location]]:
         """
         Get home and work locations.

--- a/app/services/commute_service.py
+++ b/app/services/commute_service.py
@@ -294,6 +294,7 @@ class CommuteService:
         """
         route_group = rec.route_group
         
+        rep = route_group.representative_route
         result = {
             'status': 'success',
             'direction': rec.direction,
@@ -301,12 +302,12 @@ class CommuteService:
             'route': {
                 'id': route_group.id,
                 'name': route_group.name or f"Route {route_group.id}",
-                'distance': route_group.representative_route.distance,
-                'duration': route_group.representative_route.duration,
-                'elevation': route_group.representative_route.elevation_gain,
+                'distance': rep.distance / 1000,
+                'duration': rep.duration / 60,
+                'elevation': rep.elevation_gain,
                 'frequency': route_group.frequency,
                 'is_plus_route': route_group.is_plus_route,
-                'coordinates': route_group.representative_route.coordinates
+                'coordinates': rep.coordinates
             },
             'score': rec.score,
             'breakdown': rec.breakdown,
@@ -539,8 +540,8 @@ class CommuteService:
         route = route_option.get('route', {})
         weather = route_option.get('weather') or {}
         route_name = escape(route.get('name', 'Unknown Route'))
-        distance_km = route.get('distance', 0) / 1000
-        duration_min = route.get('duration', 0) / 60
+        distance_km = route.get('distance', 0)
+        duration_min = route.get('duration', 0)
         elevation_m = route.get('elevation', 0)
         score_pct = route_option.get('score', 0) * 100
         
@@ -745,7 +746,8 @@ class CommuteService:
                 workout_constraints
             )
             if extended_rec:
-                extended_rec['workout_fit'] = workout_fit
+                extended_fit = self._analyze_workout_fit(extended_rec, workout_constraints)
+                extended_rec['workout_fit'] = extended_fit
                 extended_rec['is_workout_extended'] = True
                 return extended_rec
         
@@ -817,8 +819,8 @@ class CommuteService:
             Dictionary with fit analysis
         """
         route = recommendation.get('route', {})
-        duration_min = route.get('duration', 0)
-        
+        duration_min = route.get('duration', 0) / 60  # duration stored in seconds
+
         workout_name = constraints.get('workout_name', 'Unknown Workout')
         workout_type = constraints.get('workout_type', 'Unknown')
         min_duration = constraints.get('min_duration_minutes')
@@ -878,17 +880,18 @@ class CommuteService:
         Returns:
             True if route should be extended
         """
-        # Only extend for endurance workouts
-        if constraints.get('workout_type') != 'Endurance':
+        # Don't extend for high-intensity workouts best done indoors
+        indoor_types = {'VO2Max', 'Sprint', 'Anaerobic'}
+        if constraints.get('workout_type') in indoor_types:
             return False
-        
+
         # Don't extend if indoor fallback is preferred
         if constraints.get('indoor_fallback', False):
             return False
         
         # Check if current route is too short
         route = recommendation.get('route', {})
-        duration_min = route.get('duration', 0)
+        duration_min = route.get('duration', 0) / 60  # duration stored in seconds
         min_duration = constraints.get('min_duration_minutes')
         
         if min_duration and duration_min < min_duration:

--- a/app/services/trainerroad_service.py
+++ b/app/services/trainerroad_service.py
@@ -248,7 +248,8 @@ class TrainerRoadService:
             ('Sprint', ['sprint', 'neuromuscular']),
             ('Threshold', ['threshold', 'sweet spot', 'ftp test']),
             ('Tempo', ['tempo']),
-            ('Endurance', ['endurance', 'easy', 'recovery', 'base'])
+            ('Endurance', ['endurance', 'easy', 'recovery', 'base']),
+            ('Group Ride', ['group ride', 'group'])
         ]
 
         for workout_type, keywords in type_keywords:
@@ -458,6 +459,13 @@ class TrainerRoadService:
             constraints['indoor_preferred'] = True
             constraints['preferred_intensity'] = 'high'
             constraints['notes'].append('High-intensity workout - consider indoor trainer')
+
+        elif wtype == 'Group Ride':
+            constraints['min_duration_minutes'] = duration or 60
+            constraints['max_duration_minutes'] = (duration or 60) + 60
+            constraints['preferred_intensity'] = 'moderate'
+            constraints['indoor_preferred'] = False
+            constraints['notes'].append('Group ride — match to historical day-of-week pattern')
 
         elif wtype == 'Recovery':
             constraints['max_duration_minutes'] = 45

--- a/launch.py
+++ b/launch.py
@@ -659,7 +659,7 @@ def get_recommendation():
                 'recommended_route': {
                     'id': route.get('id'),
                     'name': route.get('name', 'Unknown Route'),
-                    'distance': route.get('distance', 0) / 1000,
+                    'distance': route.get('distance', 0),
                     'duration': route.get('duration', 0),
                     'elevation_gain': route.get('elevation', 0),
                     'coordinates': route.get('coordinates', [])
@@ -1006,8 +1006,8 @@ def get_workout_options():
                         'route': {
                             'id': route.get('id'),
                             'name': route.get('name', 'Commute'),
-                            'distance': route.get('distance'),
-                            'elevation': route.get('elevation'),
+                            'distance': route.get('distance', 0),
+                            'elevation': route.get('elevation', 0),
                         },
                         'fit_score': wf.get('fit_score', 0) if wf else 0,
                         'is_extended': commute_rec.get('is_workout_extended', False),
@@ -1034,8 +1034,8 @@ def get_workout_options():
                     options['workout_ride'] = {
                         'route': {
                             'name': best['name'],
-                            'distance': best['distance_miles'],
-                            'elevation': best['elevation_ft'],
+                            'distance': best['distance_miles'] * 1.60934,
+                            'elevation': best['elevation_ft'] / 3.28084,
                         },
                         'fit_score': best['score'],
                         'duration_minutes': best['duration_minutes'],
@@ -1043,6 +1043,28 @@ def get_workout_options():
                     }
             except Exception as e:
                 logger.warning(f"Workout-options: workout ride unavailable: {e}")
+
+        # Group ride option — match historical rides for this day of week
+        if constraints.get('workout_type') == 'Group Ride' and _analysis_service:
+            try:
+                target_weekday = _date.today().weekday()
+                group_rides = _analysis_service.find_group_rides_for_day(
+                    target_weekday=target_weekday,
+                    min_duration_minutes=constraints.get('min_duration_minutes') or 30,
+                    limit=3,
+                )
+                if group_rides:
+                    best = group_rides[0]
+                    options['group_ride'] = {
+                        'name': best['name'],
+                        'frequency': best['frequency'],
+                        'avg_duration_minutes': best['avg_duration_minutes'],
+                        'avg_distance_miles': best['avg_distance_miles'],
+                        'latest_date': best['latest_date'],
+                        'alternatives': group_rides[1:],
+                    }
+            except Exception as e:
+                logger.warning(f"Workout-options: group ride lookup failed: {e}")
 
         # Indoor option (always available)
         options['indoor'] = {

--- a/static/js/commute.js
+++ b/static/js/commute.js
@@ -159,17 +159,10 @@
         const scorePercent = typeof score === 'number' ? (score <= 1 ? score * 100 : score) : 0;
         const scoreClass = scorePercent >= 70 ? '' : scorePercent >= 50 ? 'medium' : 'low';
         
-        // Format metrics
-        const distanceKm = (route.distance / 1000).toFixed(1);
-        const distanceMi = (distanceKm * 0.621371).toFixed(1);
-        const durationMin = Math.round(route.duration / 60);
-        const elevationM = Math.round(route.elevation);
-        const elevationFt = Math.round(elevationM * 3.28084);
-        
-        // Get unit system preference
-        const unitSystem = window.getUnitSystem ? window.getUnitSystem() : 'imperial';
-        const distance = unitSystem === 'metric' ? `${distanceKm} km` : `${distanceMi} mi`;
-        const elevation = unitSystem === 'metric' ? `${elevationM} m` : `${elevationFt} ft`;
+        // Format metrics — API returns distance in km, duration in minutes, elevation in meters
+        const durationMin = Math.round(route.duration);
+        const distance = window.formatDistance ? window.formatDistance(route.distance) : `${route.distance.toFixed(1)} km`;
+        const elevation = window.formatElevation ? window.formatElevation(route.elevation) : `${Math.round(route.elevation)} m`;
         
         // Weather data
         const weather = recommendation.weather || {};

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -39,6 +39,7 @@ const WORKOUT_TYPE_BADGES = {
     'Sprint':     'bg-danger',
     'Anaerobic':  'bg-danger',
     'Recovery':   'bg-success',
+    'Group Ride': 'bg-info text-dark',
 };
 
 /**
@@ -179,7 +180,7 @@ function renderWorkoutOptionCards(options, esc) {
                 <div class="fw-semibold small">${esc((c.route && c.route.name) || 'Commute route')}</div>
                 <div class="d-flex gap-2 small text-muted">
                     ${c.duration_minutes ? `<span>${c.duration_minutes} min</span>` : ''}
-                    ${c.route && c.route.distance ? `<span>${c.route.distance.toFixed(1)} mi</span>` : ''}
+                    ${c.route && c.route.distance ? `<span>${window.formatDistance(c.route.distance)}</span>` : ''}
                 </div>
                 <span class="badge ${scoreClass} mt-1">${scorePct > 0 ? scorePct + ' fit' : 'Commute fit'}</span>
             </div>`);
@@ -195,9 +196,23 @@ function renderWorkoutOptionCards(options, esc) {
                 <div class="fw-semibold small">${esc((wr.route && wr.route.name) || 'Best match')}</div>
                 <div class="d-flex gap-2 small text-muted">
                     ${wr.duration_minutes ? `<span>${wr.duration_minutes} min</span>` : ''}
-                    ${wr.route && wr.route.distance ? `<span>${wr.route.distance.toFixed(1)} mi</span>` : ''}
+                    ${wr.route && wr.route.distance ? `<span>${window.formatDistance(wr.route.distance)}</span>` : ''}
                 </div>
                 <span class="badge ${scoreClass} mt-1">${scorePct > 0 ? scorePct + ' match' : 'Best match'}</span>
+            </div>`);
+    }
+
+    if (options.group_ride) {
+        const gr = options.group_ride;
+        cards.push(`
+            <div class="workout-option-card${!options.commute ? ' active' : ''}" data-option="group_ride" role="button" tabindex="0">
+                <div class="workout-option-label"><i class="bi bi-people"></i> Group Ride</div>
+                <div class="fw-semibold small">${esc(gr.name)}</div>
+                <div class="d-flex gap-2 small text-muted">
+                    ${gr.avg_duration_minutes ? `<span>~${gr.avg_duration_minutes} min</span>` : ''}
+                    ${gr.avg_distance_miles ? `<span>~${gr.avg_distance_miles} mi</span>` : ''}
+                </div>
+                <span class="badge bg-info text-dark mt-1">${gr.frequency}x ridden</span>
             </div>`);
     }
 
@@ -681,8 +696,8 @@ function renderHeroCard(rec, isHero) {
                 ` : ''}
                 ${renderWorkoutFitRow(rec)}
                 <div class="hero-meta small text-muted mt-2">
-                    <span><i class="bi bi-signpost"></i> ${route.distance ? route.distance.toFixed(1) : '—'} mi</span>
-                    <span class="ms-3"><i class="bi bi-graph-up"></i> ${route.elevation || '—'} ft</span>
+                    <span><i class="bi bi-signpost"></i> ${route.distance ? window.formatDistance(route.distance) : '—'}</span>
+                    <span class="ms-3"><i class="bi bi-graph-up"></i> ${route.elevation != null ? window.formatElevation(route.elevation) : '—'}</span>
                     ${departureTime ? `<span class="ms-3"><i class="bi bi-alarm"></i> ${departureTime}</span>` : ''}
                 </div>
                 ${transitBanner}
@@ -713,7 +728,7 @@ function renderHeroCard(rec, isHero) {
             ${weatherSummary ? `<div class="small text-muted mt-1">${weatherSummary}</div>` : ''}
             <div class="d-flex gap-3 mt-1 small text-muted">
                 ${estMins ? `<span><i class="bi bi-clock"></i> ${estMins} min</span>` : ''}
-                <span><i class="bi bi-signpost"></i> ${route.distance ? route.distance.toFixed(1) : '—'} mi</span>
+                <span><i class="bi bi-signpost"></i> ${route.distance ? window.formatDistance(route.distance) : '—'}</span>
             </div>
             ${renderWorkoutFitCompact(rec)}
         </div>`;
@@ -929,8 +944,8 @@ async function loadRouteStats() {
         // Calculate statistics
         const totalRoutes = routes.length;
         const favoriteRoutes = routes.filter(r => r.is_favorite).length;
-        const totalDistance = routes.reduce((sum, r) => sum + (r.distance || 0), 0);
-        const avgDistance = totalRoutes > 0 ? (totalDistance / totalRoutes).toFixed(1) : 0;
+        const totalDistanceKm = routes.reduce((sum, r) => sum + (r.distance || 0), 0);
+        const avgDistanceKm = totalRoutes > 0 ? totalDistanceKm / totalRoutes : 0;
         
         // Stats HTML
         const statsHtml = `
@@ -952,14 +967,14 @@ async function loadRouteStats() {
                 <div class="col-md-3">
                     <div class="stat-card">
                         <i class="bi bi-speedometer2 fs-2 text-success"></i>
-                        <h3 class="mt-2">${totalDistance.toFixed(0)}</h3>
-                        <small class="text-muted">Total Miles</small>
+                        <h3 class="mt-2">${window.formatDistance(totalDistanceKm, 0)}</h3>
+                        <small class="text-muted">Total Distance</small>
                     </div>
                 </div>
                 <div class="col-md-3">
                     <div class="stat-card">
                         <i class="bi bi-graph-up fs-2 text-info"></i>
-                        <h3 class="mt-2">${avgDistance}</h3>
+                        <h3 class="mt-2">${window.formatDistance(avgDistanceKm)}</h3>
                         <small class="text-muted">Avg Distance</small>
                     </div>
                 </div>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -81,8 +81,8 @@ class TestLaunchAPIEndpoints:
             'route': {
                 'id': 'route-1',
                 'name': 'Main Route',
-                'distance': 5200,
-                'duration': 1500,
+                'distance': 5.2,
+                'duration': 25,
                 'elevation': 45,
                 'coordinates': [(40.7128, -74.0060), (40.7589, -73.9851)]
             },

--- a/tests/test_commute_service.py
+++ b/tests/test_commute_service.py
@@ -38,8 +38,8 @@ def mock_route():
     """Create a mock route."""
     route = Mock(spec=Route)
     route.activity_id = "12345"
-    route.distance = 10.5
-    route.duration = 1800  # 30 minutes
+    route.distance = 10500  # 10.5 km in meters
+    route.duration = 1800  # 30 min in seconds
     route.elevation_gain = 150.0
     route.coordinates = [
         (40.7128, -74.0060),
@@ -360,8 +360,8 @@ class TestFormatRecommendation:
         assert result['time_window'] == 'morning'
         assert result['route']['id'] == 'route_123'
         assert result['route']['name'] == 'Main Commute Route'
-        assert result['route']['distance'] == 10.5
-        assert result['route']['duration'] == 1800
+        assert result['route']['distance'] == 10.5  # 10500m → 10.5 km
+        assert result['route']['duration'] == 30  # 1800s → 30 min
         assert result['route']['elevation'] == 150.0
         assert result['route']['frequency'] == 25
         assert result['route']['is_plus_route'] is False
@@ -848,7 +848,7 @@ class TestAnalyzeWorkoutFit:
     """Test _analyze_workout_fit."""
 
     def test_duration_matches(self, commute_service):
-        recommendation = {'route': {'duration': 45}}  # 45 "minutes" (code reads raw value)
+        recommendation = {'route': {'duration': 2700}}  # 45 min (seconds)
         constraints = {
             'workout_name': 'Endurance',
             'workout_type': 'Endurance',
@@ -863,7 +863,7 @@ class TestAnalyzeWorkoutFit:
         assert result['indoor_fallback'] is False
 
     def test_duration_too_short(self, commute_service):
-        recommendation = {'route': {'duration': 10}}
+        recommendation = {'route': {'duration': 600}}  # 10 min (seconds)
         constraints = {
             'workout_name': 'Long Ride',
             'workout_type': 'Endurance',
@@ -876,7 +876,7 @@ class TestAnalyzeWorkoutFit:
         assert result['fit_score'] < 0.5
 
     def test_duration_too_long(self, commute_service):
-        recommendation = {'route': {'duration': 7200}}  # 120 min
+        recommendation = {'route': {'duration': 7200}}  # 120 min (seconds)
         constraints = {
             'workout_name': 'Recovery',
             'workout_type': 'Recovery',
@@ -889,7 +889,7 @@ class TestAnalyzeWorkoutFit:
         assert 'longer than recommended' in result['fit_reasons'][0]
 
     def test_indoor_fallback_penalty(self, commute_service):
-        recommendation = {'route': {'duration': 2400}}
+        recommendation = {'route': {'duration': 2400}}  # 40 min (seconds)
         constraints = {
             'workout_name': 'Sprint Intervals',
             'workout_type': 'VO2Max',
@@ -913,17 +913,35 @@ class TestShouldExtendForWorkout:
             'indoor_fallback': False,
             'min_duration_minutes': 60
         }
-        recommendation = {'route': {'duration': 30}}  # 30 < 60
+        recommendation = {'route': {'duration': 1800}}  # 30 min in seconds < 60 min target
         assert commute_service._should_extend_for_workout(constraints, recommendation) is True
 
-    def test_no_extend_for_non_endurance(self, commute_service):
+    def test_no_extend_for_indoor_intensity(self, commute_service):
         constraints = {
             'workout_type': 'VO2Max',
             'indoor_fallback': False,
             'min_duration_minutes': 60
         }
-        recommendation = {'route': {'duration': 1800}}
+        recommendation = {'route': {'duration': 1800}}  # 30 min in seconds
         assert commute_service._should_extend_for_workout(constraints, recommendation) is False
+
+    def test_extends_for_untyped_workout(self, commute_service):
+        constraints = {
+            'workout_type': None,
+            'indoor_fallback': False,
+            'min_duration_minutes': 90
+        }
+        recommendation = {'route': {'duration': 2220}}  # 37 min in seconds
+        assert commute_service._should_extend_for_workout(constraints, recommendation) is True
+
+    def test_extends_for_tempo_workout(self, commute_service):
+        constraints = {
+            'workout_type': 'Tempo',
+            'indoor_fallback': False,
+            'min_duration_minutes': 75
+        }
+        recommendation = {'route': {'duration': 2220}}  # 37 min in seconds
+        assert commute_service._should_extend_for_workout(constraints, recommendation) is True
 
     def test_no_extend_for_indoor_fallback(self, commute_service):
         constraints = {
@@ -931,7 +949,7 @@ class TestShouldExtendForWorkout:
             'indoor_fallback': True,
             'min_duration_minutes': 60
         }
-        recommendation = {'route': {'duration': 1800}}
+        recommendation = {'route': {'duration': 1800}}  # 30 min in seconds
         assert commute_service._should_extend_for_workout(constraints, recommendation) is False
 
     def test_no_extend_when_duration_sufficient(self, commute_service):
@@ -940,7 +958,7 @@ class TestShouldExtendForWorkout:
             'indoor_fallback': False,
             'min_duration_minutes': 30
         }
-        recommendation = {'route': {'duration': 2400}}  # 40 min > 30 min
+        recommendation = {'route': {'duration': 2400}}  # 40 min in seconds > 30 min target
         assert commute_service._should_extend_for_workout(constraints, recommendation) is False
 
 
@@ -961,7 +979,7 @@ class TestExtendRouteForWorkout:
         commute_service._recommender.get_all_recommendations.return_value = []
 
         result = commute_service._extend_route_for_workout(
-            {'direction': 'to_work', 'route': {'duration': 1800}},
+            {'direction': 'to_work', 'route': {'duration': 30}},
             {'min_duration_minutes': 120, 'workout_name': 'Long Endurance'}
         )
         assert result is None
@@ -983,7 +1001,7 @@ class TestExtendRouteForWorkout:
         commute_service._recommender.get_all_recommendations.return_value = [extended_rec]
 
         result = commute_service._extend_route_for_workout(
-            {'direction': 'to_work', 'route': {'duration': 1800}},
+            {'direction': 'to_work', 'route': {'duration': 30}},
             {'min_duration_minutes': 60, 'workout_name': 'Endurance Ride'}
         )
         assert result is not None
@@ -994,7 +1012,7 @@ class TestExtendRouteForWorkout:
         commute_service._recommender.get_all_recommendations.side_effect = Exception("Boom")
 
         result = commute_service._extend_route_for_workout(
-            {'direction': 'to_work', 'route': {'duration': 1800}},
+            {'direction': 'to_work', 'route': {'duration': 30}},
             {'min_duration_minutes': 60, 'workout_name': 'Test'}
         )
         assert result is None


### PR DESCRIPTION
## Summary
- Fix seconds-to-minutes conversion bugs in workout fit scoring and route extension logic — a 37-min commute was being compared as 2220 "minutes" against workout targets
- Recognize "Group Ride" as its own workout type and match it to historical Strava rides by day-of-week pattern (e.g., WNR on Wednesdays)
- Fix unit conversions in map popups, commute page, and API tests (parallel session)

## Test plan
- [x] All 117 commute/trainerroad/route-naming tests pass
- [ ] Verify workout fit shows "too short" for a 37-min commute against a 90-min workout
- [ ] Verify group ride option card appears when TrainerRoad has a Group Ride scheduled
- [ ] Verify map popup distances/durations display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)