### PR TITLE
fix: convert commute forecast weather to imperial units

### DIFF
--- a/app/services/commute_service.py
+++ b/app/services/commute_service.py
@@ -318,9 +318,18 @@ class CommuteService:
             'confidence': self._get_confidence_label(rec.score)
         }
         
-        # Add weather if available
+        # Add weather if available — convert to the same imperial schema
+        # /api/weather uses (temperature/wind_speed/precipitation_probability),
+        # since forecast_weather comes from next_commute_recommender in metric units
         if rec.forecast_weather:
-            result['weather'] = rec.forecast_weather
+            fw = rec.forecast_weather
+            result['weather'] = {
+                'temperature': round(fw['temp_c'] * 9 / 5 + 32),
+                'wind_speed': round(fw['wind_speed_kph'] * 0.621371),
+                'wind_gust': round(fw['wind_gust_kph'] * 0.621371),
+                'wind_direction_deg': fw['wind_direction_deg'],
+                'precipitation_probability': round(fw['precipitation_prob']),
+            }
         
         return result
     

--- a/tests/test_commute_service.py
+++ b/tests/test_commute_service.py
@@ -166,11 +166,13 @@ class TestGetNextCommute:
         mock_rec.window_start = time(7, 0)
         mock_rec.window_end = time(9, 0)
         mock_rec.forecast_weather = {
-            'temperature': 72.0,
-            'conditions': 'Clear',
-            'wind_speed': 5.0
+            'temp_c': 22.2,
+            'wind_speed_kph': 8.0,
+            'wind_gust_kph': 12.0,
+            'wind_direction_deg': 180,
+            'precipitation_prob': 5.0
         }
-        
+
         commute_service._recommender = Mock()
         commute_service._recommender.get_next_commute_recommendations.return_value = {'to_work': mock_rec}
 
@@ -385,18 +387,17 @@ class TestFormatRecommendation:
         rec.window_start = time(16, 0)
         rec.window_end = time(17, 30)
         rec.forecast_weather = {
-            'temperature': 68.0,
-            'conditions': 'Partly Cloudy',
-            'wind_speed': 8.0,
-            'wind_direction': 'NW',
-            'precipitation': 0.0
+            'temp_c': 20.0,
+            'wind_speed_kph': 12.9,
+            'wind_gust_kph': 19.3,
+            'wind_direction_deg': 315,
+            'precipitation_prob': 0.0
         }
-        
+
         result = commute_service._format_recommendation(rec)
-        
+
         assert 'weather' in result
         assert result['weather']['temperature'] == 68.0
-        assert result['weather']['conditions'] == 'Partly Cloudy'
         assert result['weather']['wind_speed'] == 8.0
         assert result['is_today'] is False
     


### PR DESCRIPTION
## Summary
- `_format_recommendation()` was passing next_commute_recommender's raw metric weather dict (`temp_c`/`wind_speed_kph`/`precipitation_prob`) straight through as the API's `weather` field, but the frontend (commute.js) reads `temperature`/`wind_speed`/`precipitation` — so commute cards always showed weather as N/A and severity as Unknown.
- Converts to the same imperial schema `/api/weather` already uses.
- Updated `test_commute_service.py` mocks to use the real raw field names instead of the already-converted ones that were masking the bug.

## Test plan
- [x] `pytest tests/test_commute_service.py` — 61/61 passed
- [x] `pytest tests/test_api.py tests/test_next_commute_recommender.py` — 66/66 passed
- [x] Confirmed root cause live against the Pi deployment's `/api/commute` response

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>