### PR TITLE
Design Review Epic #352: Fair Weather rebrand + 20-issue UX pass

### DIFF
--- a/.bob/github_labels.md
+++ b/.bob/github_labels.md
@@ -42,6 +42,7 @@
 - `touch` - Touch interaction
 - `gestures` - Gesture support
 - `routes` - Route-related features
+- `explore` - Explore tab — tile coverage, route generation, yard(inho)
 - `notifications` - Notifications and toasts
 - `toast` - Toast notifications
 - `undo` - Undo functionality

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,7 +76,7 @@ A server-side route search endpoint exists but the frontend ignores it — the r
 
 **Brand identity:** `docs/designs/FAIR_WEATHER_BRAND_BOOK.md` (adopted 2026-07-05) — logo mark, Day/Night color tokens, type, and reference screens for the current "Fair Weather" identity. `docs/designs/BRAND_CONCEPTS_COMPARISON.html` holds the two alternate directions that were reviewed and not chosen. **Design rules:** `plans/v0.6.0/DESIGN_PRINCIPLES.md` (v2.2) is the living guideline doc — mobile-first, visual hierarchy, color usage, map/controls layout, etc.
 
-`static/css/main.css` and `static/*.html` have **not yet been updated** to the Fair Weather tokens — they still carry the pre-rebrand indigo gradient (`#667eea`/`#764ba2`). When touching UI, check the brand book before introducing a new color, icon, or shape rather than matching the current (soon-to-be-replaced) styling.
+`static/css/main.css` and all `static/*.html` pages have been migrated to the Fair Weather Day/Night tokens (colors, navbar, cards, buttons, focus rings) — no pre-rebrand indigo gradient (`#667eea`/`#764ba2`) remains. When touching UI, check the brand book before introducing a new color, icon, or shape rather than reaching for a one-off hardcoded value.
 
 ## Key Patterns
 

--- a/ISSUE_PRIORITIES.md
+++ b/ISSUE_PRIORITIES.md
@@ -1,6 +1,6 @@
 # Issue Prioritization
 
-**Last Updated:** 2026-07-06 02:54:26 UTC / 2026-07-05 21:54:26 CDT
+**Last Updated:** 2026-07-06 03:00:45 UTC / 2026-07-05 22:00:45 CDT
 
 This file reflects the current state of GitHub issues organized by release milestone and priority within each release.
 
@@ -24,7 +24,6 @@ This file reflects the current state of GitHub issues organized by release miles
 ### 🔴 P1 - HIGH
 - #436 - PR #431: CoverageTracker silently falls back to test fixture data when activities cache is missing
 - #432 - PR #431: kill_existing_server dropped process-ownership check (security regression)
-- #352 - Epic: Design Review — Information Density, Discoverability & Card Placement
 
 ### 🟡 P2 - MEDIUM
 - #435 - PR #431: static/js/mobile.js is dead code — new nav/swipe logic never executes
@@ -51,14 +50,11 @@ This file reflects the current state of GitHub issues organized by release miles
 - #405 - Explore: generate a tile-acquisition overlay for today's workout route
 - #404 - Explore: add yard(inho) optimization mode — max new tiles vs. infill
 - #402 - Explore: support round-trip vs. point-to-point route type with configurable endpoint
-- #375 - [Design Review] Apply unit system preference to temperature slider, Reports distance label, and Explore distance slider
-- #374 - [Design Review] Ship or gracefully degrade help modal tutorial assets
-- #373 - [Design Review] Weather: add comfort score legend; fix hardcoded commute window time labels
-- #371 - [Design Review] Route Detail: demote Uses metric; surface performance charts above history tables
-- #368 - [Design Review] Settings: split Connections card; nest Outdoor Prefs; move Save above About
-- #369 - [Design Review] Reports: hide empty secondary stats; move admin gear buttons to Settings
 
 ### 🟢 P3 - LOW
+- #443 - PR #431: bottom-nav-more drawer markup duplicated across 7 pages
+- #442 - PR #431: reports.js duplicates unit-conversion and stats-derivation logic
+- #441 - PR #431: CLAUDE.md's 'main.css not yet migrated' note goes stale once this PR merges
 - #440 - PR #431: Route Detail stat grid col-4 layout has no responsive breakpoint
 - #439 - PR #431: Night-mode token gaps — hardcoded divider color and .text-muted vs --ink-soft drift
 - #438 - PR #431: three inconsistent disclosure/chevron toggle patterns shipped in one PR
@@ -67,7 +63,6 @@ This file reflects the current state of GitHub issues organized by release miles
 - #419 - Phase 6: Cleanup — remove dead code, update AGENTS.md architecture section
 - #410 - Explore: minimize route overlap with already-visited tiles where possible
 - #409 - Explore: differentiate Phase-1 and Phase-2 polylines for the same direction with tonal color variants
-- #376 - [Design Review] P3 polish bundle: stale versions, missing H1s, a11y minor, UX polish items
 
 ### 📋 P4 - FUTURE
 **No P4 issues** ✅

--- a/ISSUE_PRIORITIES.md
+++ b/ISSUE_PRIORITIES.md
@@ -1,6 +1,6 @@
 # Issue Prioritization
 
-**Last Updated:** 2026-07-05 16:21:40 UTC / 2026-07-05 11:21:40 CDT
+**Last Updated:** 2026-07-05 19:42:35 UTC / 2026-07-05 14:42:35 CDT
 
 This file reflects the current state of GitHub issues organized by release milestone and priority within each release.
 
@@ -30,6 +30,13 @@ This file reflects the current state of GitHub issues organized by release miles
 - #352 - Epic: Design Review — Information Density, Discoverability & Card Placement
 
 ### 🟡 P2 - MEDIUM
+- #408 - Explore: clicking a map polyline highlights the corresponding route in the list
+- #407 - Explore: clicking a route list item highlights the polyline on the map
+- #406 - Explore: suggest adjacent-tile routes for future yard(inho) expansion in low-coverage areas
+- #405 - Explore: generate a tile-acquisition overlay for today's workout route
+- #404 - Explore: add yard(inho) optimization mode — max new tiles vs. infill
+- #403 - Explore: support round-trip vs. point-to-point route type with configurable endpoint
+- #402 - Explore: support round-trip vs. point-to-point route type with configurable endpoint
 - #375 - [Design Review] Apply unit system preference to temperature slider, Reports distance label, and Explore distance slider
 - #374 - [Design Review] Ship or gracefully degrade help modal tutorial assets
 - #373 - [Design Review] Weather: add comfort score legend; fix hardcoded commute window time labels
@@ -38,14 +45,16 @@ This file reflects the current state of GitHub issues organized by release miles
 - #371 - [Design Review] Route Detail: demote Uses metric; surface performance charts above history tables
 - #369 - [Design Review] Reports: hide empty secondary stats; move admin gear buttons to Settings
 - #368 - [Design Review] Settings: split Connections card; nest Outdoor Prefs; move Save above About
-- #367 - [Design Review] Explore: move coverage stats below map; merge controls into route generation card
 - #366 - [Design Review] Reports: reorder cards — Activities before Gear; consolidate chart cards
+- #367 - [Design Review] Explore: move coverage stats below map; merge controls into route generation card
 - #365 - [Design Review] Routes Library: invert column ratio to give route list more space than map
 - #363 - [Design Review] Dashboard: relocate 'How It Works' button out of above-the-fold content
 - #364 - [Design Review] Routes Library: collapse advanced filters behind 'More Filters' toggle
 - #362 - [Design Review] Navigation: add Reports and Explore to mobile bottom nav
 
 ### 🟢 P3 - LOW
+- #410 - Explore: minimize route overlap with already-visited tiles where possible
+- #409 - Explore: differentiate Phase-1 and Phase-2 polylines for the same direction with tonal color variants
 - #376 - [Design Review] P3 polish bundle: stale versions, missing H1s, a11y minor, UX polish items
 
 ### 📋 P4 - FUTURE

--- a/ISSUE_PRIORITIES.md
+++ b/ISSUE_PRIORITIES.md
@@ -1,6 +1,6 @@
 # Issue Prioritization
 
-**Last Updated:** 2026-07-05 19:42:35 UTC / 2026-07-05 14:42:35 CDT
+**Last Updated:** 2026-07-06 02:54:26 UTC / 2026-07-05 21:54:26 CDT
 
 This file reflects the current state of GitHub issues organized by release milestone and priority within each release.
 
@@ -8,7 +8,7 @@ This file reflects the current state of GitHub issues organized by release miles
 
 ## 📍 Release Context
 
-- **Current Release:** v0.16.0 (deployed, milestone fully closed)
+- **Current Release:** none (deployed, milestone fully closed)
 - **Next Release:** v0.17.0 (in development)
 - **Future Releases:** 
 
@@ -22,37 +22,49 @@ This file reflects the current state of GitHub issues organized by release miles
 **No P0 issues** ✅
 
 ### 🔴 P1 - HIGH
-- #361 - [Design Review] Explore: add numbered workflow steps and progressive button enablement
-- #360 - [Design Review] Explore: add tile/Squadrats concept explainer and coverage legend
-- #359 - [Design Review] Route Detail: replace raw JSON weather dump with formatted card
-- #358 - [Design Review] Dashboard: fix mobile column stacking and widen decision panel
-- #357 - [Design Review] Weather: swap 7-day forecast and same-day commute windows order
+- #436 - PR #431: CoverageTracker silently falls back to test fixture data when activities cache is missing
+- #432 - PR #431: kill_existing_server dropped process-ownership check (security regression)
 - #352 - Epic: Design Review — Information Density, Discoverability & Card Placement
 
 ### 🟡 P2 - MEDIUM
+- #435 - PR #431: static/js/mobile.js is dead code — new nav/swipe logic never executes
+- #434 - PR #431: Reports Personal Records silently truncate at 1000 activities for all-time period
+- #433 - PR #431: ORS empty-list response bypasses unroutable-waypoint error handling
+- #428 - Phase 4i: Extract strava_bp Blueprint (/api/strava/*, /api/setup/*)
+- #427 - Phase 4h: Extract integrations_bp Blueprint (/api/intervals/*, /api/ors/*, /api/garmin/*, /api/trainerroad/*)
+- #426 - Phase 4g: Extract data_bp Blueprint (/api/analyze/*, /api/fetch/*, /api/cache-info, /api/activities)
+- #425 - Phase 4f: Extract commute_bp Blueprint (/api/commute, /api/recommendation, /api/workout-options)
+- #424 - Phase 4e: Extract core_bp Blueprint (/api/status, /api/settings/*, /api/plans/*, /api/user/*)
+- #423 - Phase 4d: Extract planner_bp Blueprint (/api/planner/*, /api/exploration/*, /api/geocode)
+- #422 - Phase 4c: Extract weather_bp Blueprint (/api/weather/*)
+- #421 - Phase 4b: Extract routes_bp Blueprint (/api/routes/*)
+- #420 - Phase 4a: Extract stats_bp Blueprint (/api/stats/*)
+- #418 - Phase 5: Thin launch.py — wire create_app(), reduce to ~120 lines
+- #416 - Phase 3: Parallel service initialisation via ServiceContainer
+- #415 - Phase 2: Extract infrastructure — credentials, env helpers, process management
+- #413 - Epic: launch.py Blueprint Refactor — Split 3,404-line monolith into 9 focused Blueprints
+- #412 - Epic: Explore Tab Enhancements — v0.17.0
+- #411 - Explore: allow exclusion of major highways, unpaved roads, and high-traffic roads
 - #408 - Explore: clicking a map polyline highlights the corresponding route in the list
 - #407 - Explore: clicking a route list item highlights the polyline on the map
 - #406 - Explore: suggest adjacent-tile routes for future yard(inho) expansion in low-coverage areas
 - #405 - Explore: generate a tile-acquisition overlay for today's workout route
 - #404 - Explore: add yard(inho) optimization mode — max new tiles vs. infill
-- #403 - Explore: support round-trip vs. point-to-point route type with configurable endpoint
 - #402 - Explore: support round-trip vs. point-to-point route type with configurable endpoint
 - #375 - [Design Review] Apply unit system preference to temperature slider, Reports distance label, and Explore distance slider
 - #374 - [Design Review] Ship or gracefully degrade help modal tutorial assets
 - #373 - [Design Review] Weather: add comfort score legend; fix hardcoded commute window time labels
-- #372 - [Design Review] Routes Library: label compare checkbox; add entry-point for Saved Plans
-- #370 - [Design Review] Dashboard: add affordance labels and count badges to collapse toggles
 - #371 - [Design Review] Route Detail: demote Uses metric; surface performance charts above history tables
-- #369 - [Design Review] Reports: hide empty secondary stats; move admin gear buttons to Settings
 - #368 - [Design Review] Settings: split Connections card; nest Outdoor Prefs; move Save above About
-- #366 - [Design Review] Reports: reorder cards — Activities before Gear; consolidate chart cards
-- #367 - [Design Review] Explore: move coverage stats below map; merge controls into route generation card
-- #365 - [Design Review] Routes Library: invert column ratio to give route list more space than map
-- #363 - [Design Review] Dashboard: relocate 'How It Works' button out of above-the-fold content
-- #364 - [Design Review] Routes Library: collapse advanced filters behind 'More Filters' toggle
-- #362 - [Design Review] Navigation: add Reports and Explore to mobile bottom nav
+- #369 - [Design Review] Reports: hide empty secondary stats; move admin gear buttons to Settings
 
 ### 🟢 P3 - LOW
+- #440 - PR #431: Route Detail stat grid col-4 layout has no responsive breakpoint
+- #439 - PR #431: Night-mode token gaps — hardcoded divider color and .text-muted vs --ink-soft drift
+- #438 - PR #431: three inconsistent disclosure/chevron toggle patterns shipped in one PR
+- #437 - PR #431: Weather comfort pills use hardcoded hex colors instead of brand tokens
+- #430 - Coverage tracker should include Garmin activities, not just Strava
+- #419 - Phase 6: Cleanup — remove dead code, update AGENTS.md architecture section
 - #410 - Explore: minimize route overlap with already-visited tiles where possible
 - #409 - Explore: differentiate Phase-1 and Phase-2 polylines for the same direction with tonal color variants
 - #376 - [Design Review] P3 polish bundle: stale versions, missing H1s, a11y minor, UX polish items
@@ -66,23 +78,7 @@ This file reflects the current state of GitHub issues organized by release miles
 
 These issues need to be assigned to a release milestone and prioritized.
 
-### 🔴 P0 - CRITICAL
-None
-
-### 🔴 P1 - HIGH
-None
-
-### 🟡 P2 - MEDIUM
-None
-
-### 🟢 P3 - LOW
-None
-
-### 📋 P4 - FUTURE
-None
-
-### ⚠️ Unprioritized (No P-label)
-- #345 - [FEATURE] Manage and monitor python launch.py dev server processes (no PID tracking, kill_existing_server is a no-op on Windows)
+**All issues are assigned to releases** ✅
 
 ---
 

--- a/app/services/exploration_service.py
+++ b/app/services/exploration_service.py
@@ -117,6 +117,40 @@ class ExplorationService:
             profile = "cycling-regular"
             raw = ors_client.get_route(ors_coords, profile, api_key=api_key, timeout=timeout)
 
+        # Unroutable waypoints: drop every interior bad waypoint and retry.
+        # "Interior" = not the first (start) or last (end) coordinate.
+        # We identify bad waypoints by their [lon, lat] coordinates, not by
+        # index, because ORS index numbering can vary across versions.
+        # Retry until no interior waypoints remain to drop (guard against loops).
+        _drop_attempts = 0
+        while raw is not None and raw.get("_ors_unroutable"):
+            bad_coords = {(round(lon, 4), round(lat, 4)) for lon, lat in raw["_ors_unroutable"]}
+            # Only drop interior points (preserve first and last).
+            interior = ors_coords[1:-1]
+            pruned = [c for c in interior if (round(c[0], 4), round(c[1], 4)) not in bad_coords]
+            if len(pruned) == len(interior):
+                # None of the bad coords matched an interior waypoint — can't fix.
+                break
+            ors_coords = [ors_coords[0]] + pruned + [ors_coords[-1]]
+            logger.info(
+                "Dropped %d unroutable interior waypoint(s); retrying with %d coords",
+                len(interior) - len(pruned), len(ors_coords),
+            )
+            _drop_attempts += 1
+            if len(ors_coords) < 2 or _drop_attempts > 10:
+                break
+            # Re-check cache for the pruned list.
+            cache_key = (
+                tuple((round(c[1], 6), round(c[0], 6)) for c in ors_coords),
+                profile,
+            )
+            cached = self._route_cache.get(cache_key)
+            if cached is not None:
+                result, expires_at = cached
+                if time.monotonic() < expires_at:
+                    return result
+            raw = ors_client.get_route(ors_coords, profile, api_key=api_key, timeout=timeout)
+
         if raw is None:
             return {"status": "error", "message": "Road routing request failed"}
         if raw.get("_ors_rate_limited"):
@@ -124,6 +158,8 @@ class ExplorationService:
                 "status": "error",
                 "message": "Road routing rate limit reached — try again shortly",
             }
+        if raw.get("_ors_unroutable"):
+            return {"status": "error", "message": "Road routing failed: no routable path near waypoints"}
 
         try:
             result = self._parse_ors_response(raw)

--- a/app/services/exploration_service.py
+++ b/app/services/exploration_service.py
@@ -158,7 +158,7 @@ class ExplorationService:
                 "status": "error",
                 "message": "Road routing rate limit reached — try again shortly",
             }
-        if raw.get("_ors_unroutable"):
+        if raw.get("_ors_unroutable") is not None:
             return {"status": "error", "message": "Road routing failed: no routable path near waypoints"}
 
         try:

--- a/launch.py
+++ b/launch.py
@@ -2877,9 +2877,16 @@ def _compute_summary(activities):
     }
 
 
+# Sport types treated as "cycling" for Personal Records (#376) — mirrors the
+# activity-type-filter dropdown options minus Run. Keep in sync with
+# CYCLING_TYPES in static/js/reports.js.
+_CYCLING_SPORT_TYPES = {'Ride', 'GravelRide', 'EBikeRide', 'VirtualRide'}
+
+
 def _compute_records(activities):
-    """Personal records across activities."""
-    if not activities:
+    """Personal records across cycling activities only (#376, #434)."""
+    cycling = [a for a in activities if (a.sport_type or a.type) in _CYCLING_SPORT_TYPES]
+    if not cycling:
         return {}
 
     def _fmt(a):
@@ -2892,10 +2899,10 @@ def _compute_records(activities):
             'time_h': round(_seconds_to_hours(a.moving_time), 1),
         }
 
-    longest = max(activities, key=lambda a: a.distance)
-    highest_elev = max(activities, key=lambda a: a.total_elevation_gain)
-    fastest = max(activities, key=lambda a: a.average_speed)
-    most_kj = max((a for a in activities if a.kilojoules), key=lambda a: a.kilojoules, default=None)
+    longest = max(cycling, key=lambda a: a.distance)
+    highest_elev = max(cycling, key=lambda a: a.total_elevation_gain)
+    fastest = max(cycling, key=lambda a: a.average_speed)
+    most_kj = max((a for a in cycling if a.kilojoules), key=lambda a: a.kilojoules, default=None)
     records = {
         'longest_ride': _fmt(longest),
         'most_elevation': _fmt(highest_elev),

--- a/launch.py
+++ b/launch.py
@@ -116,7 +116,8 @@ def set_security_headers(response):
         "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com; "
         "img-src 'self' data: https: blob:; "
         "font-src 'self' https://cdn.jsdelivr.net; "
-        "connect-src 'self'; "
+        "connect-src 'self' https://cdn.jsdelivr.net https://unpkg.com; "
+        "frame-src 'self' blob:; "
         "frame-ancestors 'none'"
     )
     

--- a/launch.py
+++ b/launch.py
@@ -1681,7 +1681,8 @@ def strava_connect():
     # Remember if the user came from the setup wizard
     if request.args.get('setup_redirect') == '1':
         session['setup_redirect'] = True
-    client_id = os.getenv('STRAVA_CLIENT_ID')
+    _env = _read_env()
+    client_id = _env.get('STRAVA_CLIENT_ID') or os.getenv('STRAVA_CLIENT_ID')
     redirect_uri = url_for('strava_callback', _external=True)
     auth_url = (
         'https://www.strava.com/oauth/authorize'
@@ -1715,8 +1716,8 @@ def strava_callback():
         import requests as http_req
         _env = _read_env()
         resp = http_req.post('https://www.strava.com/oauth/token', data={
-            'client_id': os.getenv('STRAVA_CLIENT_ID') or _env.get('STRAVA_CLIENT_ID'),
-            'client_secret': os.getenv('STRAVA_CLIENT_SECRET') or _env.get('STRAVA_CLIENT_SECRET'),
+            'client_id': _env.get('STRAVA_CLIENT_ID') or os.getenv('STRAVA_CLIENT_ID'),
+            'client_secret': _env.get('STRAVA_CLIENT_SECRET') or os.getenv('STRAVA_CLIENT_SECRET'),
             'code': code,
             'grant_type': 'authorization_code',
         }, timeout=15)

--- a/launch.py
+++ b/launch.py
@@ -112,10 +112,12 @@ def set_security_headers(response):
     # Content Security Policy
     response.headers['Content-Security-Policy'] = (
         "default-src 'self'; "
-        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com; "
-        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com; "
+        "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com "
+        "https://code.jquery.com https://cdnjs.cloudflare.com; "
+        "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://unpkg.com "
+        "https://cdnjs.cloudflare.com https://netdna.bootstrapcdn.com; "
         "img-src 'self' data: https: blob:; "
-        "font-src 'self' https://cdn.jsdelivr.net; "
+        "font-src 'self' https://cdn.jsdelivr.net https://netdna.bootstrapcdn.com; "
         "connect-src 'self' https://cdn.jsdelivr.net https://unpkg.com; "
         "frame-src 'self' blob:; "
         "frame-ancestors 'none'"

--- a/launch.py
+++ b/launch.py
@@ -3328,6 +3328,8 @@ def _is_our_server_process(pid: int) -> bool:
         # Must be alive and belong to current user
         if proc.status() == psutil.STATUS_ZOMBIE:
             return False
+        if proc.username() != psutil.Process().username():
+            return False
         cmdline = proc.cmdline()
         # Expect: [...python..., ...launch.py..., '--serve', ...]
         cmdline_str = ' '.join(cmdline)

--- a/launch.py
+++ b/launch.py
@@ -3267,92 +3267,263 @@ def open_browser(port):
         logger.info(f"Please open your browser manually to: {url}")
 
 
-def kill_existing_server(port):
-    """Kill any existing server process running on the specified port."""
-    import subprocess
-    import signal
-    
-    # Validate port is an integer in valid range
+# ---------------------------------------------------------------------------
+# Process management helpers (cross-platform, uses psutil)
+# ---------------------------------------------------------------------------
+
+def _pid_file_path() -> str:
+    """Return the canonical path for the server PID file."""
+    import tempfile
+    return os.path.join(tempfile.gettempdir(), 'ride-optimizer-server.pid')
+
+
+def _write_pid_file(pid: int, port: int) -> None:
+    """Write PID, port, and start time to the PID file."""
+    pid_path = _pid_file_path()
+    data = {
+        'pid': pid,
+        'port': port,
+        'started': datetime.now().isoformat(),
+    }
+    with open(pid_path, 'w') as fh:
+        json.dump(data, fh)
+    try:
+        os.chmod(pid_path, 0o600)
+    except OSError:
+        pass  # Windows doesn't support chmod; not critical
+
+
+def _read_pid_file() -> dict:
+    """Read PID file. Returns {} if missing or corrupt."""
+    try:
+        with open(_pid_file_path()) as fh:
+            return json.load(fh)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _remove_pid_file() -> None:
+    """Remove the PID file if it exists."""
+    try:
+        os.remove(_pid_file_path())
+    except FileNotFoundError:
+        pass
+
+
+def _is_our_server_process(pid: int) -> bool:
+    """Return True if *pid* is a live launch.py --serve process owned by us."""
+    try:
+        import psutil
+        proc = psutil.Process(pid)
+        # Must be alive and belong to current user
+        if proc.status() == psutil.STATUS_ZOMBIE:
+            return False
+        cmdline = proc.cmdline()
+        # Expect: [...python..., ...launch.py..., '--serve', ...]
+        cmdline_str = ' '.join(cmdline)
+        return 'launch.py' in cmdline_str and '--serve' in cmdline_str
+    except Exception:
+        return False
+
+
+def _find_server_on_port(port: int) -> int | None:
+    """
+    Fallback: scan listening sockets for *port* and return a matching
+    launch.py --serve PID, or None.
+    """
+    try:
+        import psutil
+        for conn in psutil.net_connections(kind='inet'):
+            if conn.laddr.port == port and conn.status == psutil.CONN_LISTEN and conn.pid:
+                if _is_our_server_process(conn.pid):
+                    return conn.pid
+    except Exception:
+        pass
+    return None
+
+
+def kill_existing_server(port: int) -> None:
+    """
+    Kill any existing ride-optimizer server process.
+
+    Strategy (cross-platform, no lsof/ps):
+    1. Read PID file; if the recorded process is our server → SIGTERM it.
+    2. Fall back to a port-scan via psutil to catch processes that started
+       without writing a PID file (e.g. older launcher versions).
+    3. Clean up the PID file afterwards.
+    """
+    import psutil
+
     if not isinstance(port, int) or port < 1024 or port > 65535:
         logger.error(f"Invalid port number: {port}")
         return
-    
+
+    killed_any = False
+
+    # --- PID-file path ---
+    data = _read_pid_file()
+    if data:
+        pid = data.get('pid')
+        if pid and _is_our_server_process(pid):
+            try:
+                proc = psutil.Process(pid)
+                proc.terminate()
+                proc.wait(timeout=5)
+                logger.info(
+                    f"Stopped existing server (PID {pid}, port {data.get('port', '?')}, "
+                    f"started {data.get('started', '?')})"
+                )
+                killed_any = True
+            except psutil.TimeoutExpired:
+                proc.kill()
+                logger.warning(f"Server PID {pid} did not exit cleanly; force-killed.")
+                killed_any = True
+            except psutil.NoSuchProcess:
+                logger.debug(f"PID {pid} from PID file no longer exists.")
+        else:
+            logger.debug("PID file present but process is gone — cleaning up stale file.")
+        _remove_pid_file()
+
+    # --- Port-scan fallback ---
+    pid_via_port = _find_server_on_port(port)
+    if pid_via_port and not killed_any:
+        try:
+            proc = psutil.Process(pid_via_port)
+            proc.terminate()
+            proc.wait(timeout=5)
+            logger.info(f"Stopped stale server found on port {port} (PID {pid_via_port})")
+        except psutil.TimeoutExpired:
+            proc.kill()
+            logger.warning(f"Stale server PID {pid_via_port} did not exit cleanly; force-killed.")
+        except psutil.NoSuchProcess:
+            pass
+
+
+def server_status() -> dict:
+    """
+    Return a dict describing the current server state:
+      {'running': bool, 'pid': int|None, 'port': int|None,
+       'started': str|None, 'uptime_seconds': float|None}
+    """
+    import psutil
+
+    data = _read_pid_file()
+    if not data:
+        # Try port scan as a best-effort fallback
+        PORT = 8083
+        port = int(os.environ.get('RIDE_OPTIMIZER_PORT', PORT))
+        pid = _find_server_on_port(port)
+        if pid:
+            return {'running': True, 'pid': pid, 'port': port, 'started': None, 'uptime_seconds': None}
+        return {'running': False, 'pid': None, 'port': None, 'started': None, 'uptime_seconds': None}
+
+    pid = data.get('pid')
+    if pid and _is_our_server_process(pid):
+        uptime = None
+        try:
+            proc = psutil.Process(pid)
+            uptime = (datetime.now() - datetime.fromtimestamp(proc.create_time())).total_seconds()
+        except Exception:
+            pass
+        return {
+            'running': True,
+            'pid': pid,
+            'port': data.get('port'),
+            'started': data.get('started'),
+            'uptime_seconds': uptime,
+        }
+
+    # Stale PID file
+    _remove_pid_file()
+    return {'running': False, 'pid': None, 'port': None, 'started': None, 'uptime_seconds': None}
+
+
+def stop_server() -> bool:
+    """
+    Stop the tracked server.  Returns True if a process was stopped.
+    """
+    import psutil
+
+    data = _read_pid_file()
+    pid = data.get('pid') if data else None
+
+    if not pid:
+        # Try port scan
+        PORT = 8083
+        port = int(os.environ.get('RIDE_OPTIMIZER_PORT', PORT))
+        pid = _find_server_on_port(port)
+
+    if not pid:
+        logger.info("No running server found.")
+        return False
+
+    if not _is_our_server_process(pid):
+        logger.info(f"PID {pid} is no longer a ride-optimizer server process.")
+        _remove_pid_file()
+        return False
+
     try:
-        # Find process using the port
-        result = subprocess.run(
-            ['lsof', '-ti', f':{port}'],
-            capture_output=True,
-            text=True,
-            timeout=5  # Add timeout for security
-        )
-        
-        if result.stdout.strip():
-            pids = result.stdout.strip().split('\n')
-            current_user = os.getenv('USER') or os.getenv('USERNAME')
-            
-            for pid in pids:
-                try:
-                    pid_int = int(pid)
-                    
-                    # Verify process belongs to current user before killing
-                    try:
-                        proc_info = subprocess.run(
-                            ['ps', '-p', str(pid_int), '-o', 'user='],
-                            capture_output=True,
-                            text=True,
-                            timeout=2
-                        )
-                        proc_user = proc_info.stdout.strip()
-                        
-                        if proc_user == current_user:
-                            logger.info(f"Killing server process {pid_int} on port {port}")
-                            os.kill(pid_int, signal.SIGTERM)
-                            time.sleep(0.5)  # Give it time to terminate
-                        else:
-                            logger.warning(f"Skipping process {pid_int} - owned by {proc_user}, not {current_user}")
-                    except subprocess.TimeoutExpired:
-                        logger.warning(f"Timeout checking ownership of process {pid_int}")
-                    except Exception as e:
-                        logger.debug(f"Could not verify process {pid_int} ownership: {e}")
-                        
-                except (ValueError, ProcessLookupError, PermissionError) as e:
-                    logger.debug(f"Could not kill process {pid}: {e}")
-                    
-    except subprocess.TimeoutExpired:
-        logger.error("Timeout checking for existing server")
-    except FileNotFoundError:
-        # lsof not available (Windows)
-        logger.debug("lsof command not available, skipping process check")
-    except Exception as e:
-        logger.warning(f"Error checking for existing server: {e}")
+        proc = psutil.Process(pid)
+        proc.terminate()
+        proc.wait(timeout=5)
+        logger.info(f"Server PID {pid} stopped.")
+    except psutil.TimeoutExpired:
+        proc.kill()
+        logger.warning(f"Server PID {pid} force-killed after timeout.")
+    except psutil.NoSuchProcess:
+        logger.debug(f"PID {pid} was already gone.")
+
+    _remove_pid_file()
+    return True
 
 
-def run_server(port):
+def run_server(port: int) -> None:
     """Run the Flask server (called in subprocess)."""
-    app.run(host='0.0.0.0', port=port, debug=False, use_reloader=False)
+    _write_pid_file(os.getpid(), port)
+    try:
+        app.run(host='0.0.0.0', port=port, debug=False, use_reloader=False)
+    finally:
+        _remove_pid_file()
 
 
 if __name__ == '__main__':
-    # Development server
-    import os
     import sys
     import subprocess
-    import tempfile
 
-    # Check if running as server subprocess
+    PORT = 8083
+    port = int(os.environ.get('RIDE_OPTIMIZER_PORT', PORT))
+
+    # ---- server subprocess ----
     if len(sys.argv) > 1 and sys.argv[1] == '--serve':
-        port = int(sys.argv[2]) if len(sys.argv) > 2 else 8083
+        port = int(sys.argv[2]) if len(sys.argv) > 2 else port
         logger.info(f"Running server on port {port}")
         run_server(port)
         sys.exit(0)
-    
-    # Main launcher process
-    PORT = 8083
-    port = int(os.environ.get('RIDE_OPTIMIZER_PORT', PORT))
-    
+
+    # ---- --status ----
+    if len(sys.argv) > 1 and sys.argv[1] == '--status':
+        st = server_status()
+        if st['running']:
+            uptime = f"{int(st['uptime_seconds'])}s" if st['uptime_seconds'] is not None else 'unknown'
+            print(
+                f"Server is RUNNING  pid={st['pid']}  port={st['port']}  "
+                f"started={st['started']}  uptime={uptime}"
+            )
+        else:
+            print("Server is NOT running.")
+        sys.exit(0 if st['running'] else 1)
+
+    # ---- --stop ----
+    if len(sys.argv) > 1 and sys.argv[1] == '--stop':
+        stopped = stop_server()
+        sys.exit(0 if stopped else 1)
+
+    # ---- normal launch ----
+    import tempfile
+
     # Kill any existing server on this port
     kill_existing_server(port)
-    
+
     logger.info("Starting Ride Optimizer API server...")
     logger.info("API endpoints:")
     logger.info("  GET /api/weather - Current weather data")
@@ -3360,7 +3531,7 @@ if __name__ == '__main__':
     logger.info("  GET /api/routes - All routes for library")
     logger.info("  GET /api/status - System health and freshness")
     logger.info(f"Server will run on port {port}")
-    
+
     # Start server in background subprocess
     log_path = os.path.join(tempfile.gettempdir(), 'ride-optimizer-server.log')
     with open(log_path, 'a') as log_file:
@@ -3371,18 +3542,18 @@ if __name__ == '__main__':
             start_new_session=True
         )
 
-        logger.info(f"Server started with PID {server_process.pid}")
-        logger.info(f"Server logs: {log_path}")
-    
+    logger.info(f"Server started with PID {server_process.pid}")
+    logger.info(f"Server logs: {log_path}")
+
     # Wait for server to start
     time.sleep(2)
-    
+
     # Open browser
     url = f'http://localhost:{port}'
     try:
         import platform
         system = platform.system()
-        
+
         if system == 'Darwin':  # macOS
             os.system(f'open -a "Google Chrome" {url} 2>/dev/null || open {url}')
         elif system == 'Windows':
@@ -3391,12 +3562,12 @@ if __name__ == '__main__':
             os.system(f'google-chrome {url} 2>/dev/null || xdg-open {url}')
         else:
             webbrowser.open(url)
-        
+
         logger.info(f"Browser opened at {url}")
     except Exception as e:
         logger.warning(f"Could not open browser: {e}")
         logger.info(f"Please open your browser manually to: {url}")
-    
+
     # Exit cleanly
     logger.info("Launch complete. Server running in background.")
     sys.exit(0)

--- a/plans/v0.6.0/DESIGN_PRINCIPLES.md
+++ b/plans/v0.6.0/DESIGN_PRINCIPLES.md
@@ -1,6 +1,6 @@
 # Design Principles & Guidelines
 
-**Version:** 2.2
+**Version:** 2.3
 **Last Updated:** 2026-07-05
 **Status:** Active
 
@@ -97,7 +97,9 @@ The app's visual identity is **Fair Weather** — built around the one decision 
 
 > **Field note (v0.17.0 Design Review):** Findings PLACE-DASH-2, PLACE-ROUTES-2, and PLACE-DETAIL-2 identified three pages where the map column received more Bootstrap columns than the decision/data column. Finding ID-RDTL-2 documented the "Uses" popularity metric sharing equal visual weight with Distance, Duration, and Elevation in the Route Detail primary grid. CP-4 (Information Density) documented this secondary-at-primary-weight pattern recurring across Dashboard, Reports, Route Detail, and Explore.
 
-> **Field note (v2.2 — Fair Weather):** The map + controls side-by-side rule formalizes a recommendation already made ad hoc in #367 (Explore: "two-column layout on desktop: generation controls left `col-lg-4` / map right `col-lg-8`"). It also applies to #365 (Routes Library column ratio) and should be checked against Route Detail's existing `col-lg-5`/`col-lg-7` split (`route-detail.html`), which already follows this pattern and can serve as the reference implementation.
+> **Field note (v2.2 — Fair Weather):** The map + controls side-by-side rule formalizes a recommendation already made ad hoc in #367 (Explore: "two-column layout on desktop: generation controls left `col-lg-4` / map right `col-lg-8`"). It also applies to #365 (Routes Library column ratio).
+>
+> **Correction (v2.3):** An earlier version of this note called Route Detail's existing `col-lg-5`/`col-lg-7` split (`route-detail.html`) "the reference implementation" for this rule. That was wrong: `col-lg-5` for the stats column is below the `col-lg-6` minimum the ratio rule above requires, and finding PLACE-DETAIL-2 (v0.17.0 Design Review, field note above) already flagged this exact split as an instance of the map column outweighing the data column — the two field notes contradicted each other. Route Detail *does* correctly follow the side-by-side placement rule (stats beside the map, not stacked, on `lg`+); it does *not* comply with the column-ratio rule. Treat the placement as the reference example and the ratio as a known, not-yet-corrected deviation — don't cite the split as compliant with both rules.
 
 **Rationale:** Users should immediately understand what's most important.
 
@@ -459,6 +461,7 @@ Before merging UI/UX changes:
 
 ## Version History
 
+- **v2.3** (2026-07-05): Corrected an internal contradiction in §3 — the v2.2 field note called Route Detail's `col-lg-5`/`col-lg-7` split "the reference implementation" for the map+controls side-by-side rule, but the v0.17.0 field note directly above it (finding PLACE-DETAIL-2) already flagged that same split as violating the column-ratio rule's `col-lg-6` minimum. Route Detail remains the reference example for side-by-side *placement* only; the ratio itself is a known, uncorrected deviation.
 - **v2.2** (2026-07-05): Fair Weather brand identity adopted — new Brand Identity section (mark, wordmark, type, tagline); Primary/Semantic Colors in §4 replaced with Day/Night cobalt/coral tokens (full spec: [`docs/designs/FAIR_WEATHER_BRAND_BOOK.md`](../../docs/designs/FAIR_WEATHER_BRAND_BOOK.md)); §2 new guideline that weather cards show wind and precipitation alongside temperature whenever meaningful; §3 new guideline that map controls/lists sit beside the map on desktop (`lg`+), not stacked above or below it, formalizing prior ad hoc recommendations in #365 and #367; Common Patterns Library CSS snippets updated to the new tokens and 999px/16px shape language.
 - **v2.1** (2026-07-04): Field notes and extended guidelines added from v0.17.0 Design Review (Epic #352). New sub-guidelines added to §2 (time-urgency ordering, teaser before collapse), §3 (card column ratios, secondary metrics demoted), §7 (workflow sequencing, jargon-free first use, interactive elements visually distinct, post-action navigation hints), §10 (destructive action confirmation, unit system applied globally).
 - **v2.0** (2026-03-26): Comprehensive design system with mobile-first approach

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ apscheduler>=3.10.0
 icalendar>=5.0.0
 marshmallow>=3.20.0
 garth>=0.4.0
+psutil>=5.9.0

--- a/scripts/backup_caches.sh
+++ b/scripts/backup_caches.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# Backup analysis caches to private backups repository
+# Usage: ./scripts/backup_caches.sh
+#
+# Backs up:
+#   cache/route_groups_cache.json        — commute route grouping (incremental analysis)
+#   cache/route_similarity_cache.json    — commute pair similarity scores
+#   cache/long_ride_similarity_cache.json — long ride pair similarity scores
+#   cache/geocoding_cache.json           — reverse-geocoded route names
+#   data/cache/activities.json           — full Strava activity cache
+#   data/route_groups.json               — web app route groups
+#   data/long_rides.json                 — web app long rides
+
+set -e
+
+TIMESTAMP=$(date +%Y%m%d-%H%M%S)
+BACKUP_REPO_PATH="$HOME/dev/backups"
+DEST="$BACKUP_REPO_PATH/ride-optimizer"
+
+echo "💾 Backing up ride-optimizer caches — $TIMESTAMP"
+echo "=================================================="
+echo ""
+
+# Check if backups repo exists
+if [ ! -d "$BACKUP_REPO_PATH" ]; then
+    echo "❌ Error: Backups repository not found at $BACKUP_REPO_PATH"
+    echo ""
+    echo "Clone it first:"
+    echo "  git clone https://github.com/e2kd7n/backups.git ~/dev/backups"
+    exit 1
+fi
+
+mkdir -p "$DEST/cache" "$DEST/data/cache"
+
+backed_up=0
+
+backup_file() {
+    local src="$1"
+    local dest="$2"
+    if [ -f "$src" ]; then
+        cp "$src" "$dest"
+        echo "  ✅ $src"
+        backed_up=$((backed_up + 1))
+    else
+        echo "  ⚠️  $src (not found, skipped)"
+    fi
+}
+
+# cache/ files
+backup_file "cache/route_groups_cache.json"        "$DEST/cache/route_groups_cache.json"
+backup_file "cache/route_similarity_cache.json"    "$DEST/cache/route_similarity_cache.json"
+backup_file "cache/long_ride_similarity_cache.json" "$DEST/cache/long_ride_similarity_cache.json"
+backup_file "cache/geocoding_cache.json"           "$DEST/cache/geocoding_cache.json"
+
+# data/ files
+backup_file "data/cache/activities.json"           "$DEST/data/cache/activities.json"
+backup_file "data/route_groups.json"               "$DEST/data/route_groups.json"
+backup_file "data/long_rides.json"                 "$DEST/data/long_rides.json"
+
+echo ""
+echo "$backed_up file(s) staged for commit"
+
+# Only commit if something actually changed
+cd "$BACKUP_REPO_PATH"
+if git diff --quiet && git diff --cached --quiet; then
+    echo "✅ No changes — caches already up to date in backup repo"
+else
+    git add "ride-optimizer/cache/" "ride-optimizer/data/"
+    git commit -m "Backup ride-optimizer caches — $TIMESTAMP"
+    git push
+    echo ""
+    echo "✅ Cache backup complete!"
+fi
+
+# Made with Bob

--- a/src/coverage_tracker.py
+++ b/src/coverage_tracker.py
@@ -250,14 +250,9 @@ class CoverageTracker:
 
         path = Path("data/cache/activities.json")
         if not path.exists():
-            fallback = Path("data/cache/activities_test.json")
-            if fallback.exists():
-                logger.warning("No activities cache found at %s — falling back to test data at %s", path, fallback)
-                path = fallback
-            else:
-                logger.warning("No activities cache found at %s", path)
-                self._activities_cache = []
-                return self._activities_cache
+            logger.warning("No activities cache found at %s", path)
+            self._activities_cache = []
+            return self._activities_cache
 
         try:
             with open(path, "r", encoding="utf-8") as f:

--- a/src/coverage_tracker.py
+++ b/src/coverage_tracker.py
@@ -250,9 +250,14 @@ class CoverageTracker:
 
         path = Path("data/cache/activities.json")
         if not path.exists():
-            logger.warning("No activities cache found at %s", path)
-            self._activities_cache = []
-            return self._activities_cache
+            fallback = Path("data/cache/activities_test.json")
+            if fallback.exists():
+                logger.warning("No activities cache found at %s — falling back to test data at %s", path, fallback)
+                path = fallback
+            else:
+                logger.warning("No activities cache found at %s", path)
+                self._activities_cache = []
+                return self._activities_cache
 
         try:
             with open(path, "r", encoding="utf-8") as f:

--- a/src/long_ride_analyzer.py
+++ b/src/long_ride_analyzer.py
@@ -4,8 +4,10 @@ Long Ride Analysis Module
 Analyzes non-commute cycling activities for recreational ride recommendations.
 """
 
+import json
 import logging
 import math
+from pathlib import Path
 from typing import List, Tuple, Dict, Any, Optional
 from dataclasses import dataclass
 from datetime import datetime
@@ -84,7 +86,9 @@ class RideRecommendation:
 
 class LongRideAnalyzer:
     """Analyzes non-commute rides for recreational recommendations."""
-    
+
+    _SIMILARITY_CACHE_PATH = "cache/long_ride_similarity_cache.json"
+
     def __init__(self, activities: List[Activity], config):
         """
         Initialize long ride analyzer.
@@ -97,7 +101,30 @@ class LongRideAnalyzer:
         self.config = config
         self.route_namer = RouteNamer(config)
         self.weather_fetcher = WeatherFetcher()  # WeatherFetcher doesn't take config parameter
+        self._similarity_cache: Dict[str, float] = self._load_similarity_cache()
         
+    def _load_similarity_cache(self) -> Dict[str, float]:
+        """Load long-ride similarity cache from disk."""
+        p = Path(self._SIMILARITY_CACHE_PATH)
+        if p.exists():
+            try:
+                cache = json.loads(p.read_text())
+                logger.info(f"Loaded {len(cache)} long-ride similarity values from cache")
+                return cache
+            except Exception as e:
+                logger.warning(f"Could not load long-ride similarity cache: {e}")
+        return {}
+
+    def _save_similarity_cache(self) -> None:
+        """Persist long-ride similarity cache to disk."""
+        try:
+            p = Path(self._SIMILARITY_CACHE_PATH)
+            p.parent.mkdir(parents=True, exist_ok=True)
+            p.write_text(json.dumps(self._similarity_cache))
+            logger.debug(f"Saved {len(self._similarity_cache)} long-ride similarity values to cache")
+        except Exception as e:
+            logger.warning(f"Could not save long-ride similarity cache: {e}")
+
     def classify_activities(self, commute_activities: List[Activity]) -> Tuple[List[Activity], List[Activity]]:
         """
         Classify activities into commutes and long rides.
@@ -223,6 +250,12 @@ class LongRideAnalyzer:
                     logger.debug(f"Failed to decode polyline for group '{name}': {e}")
                     continue
 
+        # Build representative activity ID map once (used as similarity cache keys)
+        rep_ids = {}
+        for n, acts in name_groups.items():
+            rep = sorted(acts, key=lambda a: a.start_date, reverse=True)[0]
+            rep_ids[n] = rep.id
+
         # Find groups to merge
         merged_groups = {}
         processed = set()
@@ -249,48 +282,59 @@ class LongRideAnalyzer:
                     continue
 
                 try:
-                    # Pre-filter: skip if average distances differ by more than 25%
-                    dists1 = [a.distance for a in name_groups[name1] if a.distance]
-                    dists2 = [a.distance for a in name_groups[name2] if a.distance]
-                    if dists1 and dists2:
-                        avg1 = sum(dists1) / len(dists1)
-                        avg2 = sum(dists2) / len(dists2)
-                        if avg1 > 0 and avg2 > 0 and max(avg1, avg2) / min(avg1, avg2) > 1.25:
+                    # Cache key: sorted pair of representative activity IDs
+                    rid1, rid2 = rep_ids[name1], rep_ids[name2]
+                    cache_key = f"{min(rid1, rid2)}:{max(rid1, rid2)}"
+
+                    if cache_key in self._similarity_cache:
+                        combined_distance = self._similarity_cache[cache_key]
+                    else:
+                        # Pre-filter: skip if average distances differ by more than 25%
+                        dists1 = [a.distance for a in name_groups[name1] if a.distance]
+                        dists2 = [a.distance for a in name_groups[name2] if a.distance]
+                        if dists1 and dists2:
+                            avg1 = sum(dists1) / len(dists1)
+                            avg2 = sum(dists2) / len(dists2)
+                            if avg1 > 0 and avg2 > 0 and max(avg1, avg2) / min(avg1, avg2) > 1.25:
+                                self._similarity_cache[cache_key] = float('inf')
+                                continue
+
+                        # Calculate route similarity in km-scaled coordinates
+                        coords1_km = group_representatives[name1]
+                        coords2_km = group_representatives[name2]
+
+                        # Pre-filter: centroid distance — loops going different places have
+                        # centroids far apart even when they share a start/end point
+                        centroid_dist = float(np.linalg.norm(
+                            coords1_km.mean(axis=0) - coords2_km.mean(axis=0)
+                        ))
+                        if centroid_dist > 5.0:
+                            self._similarity_cache[cache_key] = float('inf')
                             continue
 
-                    # Calculate route similarity in km-scaled coordinates
-                    coords1_km = group_representatives[name1]
-                    coords2_km = group_representatives[name2]
+                        # Pre-filter: extent point distance — the farthest-from-start point
+                        # of each route must be close; routes apexing in different directions
+                        # will fail even if their centroids are coincidentally similar
+                        extent_dist = float(np.linalg.norm(
+                            self._extent_point(coords1_km) - self._extent_point(coords2_km)
+                        ))
+                        if extent_dist > 10.0:
+                            self._similarity_cache[cache_key] = float('inf')
+                            continue
 
-                    # Pre-filter: centroid distance — loops going different places have
-                    # centroids far apart even when they share a start/end point
-                    centroid_dist = float(np.linalg.norm(
-                        coords1_km.mean(axis=0) - coords2_km.mean(axis=0)
-                    ))
-                    if centroid_dist > 5.0:
-                        continue
-
-                    # Pre-filter: extent point distance — the farthest-from-start point
-                    # of each route must be close; routes apexing in different directions
-                    # will fail even if their centroids are coincidentally similar
-                    extent_dist = float(np.linalg.norm(
-                        self._extent_point(coords1_km) - self._extent_point(coords2_km)
-                    ))
-                    if extent_dist > 10.0:
-                        continue
-
-                    frechet_distance = frechet_dist(coords1_km, coords2_km)
-                    hausdorff_dist = max(
-                        directed_hausdorff(coords1_km, coords2_km)[0],
-                        directed_hausdorff(coords2_km, coords1_km)[0]
-                    )
-                    combined_distance = (frechet_distance + hausdorff_dist) / 2
+                        frechet_distance = frechet_dist(coords1_km, coords2_km)
+                        hausdorff_dist = max(
+                            directed_hausdorff(coords1_km, coords2_km)[0],
+                            directed_hausdorff(coords2_km, coords1_km)[0]
+                        )
+                        combined_distance = (frechet_distance + hausdorff_dist) / 2
+                        self._similarity_cache[cache_key] = combined_distance
 
                     # If routes are similar, merge them
                     if combined_distance < similarity_threshold:
                         merged_activities.extend(name_groups[name2])
                         processed.add(name2)
-                        logger.info(f"Consolidating '{name2}' into '{name1}' (similarity: {combined_distance:.3f} km, centroid: {centroid_dist:.3f} km)")
+                        logger.info(f"Consolidating '{name2}' into '{name1}' (similarity: {combined_distance:.3f} km)")
                         
                 except (ValueError, IndexError, TypeError) as e:
                     logger.debug(f"Failed to calculate similarity between '{name1}' and '{name2}': {e}")
@@ -315,7 +359,8 @@ class LongRideAnalyzer:
         
         if len(merged_groups) < len(name_groups):
             logger.info(f"Consolidated {len(name_groups)} named groups into {len(merged_groups)} groups using route similarity")
-        
+
+        self._save_similarity_cache()
         return merged_groups
     
     def consolidate_named_groups(self, name_groups: Dict[str, List[Activity]]) -> List[LongRide]:

--- a/src/ors_client.py
+++ b/src/ors_client.py
@@ -7,7 +7,8 @@ Distinguishes HTTP 429 so callers can surface a rate-limit message.
 """
 
 import logging
-from typing import Optional
+import re
+from typing import List, Optional, Tuple
 
 import requests
 
@@ -16,6 +17,14 @@ logger = logging.getLogger(__name__)
 # api.openrouteservice.org is deprecated for new accounts (moved to heigit.org).
 # api.heigit.org/openrouteservice works for both old and new API keys.
 _ORS_DIRECTIONS_URL = "https://api.heigit.org/openrouteservice/v2/directions/{profile}/geojson"
+
+# ORS error 2010 = "Could not find routable point within a radius of N metres of
+# specified coordinate K: <lon> <lat>."
+# The latitude value may be followed by a period (sentence end), so stop at \b or non-digit.
+_RE_UNROUTABLE = re.compile(
+    r"coordinate\s+\d+:\s*([-\d.]+)\s+([-\d]+(?:\.\d+)?)",
+    re.IGNORECASE,
+)
 
 
 def get_route(
@@ -37,6 +46,8 @@ def get_route(
     Returns:
         Parsed JSON response dict on success, or None on any failure.
         On HTTP 429 the returned dict is ``{"_ors_rate_limited": True}``.
+        On error 2010 (unroutable waypoint) the returned dict is
+        ``{"_ors_unroutable": [(lon, lat), ...]}``.
     """
     if not api_key:
         logger.debug("ORS API key not configured")
@@ -64,8 +75,17 @@ def get_route(
             try:
                 err_body = response.json()
                 if isinstance(err_body.get("error"), dict) and err_body["error"].get("code"):
-                    # ORS application error (routable point not found, etc) — treat as hard failure
-                    logger.warning("ORS routing error %s: %s", profile, err_body["error"].get("message"))
+                    err_code = err_body["error"].get("code")
+                    err_msg = err_body["error"].get("message", "")
+                    logger.warning("ORS routing error %s: %s", profile, err_msg)
+                    # Error 2010 = unroutable point(s).  Extract every (lon, lat) pair
+                    # mentioned in the message so the caller can drop them and retry.
+                    if err_code == 2010:
+                        bad: List[Tuple[float, float]] = [
+                            (float(lon), float(lat))
+                            for lon, lat in _RE_UNROUTABLE.findall(err_msg)
+                        ]
+                        return {"_ors_unroutable": bad}
                     return None
             except Exception:
                 pass

--- a/static/commute.html
+++ b/static/commute.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="refresh" content="0; url=/">
     <title>Redirecting… - Ride Optimizer</title>
+    <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
 </head>
 <body>
     <p>Commute info is now on the <a href="/">home page</a>.</p>

--- a/static/compare.html
+++ b/static/compare.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Compare Routes - Ride Optimizer</title>
+    <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="">
@@ -48,10 +49,19 @@
 </head>
 <body>
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark navbar-gradient" role="navigation" aria-label="Main navigation">
+    <nav class="navbar navbar-expand-lg navbar-fairweather" role="navigation" aria-label="Main navigation">
         <div class="container">
             <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home">
-                <i class="bi bi-bicycle" aria-hidden="true"></i> Ride Optimizer
+                <svg class="brand-mark" viewBox="0 0 48 48" fill="none" aria-hidden="true" focusable="false">
+                    <circle cx="24" cy="24" r="12" stroke="currentColor" stroke-width="3.4"/>
+                    <g stroke="currentColor" stroke-width="3.4" stroke-linecap="round">
+                        <line x1="24" y1="2" x2="24" y2="8"/><line x1="24" y1="40" x2="24" y2="46"/>
+                        <line x1="2" y1="24" x2="8" y2="24"/><line x1="40" y1="24" x2="46" y2="24"/>
+                        <line x1="8.3" y1="8.3" x2="12.5" y2="12.5"/><line x1="35.5" y1="35.5" x2="39.7" y2="39.7"/>
+                        <line x1="39.7" y1="8.3" x2="35.5" y2="12.5"/><line x1="12.5" y1="35.5" x2="8.3" y2="39.7"/>
+                    </g>
+                </svg>
+                <span><span class="brand-ride">Ride</span>&nbsp;<span class="brand-optimizer">Optimizer</span></span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -101,26 +111,42 @@
         </div>
     </main>
 
+    <div id="bottom-nav-more" class="bottom-nav-drawer collapse d-md-none" aria-label="More pages">
+        <a class="bottom-nav-drawer-item" href="/explore.html">
+            <i class="bi bi-compass" aria-hidden="true"></i>
+            <span>Explore</span>
+        </a>
+        <a class="bottom-nav-drawer-item" href="/settings.html">
+            <i class="bi bi-gear" aria-hidden="true"></i>
+            <span>Settings</span>
+        </a>
+    </div>
     <nav id="bottom-nav" class="bottom-nav d-md-none" role="navigation" aria-label="Mobile navigation">
-        <button class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
+        <button type="button" class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
             <i class="bi bi-house-door" aria-hidden="true"></i>
             <span>Home</span>
         </button>
-        <button class="bottom-nav-item active" aria-label="Routes" aria-current="page" onclick="window.location.href='/routes.html'">
+        <button type="button" class="bottom-nav-item active" aria-label="Routes" aria-current="page" onclick="window.location.href='/routes.html'">
             <i class="bi bi-map" aria-hidden="true"></i>
             <span>Routes</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
+        <button type="button" class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
             <i class="bi bi-cloud-sun" aria-hidden="true"></i>
             <span>Weather</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Settings" onclick="window.location.href='/settings.html'">
-            <i class="bi bi-gear" aria-hidden="true"></i>
-            <span>Settings</span>
+        <button type="button" class="bottom-nav-item" aria-label="Reports" onclick="window.location.href='/reports.html'">
+            <i class="bi bi-bar-chart-line" aria-hidden="true"></i>
+            <span>Reports</span>
+        </button>
+        <button type="button" class="bottom-nav-item" aria-label="More pages"
+                data-bs-toggle="collapse" data-bs-target="#bottom-nav-more"
+                aria-expanded="false" aria-controls="bottom-nav-more">
+            <i class="bi bi-three-dots" aria-hidden="true"></i>
+            <span>More</span>
         </button>
     </nav>
 
-    <footer class="mt-3 bg-light">
+    <footer class="mt-3">
         <div class="container text-center text-muted">
             <small>Ride Optimizer v0.17.0 - Smart Static Architecture</small>
         </div>

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2267,6 +2267,13 @@ h5.card-title {
 [aria-expanded="true"] .tr-chevron { transform: rotate(90deg); }
 .tr-chevron { transition: transform 0.2s; display: inline-block; }
 
+/* Dashboard mobile disclosure chevrons (Conditions summary, Route Status) —
+   CSS-driven off aria-expanded so rotation can't desync from the ARIA state. */
+.conditions-chevron,
+.route-status-chevron { transition: transform 0.2s; }
+[aria-expanded="true"] .conditions-chevron,
+[aria-expanded="true"] .route-status-chevron { transform: rotate(180deg); }
+
 @media (max-width: 767.98px) {
     .workout-strip {
         padding: var(--space-2);

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -113,6 +113,12 @@ body {
     line-height: 1.45;
 }
 
+/* Bootstrap's .text-muted is a static gray that doesn't adapt to Night mode;
+   repoint it at the brand's --ink-soft token so both roles stay in sync. */
+.text-muted {
+    color: var(--ink-soft) !important;
+}
+
 /* ===== Fair Weather typography ===== */
 /* Display face on headlines, brand, decision copy, and button labels */
 h1, h2, h3,

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4,16 +4,40 @@
  */
 
 /* ===== Global Styles ===== */
+/* Fair Weather brand tokens — see docs/designs/FAIR_WEATHER_BRAND_BOOK.md */
 :root {
-    --primary-color: #667eea;
-    --primary-dark: #764ba2;
-    --primary-gradient: linear-gradient(135deg, #4a5fd5 0%, #764ba2 100%);
-    --success-color: #28a745;
-    --danger-color: #dc3545;
-    --warning-color: #ffc107;
-    --info-color: #17a2b8;
-    --light-gray: #f8f9fa;
-    --dark-gray: #343a40;
+    /* Day ground (default) */
+    --bg: #F3F6F7;
+    --surface: #FFFFFF;
+    --surface-2: #EDF2F4;
+    --ink: #0F2233;
+    --ink-soft: #5B7686;
+    --line: #DCE3E6;
+    --accent: #0B6FA6;
+    --accent-warm: #F2662D;
+    --success: #3E8E63;
+    --warning: #C98A1D;
+    --danger: #C4483A;
+    /* RGB triplet for alpha tints of the accent (kept in sync with --accent) */
+    --accent-rgb: 11, 111, 166;
+
+    /* Display face (headlines, decision copy, CTA labels) */
+    --font-display: "Century Gothic", "Avenir Next", "Futura", -apple-system, sans-serif;
+
+    /* Legacy aliases — pre-rebrand names kept so untouched code still works.
+       Gradients are retired: flat cobalt everywhere. */
+    --primary-color: var(--accent);
+    --primary-dark: var(--accent);
+    --primary-gradient: var(--accent);
+    --success-color: var(--success);
+    --danger-color: var(--danger);
+    --warning-color: var(--warning);
+    --info-color: var(--accent);
+    --light-gray: var(--bg);
+    --dark-gray: var(--ink);
+
+    /* Bootstrap utility hooks (drives .bg-primary tints, focus rings, etc.) */
+    --bs-primary-rgb: 11, 111, 166;
 
     /* Spacing scale (#280) */
     --space-1: 4px;
@@ -45,14 +69,14 @@
     /* Chart height token */
     --chart-height: 256px;
 
-    /* Semantic color tokens */
-    --color-primary: #667eea;
-    --color-accent: #764ba2;
-    --color-text: #343a40;
-    --color-text-muted: #6c757d;
-    --color-border: #dee2e6;
-    --color-bg-hover: rgba(102, 126, 234, 0.06);
-    --color-bg-selected: rgba(102, 126, 234, 0.1);
+    /* Semantic color tokens (legacy aliases) */
+    --color-primary: var(--accent);
+    --color-accent: var(--accent);
+    --color-text: var(--ink);
+    --color-text-muted: var(--ink-soft);
+    --color-border: var(--line);
+    --color-bg-hover: rgba(var(--accent-rgb), 0.06);
+    --color-bg-selected: rgba(var(--accent-rgb), 0.1);
 
     /* Workout color tokens (#340) */
     --workout-color: #e85d04;
@@ -60,9 +84,28 @@
     --workout-border: rgba(232, 93, 4, 0.3);
 }
 
+/* Fair Weather Night ground — token set only; no toggle UI ships yet.
+   Day is the default; setting data-theme="night" on <html> flips the system. */
+html[data-theme="night"] {
+    --bg: #0B1620;
+    --surface: #122232;
+    --surface-2: #16283A;
+    --ink: #EAF0F3;
+    --ink-soft: #8FA6B4;
+    --line: #223243;
+    --accent: #4FB3E8;
+    --accent-warm: #FF8A57;
+    --success: #57B384;
+    --warning: #E0A63E;
+    --danger: #E2695C;
+    --accent-rgb: 79, 179, 232;
+    --bs-primary-rgb: 79, 179, 232;
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    background-color: var(--light-gray);
+    background: var(--bg);
+    color: var(--ink);
     min-height: 100vh;
     display: flex;
     flex-direction: column;
@@ -70,11 +113,32 @@ body {
     line-height: 1.45;
 }
 
+/* ===== Fair Weather typography ===== */
+/* Display face on headlines, brand, decision copy, and button labels */
+h1, h2, h3,
+.navbar-brand,
+.btn,
+.temperature-display,
+.stat-value-hero,
+.hero-route-name {
+    font-family: var(--font-display);
+}
+
+/* Tabular numerals wherever digits line up in a column */
+.tabular-nums {
+    font-variant-numeric: tabular-nums;
+}
+
+/* Links carry cobalt */
+a {
+    color: var(--accent);
+}
+
 /* ===== Timestamp Display Styles (Issue #274) ===== */
 .timestamp-display {
     display: inline-block;
     font-size: var(--font-size-sm);
-    color: #6c757d;
+    color: var(--ink-soft);
     margin-top: var(--space-1);
 }
 
@@ -98,17 +162,47 @@ body {
 }
 
 /* ===== Navigation ===== */
+/* Fair Weather Day ground: light surface-2 bar, ink text, cobalt accents.
+   .navbar-gradient kept as a legacy alias for any untouched markup. */
+.navbar-fairweather,
 .navbar-gradient {
-    background: linear-gradient(135deg, #4a5fd5 0%, #764ba2 100%);
+    background: var(--surface-2);
+    border-bottom: 1px solid var(--line);
 }
 
 .navbar-brand {
-    font-weight: 600;
+    font-weight: 700;
     font-size: var(--font-size-lg);
+    color: var(--accent);
+    display: inline-flex;
+    align-items: center;
+    gap: var(--space-2);
+}
+
+.navbar-brand:hover,
+.navbar-brand:focus {
+    color: var(--accent);
 }
 
 .navbar-brand i {
     margin-right: var(--space-2);
+}
+
+/* Brand mark (circle + eight ticks) sized for the navbar lockup */
+.navbar-brand .brand-mark {
+    width: 27px;
+    height: 27px;
+    flex-shrink: 0;
+    color: var(--accent);
+}
+
+/* Wordmark: "Ride" in ink, "Optimizer" in cobalt */
+.navbar-brand .brand-ride {
+    color: var(--ink);
+}
+
+.navbar-brand .brand-optimizer {
+    color: var(--accent);
 }
 
 /* Desktop navigation tabs - keep left-aligned (Issue #258) */
@@ -120,7 +214,7 @@ body {
 .navbar .navbar-nav .nav-link {
     border: none;
     background: transparent;
-    color: rgba(255, 255, 255, 0.85);
+    color: var(--ink);
     padding: var(--space-2) var(--space-3);
     margin: 0 var(--space-1);
     border-radius: 4px;
@@ -128,32 +222,46 @@ body {
 }
 
 .navbar .navbar-nav .nav-link:hover {
-    background: rgba(255, 255, 255, 0.1);
-    color: white;
+    background: var(--line);
+    color: var(--accent);
 }
 
 .navbar .navbar-nav .nav-link.active {
-    background: rgba(255, 255, 255, 0.2);
-    color: white;
+    background: transparent;
+    color: var(--accent);
     font-weight: 600;
-    border-bottom: var(--space-1) solid white;
+    border-bottom: 3px solid var(--accent);
 }
 
 .navbar .navbar-nav .nav-link i {
     margin-right: var(--space-2);
 }
 
+/* Toggler on the light bar (pages no longer use navbar-dark) */
+.navbar-fairweather .navbar-toggler,
+.navbar-gradient .navbar-toggler {
+    color: var(--ink);
+    border-color: var(--line);
+}
+
 /* ===== Cards ===== */
+/* Fair Weather shape: 16px radius, hairline border, quiet shadow;
+   visible lift is reserved for hover. */
 .card {
-    border: none;
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    background: var(--surface);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    /* Keep Bootstrap's inner elements (card-header/footer/img) in sync
+       with the 16px outer radius so their corners don't poke out. */
+    --bs-card-border-radius: 16px;
+    --bs-card-inner-border-radius: 15px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
     margin-bottom: var(--space-2);
     transition: box-shadow 0.3s ease;
 }
 
 .card:hover {
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .card-body {
@@ -186,6 +294,7 @@ body {
     font-weight: 700;
     margin: var(--space-2) 0;
     color: var(--dark-gray);
+    font-variant-numeric: tabular-nums;
 }
 
 .stat-card i {
@@ -193,14 +302,17 @@ body {
 }
 
 /* ===== Badges ===== */
+/* Fully rounded, matching the mark's circular geometry */
 .badge {
     font-weight: 500;
     padding: var(--space-1) var(--space-2);
+    border-radius: 999px;
 }
 
 /* ===== Buttons ===== */
+/* Fully rounded, matching the mark's circular geometry */
 .btn {
-    border-radius: 4px;
+    border-radius: 999px;
     font-weight: 500;
     transition: all 0.2s ease;
 }
@@ -210,6 +322,85 @@ body {
     box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
+/* Bootstrap primary overrides — flat cobalt, no gradients */
+.btn-primary {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+    font-weight: 700;
+}
+
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary:active,
+.btn-primary:disabled {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+}
+
+.btn-primary:hover {
+    filter: brightness(0.92);
+    box-shadow: 0 4px 8px rgba(var(--accent-rgb), 0.3);
+}
+
+.btn-outline-primary {
+    color: var(--accent);
+    border-color: var(--accent);
+}
+
+.btn-outline-primary:hover,
+.btn-outline-primary:focus,
+.btn-outline-primary:active {
+    background: var(--accent);
+    border-color: var(--accent);
+    color: #fff;
+}
+
+.btn-link {
+    color: var(--accent);
+}
+
+.bg-primary {
+    background-color: var(--accent) !important;
+}
+
+.text-primary {
+    color: var(--accent) !important;
+}
+
+.border-primary {
+    border-color: var(--accent) !important;
+}
+
+.form-check-input:checked {
+    background-color: var(--accent);
+    border-color: var(--accent);
+}
+
+.progress-bar {
+    background-color: var(--accent);
+}
+
+/* Coral CTA — reserve for exactly ONE primary CTA/badge per screen
+   (see DESIGN_PRINCIPLES §Brand Identity; defined here, applied in later phases) */
+.btn-cta {
+    background: var(--accent-warm);
+    border-color: var(--accent-warm);
+    color: #fff;
+    border-radius: 999px;
+    font-weight: 700;
+}
+
+.btn-cta:hover,
+.btn-cta:focus,
+.btn-cta:active {
+    background: var(--accent-warm);
+    border-color: var(--accent-warm);
+    color: #fff;
+    filter: brightness(0.94);
+}
+
 .btn-sm {
     padding: var(--space-1) var(--space-2);
     font-size: var(--font-size-sm);
@@ -217,17 +408,17 @@ body {
 
 /* ===== Tables ===== */
 .table {
-    background-color: white;
+    background-color: var(--surface);
 }
 
 .table thead th {
-    border-bottom: 2px solid #dee2e6;
+    border-bottom: 2px solid var(--line);
     font-weight: 600;
     color: var(--dark-gray);
 }
 
 .table-hover tbody tr:hover {
-    background-color: rgba(0, 123, 255, 0.05);
+    background-color: rgba(var(--accent-rgb), 0.05);
 }
 
 /* ===== Alerts ===== */
@@ -251,18 +442,19 @@ body {
 /* ===== Footer ===== */
 footer {
     margin-top: auto;
-    background-color: white;
-    border-top: 1px solid #dee2e6;
+    background-color: var(--surface-2);
+    border-top: 1px solid var(--line);
     padding-top: var(--space-2) !important;
     padding-bottom: var(--space-2) !important;
 }
 
 /* ===== Filters Section ===== */
 .filters-section {
-    background-color: white;
+    background-color: var(--surface);
     padding: var(--space-3);
-    border-radius: 8px;
-    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    border: 1px solid var(--line);
+    border-radius: 16px;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
     margin-bottom: var(--space-3);
 }
 
@@ -313,11 +505,11 @@ footer {
 /* ===== Route Cards ===== */
 .route-card,
 .route-library-card {
-    border: 1px solid #dee2e6;
-    border-radius: 8px;
+    border: 1px solid var(--line);
+    border-radius: 16px;
     padding: var(--space-2) var(--space-3);
     margin-bottom: var(--space-2);
-    background-color: white;
+    background-color: var(--surface);
     transition: all 0.2s ease;
     cursor: pointer;
 }
@@ -325,13 +517,13 @@ footer {
 .route-card:hover,
 .route-library-card:hover {
     border-color: var(--primary-color);
-    box-shadow: 0 4px 8px rgba(0, 123, 255, 0.15);
+    box-shadow: 0 4px 8px rgba(var(--accent-rgb), 0.15);
     transform: translateY(-4px);
 }
 
 .route-library-card:active {
     transform: translateY(calc(-1 * var(--space-1)));
-    box-shadow: 0 2px 4px rgba(0, 123, 255, 0.2);
+    box-shadow: 0 2px 4px rgba(var(--accent-rgb), 0.2);
 }
 
 .route-card-header {
@@ -373,7 +565,7 @@ footer {
 
 .route-stat-label {
     font-size: var(--font-size-xs);
-    color: #6c757d;
+    color: var(--ink-soft);
     text-transform: uppercase;
     letter-spacing: 0.5px;
 }
@@ -382,6 +574,7 @@ footer {
     font-size: var(--font-size-base);
     font-weight: 600;
     color: var(--dark-gray);
+    font-variant-numeric: tabular-nums;
 }
 
 /* ===== Weather Display ===== */
@@ -394,6 +587,7 @@ footer {
     font-size: var(--font-size-hero);
     font-weight: 700;
     color: var(--dark-gray);
+    font-variant-numeric: tabular-nums;
 }
 
 /* ===== Responsive Design (Mobile First) ===== */
@@ -612,59 +806,59 @@ select:focus {
    Ported from deprecated CLI template
    ======================================== */
 
-/* ===== Epic #237 Color Palette ===== */
+/* ===== Epic #237 Color Palette (legacy aliases → Fair Weather accent) ===== */
 :root {
-    --epic-primary: #667eea;
-    --epic-secondary: #764ba2;
-    --epic-gradient: linear-gradient(135deg, #4a5fd5 0%, #764ba2 100%);
+    --epic-primary: var(--accent);
+    --epic-secondary: var(--accent);
+    --epic-gradient: var(--accent);
 }
 
 /* ===== Issue #242: Enhanced Focus Indicators (3px minimum, WCAG 2.4.7) ===== */
 *:focus-visible {
-    outline: 3px solid #667eea;
+    outline: 3px solid var(--accent);
     outline-offset: var(--space-1);
     border-radius: 4px;
 }
 
 button:focus-visible,
 .btn:focus-visible {
-    outline: 3px solid #667eea;
+    outline: 3px solid var(--accent);
     outline-offset: var(--space-1);
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.3);
 }
 
 input:focus-visible,
 select:focus-visible,
 textarea:focus-visible {
-    outline: 3px solid #667eea;
+    outline: 3px solid var(--accent);
     outline-offset: var(--space-1);
-    border-color: #667eea;
+    border-color: var(--accent);
 }
 
 a:focus-visible {
-    outline: 3px solid #667eea;
+    outline: 3px solid var(--accent);
     outline-offset: var(--space-1);
     text-decoration: underline;
     text-decoration-thickness: 2px;
 }
 
 .nav-link:focus-visible {
-    outline: 3px solid #667eea;
+    outline: 3px solid var(--accent);
     outline-offset: var(--space-1);
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.3);
 }
 
 .route-row:focus-visible,
 tr:focus-visible {
-    outline: 3px solid #667eea;
+    outline: 3px solid var(--accent);
     outline-offset: calc(-1 * var(--space-1));
-    background-color: rgba(102, 126, 234, 0.1);
+    background-color: rgba(var(--accent-rgb), 0.1);
 }
 
 .card:focus-visible {
-    outline: 3px solid #667eea;
+    outline: 3px solid var(--accent);
     outline-offset: var(--space-1);
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.3);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.3);
 }
 
 /* ===== Issue #243: Skip Navigation Links ===== */
@@ -672,7 +866,7 @@ tr:focus-visible {
     position: absolute;
     top: -40px;
     left: 0;
-    background: #667eea;
+    background: var(--accent);
     color: white;
     padding: var(--space-2);
     text-decoration: none;
@@ -693,8 +887,8 @@ tr:focus-visible {
     cursor: pointer;
     transition: all 0.2s ease;
     box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-    background: white;
-    border: 1px solid #e0e0e0;
+    background: var(--surface);
+    border: 1px solid var(--line);
     margin-bottom: var(--space-2);
     position: relative;
 }
@@ -705,33 +899,33 @@ tr:focus-visible {
 }
 
 .route-card-compact:focus {
-    outline: 3px solid #667eea;
+    outline: 3px solid var(--accent);
     outline-offset: var(--space-1);
-    box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.2);
+    box-shadow: 0 0 0 3px rgba(var(--accent-rgb), 0.2);
 }
 
 .route-card-compact.selected {
-    background-color: #f0f7ff;
-    border-color: #667eea;
-    box-shadow: 0 2px 8px rgba(102, 126, 234, 0.2);
+    background-color: rgba(var(--accent-rgb), 0.06);
+    border-color: var(--accent);
+    box-shadow: 0 2px 8px rgba(var(--accent-rgb), 0.2);
 }
 
 .route-card-compact.optimal {
-    background: linear-gradient(135deg, rgba(102, 126, 234, 0.05) 0%, rgba(118, 75, 162, 0.05) 100%);
-    border-left: 4px solid #667eea;
+    background: rgba(var(--accent-rgb), 0.05);
+    border-left: 4px solid var(--accent);
 }
 
 .route-card-compact-rank {
     flex: 0 0 32px;
     font-weight: bold;
-    color: #667eea;
+    color: var(--accent);
     font-size: var(--font-size-base);
 }
 
 .route-card-compact-name {
     flex: 1;
     font-weight: 600;
-    color: #333;
+    color: var(--ink);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -743,7 +937,8 @@ tr:focus-visible {
     gap: var(--space-2);
     align-items: center;
     font-size: var(--font-size-sm);
-    color: #6c757d;
+    color: var(--ink-soft);
+    font-variant-numeric: tabular-nums;
 }
 
 .route-card-compact-metric {
@@ -759,7 +954,8 @@ tr:focus-visible {
 
 .route-card-compact-score {
     font-weight: 600;
-    color: #667eea;
+    color: var(--accent);
+    font-variant-numeric: tabular-nums;
 }
 
 .route-card-compact-weather {
@@ -772,18 +968,18 @@ tr:focus-visible {
 }
 
 .route-card-compact-weather.favorable {
-    background-color: #d4edda;
-    color: #155724;
+    background-color: rgba(62, 142, 99, 0.13);
+    color: #1F5C3F;
 }
 
 .route-card-compact-weather.unfavorable {
-    background-color: #f8d7da;
-    color: #721c24;
+    background-color: rgba(196, 72, 58, 0.12);
+    color: #7A2A21;
 }
 
 .route-card-compact-weather.neutral {
-    background-color: #fff3cd;
-    color: #856404;
+    background-color: rgba(201, 138, 29, 0.15);
+    color: #6E4C0F;
 }
 
 /* ===== Issue #248: Skeleton Loading States ===== */
@@ -805,8 +1001,8 @@ tr:focus-visible {
     align-items: center;
     padding: var(--space-2) var(--space-3);
     border-radius: 4px;
-    background: white;
-    border: 1px solid #e0e0e0;
+    background: var(--surface);
+    border: 1px solid var(--line);
     margin-bottom: var(--space-2);
     gap: var(--space-2);
 }
@@ -851,7 +1047,7 @@ tr:focus-visible {
     width: 64px;
     height: 64px;
     border: 4px solid #e0e0e0;
-    border-top-color: #667eea;
+    border-top-color: var(--accent);
     border-radius: 50%;
     animation: skeleton-map-spin 1s linear infinite;
 }
@@ -863,8 +1059,8 @@ tr:focus-visible {
 .skeleton-weather {
     padding: var(--space-2);
     border-radius: 4px;
-    background: white;
-    border: 1px solid #e0e0e0;
+    background: var(--surface);
+    border: 1px solid var(--line);
 }
 
 .skeleton-weather-header {
@@ -886,9 +1082,9 @@ tr:focus-visible {
 /* Additional skeleton loaders for statistics and tables */
 .skeleton-stat-card {
     height: 120px;
-    border-radius: 8px;
-    background: white;
-    border: 1px solid #e0e0e0;
+    border-radius: 16px;
+    background: var(--surface);
+    border: 1px solid var(--line);
     padding: var(--space-3);
     margin-bottom: var(--space-3);
 }
@@ -913,8 +1109,8 @@ tr:focus-visible {
 }
 
 .skeleton-table {
-    background: white;
-    border-radius: 8px;
+    background: var(--surface);
+    border-radius: 16px;
     padding: var(--space-3);
 }
 
@@ -946,9 +1142,9 @@ tr:focus-visible {
 /* Skeleton for recommendation cards */
 .skeleton-recommendation-card {
     height: 200px;
-    border-radius: 8px;
-    background: white;
-    border: 1px solid #e0e0e0;
+    border-radius: 16px;
+    background: var(--surface);
+    border: 1px solid var(--line);
     padding: var(--space-4);
     margin-bottom: var(--space-3);
 }
@@ -983,10 +1179,10 @@ tr:focus-visible {
 
 /* Skeleton card components */
 .skeleton-card {
-    background: white;
-    border-radius: 8px;
+    background: var(--surface);
+    border-radius: 16px;
     padding: var(--space-4);
-    border: 1px solid #e0e0e0;
+    border: 1px solid var(--line);
 }
 
 .skeleton-card-header {
@@ -1049,28 +1245,28 @@ tr:focus-visible {
 }
 
 .toast-item.alert-success {
-    background-color: #d4edda;
-    border-color: #c3e6cb;
-    color: #155724;
+    background-color: #E4EFE9;
+    border-color: var(--success);
+    color: #1F5C3F;
 }
 
 .toast-item.alert-error,
 .toast-item.alert-danger {
-    background-color: #f8d7da;
-    border-color: #f5c6cb;
-    color: #721c24;
+    background-color: #F6E7E5;
+    border-color: var(--danger);
+    color: #7A2A21;
 }
 
 .toast-item.alert-warning {
-    background-color: #fff3cd;
-    border-color: #ffeaa7;
-    color: #856404;
+    background-color: #F7EFDD;
+    border-color: var(--warning);
+    color: #6E4C0F;
 }
 
 .toast-item.alert-info {
-    background-color: #d1ecf1;
-    border-color: #bee5eb;
-    color: #0c5460;
+    background-color: #E3EEF5;
+    border-color: var(--accent);
+    color: #084C73;
 }
 
 .toast-item .btn-close {
@@ -1214,8 +1410,8 @@ input[type="radio"] {
     left: 0;
     right: 0;
     height: 56px;
-    background: white;
-    border-top: 1px solid #dee2e6;
+    background: var(--surface);
+    border-top: 1px solid var(--line);
     box-shadow: 0 -2px 8px rgba(0,0,0,0.1);
     z-index: 1000;
     padding: 0;
@@ -1250,7 +1446,7 @@ input[type="radio"] {
     min-height: 56px;
     padding: var(--space-1) var(--space-2);
     text-decoration: none;
-    color: #6c757d;
+    color: var(--ink-soft);
     transition: all 0.2s ease;
     position: relative;
     cursor: pointer;
@@ -1258,13 +1454,13 @@ input[type="radio"] {
 
 .bottom-nav-item:hover,
 .mobile-bottom-nav-item:hover {
-    background-color: #f8f9fa;
-    color: #667eea;
+    background-color: var(--surface-2);
+    color: var(--accent);
 }
 
 .bottom-nav-item.active,
 .mobile-bottom-nav-item.active {
-    color: #667eea;
+    color: var(--accent);
     font-weight: 600;
 }
 
@@ -1276,7 +1472,7 @@ input[type="radio"] {
     left: 0;
     right: 0;
     height: 4px;
-    background: #667eea;
+    background: var(--accent);
 }
 
 .bottom-nav-item i,
@@ -1311,18 +1507,18 @@ input[type="radio"] {
     min-height: 56px;
     padding: var(--space-1) var(--space-2);
     text-decoration: none;
-    color: #6c757d;
+    color: var(--ink-soft);
     transition: all 0.2s ease;
     position: relative;
 }
 
 .mobile-bottom-nav-link:hover {
-    background-color: #f8f9fa;
-    color: #667eea;
+    background-color: var(--surface-2);
+    color: var(--accent);
 }
 
 .mobile-bottom-nav-link.active {
-    color: #667eea;
+    color: var(--accent);
     font-weight: 600;
 }
 
@@ -1333,7 +1529,64 @@ input[type="radio"] {
     left: 0;
     right: 0;
     height: 4px;
-    background: #667eea;
+    background: var(--accent);
+}
+
+/* ===== Issue #362: "More" drawer above the bottom nav ===== */
+/* Upward panel opened by the More button (Bootstrap collapse, no new deps).
+   Holds one-tap links to pages that don't fit the 5-item bar. */
+.bottom-nav-drawer {
+    position: fixed;
+    bottom: var(--bottom-nav-height);
+    left: 0;
+    right: 0;
+    background: var(--surface);
+    border-top: 1px solid var(--line);
+    box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.12);
+    border-radius: 16px 16px 0 0;
+    z-index: 999;
+    padding: var(--space-2) var(--space-3);
+}
+
+.bottom-nav-drawer-item {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    min-height: 48px;
+    min-width: 44px;
+    padding: var(--space-2) var(--space-3);
+    color: var(--ink);
+    text-decoration: none;
+    border-radius: 12px;
+    font-size: var(--font-size-base);
+}
+
+/* 8px spacing between touch targets */
+.bottom-nav-drawer-item + .bottom-nav-drawer-item {
+    margin-top: var(--space-2);
+}
+
+.bottom-nav-drawer-item i {
+    font-size: 20px;
+    color: var(--ink-soft);
+}
+
+.bottom-nav-drawer-item:hover,
+.bottom-nav-drawer-item:focus {
+    background: var(--surface-2);
+    color: var(--accent);
+}
+
+.bottom-nav-drawer-item:hover i,
+.bottom-nav-drawer-item:focus i,
+.bottom-nav-drawer-item.active i {
+    color: var(--accent);
+}
+
+.bottom-nav-drawer-item.active {
+    color: var(--accent);
+    font-weight: 600;
+    background: rgba(var(--accent-rgb), 0.08);
 }
 
 /* ===== Issue #252: Swipe Gesture Visual Feedback ===== */
@@ -1343,7 +1596,7 @@ input[type="radio"] {
     transform: translateY(-50%);
     width: 64px;
     height: 64px;
-    background: rgba(102, 126, 234, 0.9);
+    background: rgba(var(--accent-rgb), 0.9);
     border-radius: 50%;
     display: none;
     align-items: center;
@@ -1352,7 +1605,7 @@ input[type="radio"] {
     color: white;
     z-index: 10001;
     pointer-events: none;
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+    box-shadow: 0 4px 12px rgba(var(--accent-rgb), 0.4);
     animation: swipeIndicatorPulse 0.3s ease-out;
 }
 
@@ -1387,7 +1640,7 @@ input[type="radio"] {
     top: 0;
     left: 0;
     height: 4px;
-    background: linear-gradient(90deg, #667eea 0%, #764ba2 100%);
+    background: var(--accent);
     width: 0%;
     z-index: 10002;
     pointer-events: none;
@@ -1404,7 +1657,7 @@ input[type="radio"] {
     top: var(--space-3);
     left: 50%;
     transform: translateX(-50%);
-    background: rgba(102, 126, 234, 0.9);
+    background: rgba(var(--accent-rgb), 0.9);
     color: white;
     padding: var(--space-2) var(--space-3);
     border-radius: 24px;
@@ -1415,7 +1668,7 @@ input[type="radio"] {
     gap: var(--space-2);
     z-index: 10001;
     pointer-events: none;
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.4);
+    box-shadow: 0 4px 12px rgba(var(--accent-rgb), 0.4);
     animation: refreshIndicatorSlide 0.3s ease-out;
 }
 
@@ -1452,9 +1705,9 @@ input[type="radio"] {
     display: flex;
     gap: var(--space-3);
     padding: var(--space-2) var(--space-3);
-    background: linear-gradient(135deg, #4a5fd5 0%, #764ba2 100%);
+    background: var(--accent);
     color: white;
-    border-radius: 8px;
+    border-radius: 16px;
     margin-bottom: var(--space-2);
     height: 72px;
     align-items: center;
@@ -1671,7 +1924,7 @@ input[type="radio"] {
     
     .loading-spinner {
         animation: none;
-        border-top-color: #667eea;
+        border-top-color: var(--accent);
     }
     
     .card,
@@ -1738,30 +1991,25 @@ h5.card-title {
 
 /* --- Hero decision card: elevated shadow + branded border (#68) --- */
 .card.hero-card {
-    box-shadow: 0 4px 16px rgba(102, 126, 234, 0.15) !important;
-    border-color: rgba(102, 126, 234, 0.2) !important;
+    box-shadow: 0 4px 16px rgba(var(--accent-rgb), 0.15) !important;
+    border-color: rgba(var(--accent-rgb), 0.2) !important;
     transition: box-shadow 0.2s ease;
 }
 
 .card.hero-card:hover {
-    box-shadow: 0 8px 24px rgba(102, 126, 234, 0.22) !important;
+    box-shadow: 0 8px 24px rgba(var(--accent-rgb), 0.22) !important;
 }
 
-/* --- Optimal route card: gradient border treatment (#68) --- */
+/* --- Optimal route card: flat cobalt border (gradients retired) (#68) --- */
 .route-card-compact.optimal {
-    border: 4px solid transparent;
-    background:
-        linear-gradient(white, white) padding-box,
-        linear-gradient(135deg, var(--primary-color), var(--primary-dark)) border-box;
-    box-shadow: 0 4px 12px rgba(102, 126, 234, 0.2);
+    border: 2px solid var(--accent);
+    background: var(--surface);
+    box-shadow: 0 4px 12px rgba(var(--accent-rgb), 0.2);
 }
 
-/* Score badge: gradient text for visual pop */
+/* Score badge: flat cobalt (gradient text retired) */
 .route-card-compact-score {
-    background: var(--primary-gradient);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
+    color: var(--accent);
 }
 
 /* Route row hover: left accent bar + lift */
@@ -1900,11 +2148,11 @@ h5.card-title {
 }
 
 .workout-strip {
-    background: white;
-    border-radius: 8px;
+    background: var(--surface);
+    border-radius: 16px;
     padding: var(--space-2) var(--space-3);
-    box-shadow: 0 2px 4px rgba(0,0,0,0.08);
-    border: 1px solid rgba(0,0,0,0.07);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.08);
+    border: 1px solid var(--line);
     display: flex;
     align-items: center;
     gap: var(--space-3);
@@ -1945,18 +2193,18 @@ h5.card-title {
 }
 
 .workout-fit-badge.fit-good {
-    background-color: rgba(40, 167, 69, 0.12);
-    color: #1a7431;
+    background-color: rgba(62, 142, 99, 0.13);
+    color: #1F5C3F;
 }
 
 .workout-fit-badge.fit-moderate {
-    background-color: rgba(255, 193, 7, 0.15);
-    color: #7a6000;
+    background-color: rgba(201, 138, 29, 0.15);
+    color: #6E4C0F;
 }
 
 .workout-fit-badge.fit-poor {
-    background-color: rgba(220, 53, 69, 0.12);
-    color: #a71d2a;
+    background-color: rgba(196, 72, 58, 0.12);
+    color: #7A2A21;
 }
 
 /* Workout option cards (#341) */
@@ -1969,8 +2217,8 @@ h5.card-title {
     flex: 1;
     padding: var(--space-2);
     border: 2px solid var(--color-border);
-    border-radius: 8px;
-    background: white;
+    border-radius: 16px;
+    background: var(--surface);
     cursor: pointer;
     transition: border-color 0.15s, box-shadow 0.15s;
 }
@@ -2047,19 +2295,20 @@ h5.card-title {
 }
 
 .hourly-cell.hourly-commute {
-    background: rgba(74, 95, 213, 0.1);
-    border: 1px solid rgba(74, 95, 213, 0.3);
+    background: rgba(var(--accent-rgb), 0.1);
+    border: 1px solid rgba(var(--accent-rgb), 0.3);
 }
 
 .hourly-time {
     font-weight: 600;
-    color: #333;
+    color: var(--ink);
     margin-bottom: 2px;
 }
 
 .hourly-temp {
     font-weight: 700;
     font-size: var(--font-size-sm);
+    font-variant-numeric: tabular-nums;
 }
 
 .hourly-wind,

--- a/static/explore.html
+++ b/static/explore.html
@@ -44,6 +44,14 @@
             font-size: var(--font-size-xs);
             background: var(--surface, #fff);
             width: 100%;
+            cursor: pointer;
+        }
+        .route-badge--selected {
+            border-color: #0b6fa6;
+            box-shadow: 0 0 0 2px rgba(11,111,166,0.25);
+        }
+        .route-badge--dimmed {
+            opacity: 0.45;
         }
         .route-badge .swatch {
             width: 10px;

--- a/static/explore.html
+++ b/static/explore.html
@@ -40,9 +40,9 @@
             gap: 6px;
             padding: 6px 10px;
             border-radius: 8px;
-            border: 1px solid var(--color-border, #dee2e6);
+            border: 1px solid var(--color-border, var(--line));
             font-size: var(--font-size-xs);
-            background: var(--color-surface, #fff);
+            background: var(--surface, #fff);
             width: 100%;
         }
         .route-badge .swatch {
@@ -56,30 +56,56 @@
             font-size: 0.7rem;
             line-height: 1.5;
         }
+        /* Numbered workflow step headers (#361) — used inside the controls card */
         .workflow-step {
             display: inline-flex;
             align-items: center;
-            gap: 6px;
+            gap: 8px;
             color: var(--color-text-muted);
+            font-weight: 600;
         }
         .workflow-step-num {
             display: inline-flex;
             align-items: center;
             justify-content: center;
-            width: 20px;
-            height: 20px;
+            width: 22px;
+            height: 22px;
+            flex-shrink: 0;
             border-radius: 50%;
-            background: var(--color-border, #dee2e6);
-            color: #495057;
-            font-size: 0.7rem;
+            background: var(--color-border, var(--line));
+            color: var(--ink-soft);
+            font-size: 0.75rem;
             font-weight: 700;
         }
         .workflow-step.workflow-step-done {
-            color: #198754;
+            color: var(--success);
         }
         .workflow-step.workflow-step-done .workflow-step-num {
-            background: #198754;
+            background: var(--success);
             color: #fff;
+        }
+        .control-step {
+            padding-left: 30px;
+        }
+        .control-step + hr {
+            margin: var(--space-3, 0.75rem) 0;
+        }
+        /* Coverage legend (#360) */
+        .legend-swatch {
+            display: inline-block;
+            width: 12px;
+            height: 12px;
+            border-radius: 3px;
+            border-width: 1.5px;
+            border-style: solid;
+            flex-shrink: 0;
+        }
+        .legend-line-swatch {
+            display: inline-block;
+            width: 20px;
+            height: 0;
+            border-top: 2px dashed var(--ink-soft);
+            flex-shrink: 0;
         }
     </style>
 </head>
@@ -118,126 +144,156 @@
 
     <main id="main-content" class="container mt-2 mb-4" role="main">
 
-        <!-- Concept explainer -->
-        <p class="small text-muted mb-2">
-            Tiles are map grid squares — covering more of them means you've ridden more unique roads.
-            <strong>Squadrats</strong> are zoom-14 tiles (~1.2&nbsp;km&sup2; each);
-            <strong>Squadratinhos</strong> are zoom-17 tiles (~0.15&nbsp;km&sup2; each).
+        <h1 class="fs-4 mb-2">Explore</h1>
+
+        <!-- Concept explainer (#360, #375 field note: jargon-free first use) -->
+        <p class="small text-muted mb-3">
+            Tiles are map grid squares. Covering more tiles means you've explored more unique roads.
+            <strong>Squadrats</strong> = zoom-14 tiles (~1.2&nbsp;km&sup2;);
+            <strong>Squadratinhos</strong> = zoom-17 tiles (~0.15&nbsp;km&sup2;).
         </p>
 
-        <!-- Coverage stats -->
-        <div class="row g-2 mb-2" id="coverage-stats">
-            <div class="col-4">
-                <div class="card coverage-stat">
-                    <div class="stat-value" id="stat-tiles-visited">—</div>
-                    <div class="stat-label">Tiles Visited</div>
-                </div>
-            </div>
-            <div class="col-4">
-                <div class="card coverage-stat">
-                    <div class="stat-value" id="stat-coverage-pct">—</div>
-                    <div class="stat-label">Coverage</div>
-                </div>
-            </div>
-            <div class="col-4">
-                <div class="card coverage-stat">
-                    <div class="stat-value" id="stat-total-tiles">—</div>
-                    <div class="stat-label">Total in View</div>
-                </div>
-            </div>
-        </div>
+        <div class="row g-3">
+            <!-- Controls column (#367: side-by-side with map on lg+) -->
+            <div class="col-lg-4 order-1">
+                <div class="card mb-3">
+                    <div class="card-body py-3 px-3">
 
-        <!-- Map -->
-        <div class="card mb-2">
-            <div class="card-body p-2">
-                <div id="explore-map" role="img" aria-label="Tile coverage map"></div>
-            </div>
-        </div>
-
-        <!-- Workflow steps -->
-        <div class="d-flex flex-wrap gap-3 mb-2 small" id="workflow-steps">
-            <span class="workflow-step" id="workflow-step-1"><span class="workflow-step-num">1</span> Load your coverage</span>
-            <span class="workflow-step" id="workflow-step-2"><span class="workflow-step-num">2</span> Set a start point</span>
-            <span class="workflow-step" id="workflow-step-3"><span class="workflow-step-num">3</span> Generate</span>
-        </div>
-
-        <!-- Controls -->
-        <div class="card mb-2">
-            <div class="card-body py-2 px-3">
-                <div class="d-flex flex-wrap gap-2 align-items-center">
-                    <label class="form-label small mb-0 me-1" for="coverage-type-select">Coverage</label>
-                    <i class="bi bi-question-circle text-muted me-1" tabindex="0" role="img"
-                       title="Squadrats = zoom-14 tiles (~1.2 km² each). Squadratinhos = zoom-17 tiles (~0.15 km² each). Covering more tiles means you've ridden more unique roads."
-                       aria-label="What are Squadrats and Squadratinhos?"></i>
-                    <select class="form-select form-select-sm" id="coverage-type-select" style="max-width: 180px;" aria-label="Coverage grid granularity — also controls which grid the route generator targets">
-                        <option value="14" selected>Squadrats</option>
-                        <option value="17">Squadratinhos</option>
-                        <option value="both">Both</option>
-                    </select>
-                    <button class="btn btn-sm btn-primary" id="load-coverage-btn">
-                        <i class="bi bi-arrow-clockwise" aria-hidden="true"></i> Load Coverage
-                    </button>
-                    <button class="btn btn-sm btn-outline-secondary" id="clear-cache-btn">
-                        <i class="bi bi-trash" aria-hidden="true"></i> Clear Cache
-                    </button>
-                    <span class="text-muted small" id="coverage-status"></span>
-                </div>
-            </div>
-        </div>
-
-        <!-- Route generation -->
-        <div class="card">
-            <div class="card-body py-2 px-3">
-                <h6 class="fw-bold mb-2" style="font-size:var(--font-size-sm); text-transform:uppercase; letter-spacing:0.05em; color:var(--color-text-muted);">
-                    <i class="bi bi-signpost-2" aria-hidden="true"></i> Generate Exploration Route
-                </h6>
-                <div class="d-flex flex-wrap gap-3 align-items-center mb-2">
-                    <div>
-                        <label class="form-label small mb-0" for="distance-slider">Distance (<span id="distance-unit-label">km</span>)</label>
-                        <div class="d-flex align-items-center gap-2">
-                            <input type="range" class="form-range" id="distance-slider" min="10" max="150" value="40" step="5"
-                                   aria-label="Target route distance"
-                                   oninput="window.updateDistanceDisplay(this.value)">
-                            <span class="small fw-bold" id="distance-value">40 km</span>
-                        </div>
-                    </div>
-                    <div>
-                        <label class="form-label small mb-0" for="location-search-input">Start</label>
-                        <div class="input-group input-group-sm" style="max-width: 260px;">
-                            <input type="text" class="form-control" id="location-search-input"
-                                   placeholder="City, State or ZIP" aria-label="Search for a starting location"
-                                   autocomplete="off">
-                            <button class="btn btn-outline-secondary" type="button" id="location-search-btn"
-                                    aria-label="Search location">
-                                <i class="bi bi-search" aria-hidden="true"></i>
+                        <!-- Step 1: Coverage -->
+                        <span class="workflow-step small mb-2 d-flex" id="workflow-step-1">
+                            <span class="workflow-step-num">1</span> Load your coverage
+                        </span>
+                        <div class="control-step d-flex flex-wrap gap-2 align-items-center">
+                            <label class="form-label small mb-0 me-1" for="coverage-type-select">Coverage</label>
+                            <i class="bi bi-question-circle text-muted me-1" tabindex="0" role="img"
+                               data-bs-toggle="tooltip" data-bs-placement="top"
+                               title="Squadrats = zoom-14 tiles (~1.2 km² each). Squadratinhos = zoom-17 tiles (~0.15 km² each). Covering more tiles means you've ridden more unique roads."
+                               aria-label="What are Squadrats and Squadratinhos?"></i>
+                            <select class="form-select form-select-sm" id="coverage-type-select" style="max-width: 180px;" aria-label="Coverage grid granularity — also controls which grid the route generator targets">
+                                <option value="14" selected>Squadrats</option>
+                                <option value="17">Squadratinhos</option>
+                                <option value="both">Both</option>
+                            </select>
+                            <button class="btn btn-sm btn-primary" id="load-coverage-btn">
+                                <i class="bi bi-arrow-clockwise" aria-hidden="true"></i> Load Coverage
                             </button>
+                            <button class="btn btn-sm btn-outline-danger" id="clear-cache-btn">
+                                <i class="bi bi-trash" aria-hidden="true"></i> Clear Cache
+                            </button>
+                            <span class="text-muted small" id="coverage-status"></span>
                         </div>
-                        <div class="small text-muted mt-1" id="start-display">Click map or search to set</div>
-                    </div>
-                    <div>
-                        <label class="form-label small mb-0" for="optimize-for-select">Optimize for</label>
-                        <select class="form-select form-select-sm" id="optimize-for-select" aria-label="Route optimization priority">
-                            <option value="tiles" selected>Most new tiles</option>
-                            <option value="distance">Shortest route</option>
-                            <option value="efficiency">Efficiency (new tiles/km)</option>
-                        </select>
-                    </div>
-                    <div>
-                        <label class="form-label small mb-0" for="surface-preference-select">Surface</label>
-                        <select class="form-select form-select-sm" id="surface-preference-select" aria-label="Surface preference for road routing">
-                            <option value="any" selected>Any surface</option>
-                            <option value="paved">Prefer paved</option>
-                            <option value="unpaved">Prefer unpaved</option>
-                        </select>
+
+                        <hr>
+
+                        <!-- Step 2: Start point -->
+                        <span class="workflow-step small mb-2 d-flex" id="workflow-step-2">
+                            <span class="workflow-step-num">2</span> Set a start point
+                        </span>
+                        <div class="control-step">
+                            <label class="form-label small mb-0" for="location-search-input">Search, or click the map</label>
+                            <div class="input-group input-group-sm">
+                                <input type="text" class="form-control" id="location-search-input"
+                                       placeholder="City, State or ZIP" aria-label="Search for a starting location"
+                                       autocomplete="off">
+                                <button class="btn btn-outline-secondary" type="button" id="location-search-btn"
+                                        aria-label="Search location">
+                                    <i class="bi bi-search" aria-hidden="true"></i>
+                                </button>
+                            </div>
+                            <div class="small text-muted mt-1" id="start-display">Click map or search to set</div>
+                        </div>
+
+                        <hr>
+
+                        <!-- Step 3: Generate -->
+                        <span class="workflow-step small mb-2 d-flex" id="workflow-step-3">
+                            <span class="workflow-step-num">3</span> Generate routes
+                        </span>
+                        <div class="control-step">
+                            <div class="mb-2">
+                                <label class="form-label small mb-0" for="distance-slider">Distance (<span id="distance-unit-label"></span>)</label>
+                                <div class="d-flex align-items-center gap-2">
+                                    <input type="range" class="form-range" id="distance-slider" min="10" max="150" value="40" step="5"
+                                           aria-label="Target route distance"
+                                           oninput="window.updateDistanceDisplay(this.value)">
+                                    <span class="small fw-bold tabular-nums" id="distance-value">40</span>
+                                </div>
+                            </div>
+                            <div class="mb-2">
+                                <label class="form-label small mb-0" for="optimize-for-select">Optimize for</label>
+                                <select class="form-select form-select-sm" id="optimize-for-select" aria-label="Route optimization priority">
+                                    <option value="tiles" selected>Most new tiles</option>
+                                    <option value="distance">Shortest route</option>
+                                    <option value="efficiency">Efficiency (new tiles/km)</option>
+                                </select>
+                            </div>
+                            <div class="mb-2">
+                                <label class="form-label small mb-0" for="surface-preference-select">Surface</label>
+                                <select class="form-select form-select-sm" id="surface-preference-select" aria-label="Surface preference for road routing">
+                                    <option value="any" selected>Any surface</option>
+                                    <option value="paved">Prefer paved</option>
+                                    <option value="unpaved">Prefer unpaved</option>
+                                </select>
+                            </div>
+                            <div class="d-flex flex-wrap gap-2 align-items-center">
+                                <button class="btn btn-sm btn-outline-primary" id="generate-route-btn" disabled>
+                                    <i class="bi bi-cursor" aria-hidden="true"></i> Generate Routes
+                                </button>
+                                <span class="spinner-border spinner-border-sm text-primary d-none" id="worker-spinner" role="status" aria-hidden="true"></span>
+                            </div>
+                            <div class="text-muted small mt-1" id="worker-status"></div>
+                        </div>
+
                     </div>
                 </div>
-                <div class="d-flex flex-wrap gap-2 align-items-center mb-2">
-                    <button class="btn btn-sm btn-outline-primary" id="generate-route-btn" disabled>
-                        <i class="bi bi-cursor" aria-hidden="true"></i> Generate Routes
-                    </button>
-                    <span class="spinner-border spinner-border-sm text-primary d-none" id="worker-spinner" role="status" aria-hidden="true"></span>
-                    <span class="text-muted small" id="worker-status"></span>
+            </div>
+
+            <!-- Map column -->
+            <div class="col-lg-8 order-2">
+                <div class="card mb-2">
+                    <div class="card-body p-2">
+                        <div id="explore-map" role="img" aria-label="Tile coverage map"></div>
+
+                        <!-- Coverage legend (#360) -->
+                        <div class="d-flex flex-wrap gap-3 small text-muted mt-2 px-1" id="coverage-legend">
+                            <span class="d-inline-flex align-items-center gap-1">
+                                <span class="legend-swatch" style="background:#e8a84c; border-color:#c8813a;"></span>
+                                Visited tile
+                            </span>
+                            <span class="d-inline-flex align-items-center gap-1">
+                                <span class="legend-swatch" style="background:#4caf50; border-color:#2e7d32;"></span>
+                                New tile this route adds
+                            </span>
+                            <span class="d-inline-flex align-items-center gap-1">
+                                <span class="legend-line-swatch"></span>
+                                Dashed = quick preview, solid = real road route (colored by direction)
+                            </span>
+                        </div>
+                    </div>
                 </div>
+
+                <!-- Coverage stats (#367: below the map) -->
+                <div class="row g-2 mb-2" id="coverage-stats">
+                    <div class="col-4">
+                        <div class="card coverage-stat">
+                            <div class="stat-value tabular-nums" id="stat-tiles-visited">—</div>
+                            <div class="stat-label">Tiles Visited</div>
+                        </div>
+                    </div>
+                    <div class="col-4">
+                        <div class="card coverage-stat">
+                            <div class="stat-value tabular-nums" id="stat-coverage-pct">—</div>
+                            <div class="stat-label">Coverage</div>
+                        </div>
+                    </div>
+                    <div class="col-4">
+                        <div class="card coverage-stat">
+                            <div class="stat-value tabular-nums" id="stat-total-tiles">—</div>
+                            <div class="stat-label">Total in View</div>
+                        </div>
+                    </div>
+                </div>
+
                 <div id="route-list" class="d-flex flex-wrap gap-2"></div>
             </div>
         </div>
@@ -254,7 +310,7 @@
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="/js/common.js"></script>
     <script src="/js/api-client.js?v=6"></script>
-    <script src="/js/explore.js?v=3"></script>
+    <script src="/js/explore.js?v=4"></script>
 
     <div id="bottom-nav-more" class="bottom-nav-drawer collapse d-md-none" aria-label="More pages">
         <a class="bottom-nav-drawer-item active" href="/explore.html" aria-current="page">

--- a/static/explore.html
+++ b/static/explore.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Explore - Ride Optimizer</title>
+    <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
@@ -85,9 +86,20 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <nav class="navbar navbar-expand-lg navbar-dark navbar-gradient" role="navigation" aria-label="Main navigation">
+    <nav class="navbar navbar-expand-lg navbar-fairweather" role="navigation" aria-label="Main navigation">
         <div class="container">
-            <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home"><i class="bi bi-bicycle" aria-hidden="true"></i> Ride Optimizer</a>
+            <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home">
+                <svg class="brand-mark" viewBox="0 0 48 48" fill="none" aria-hidden="true" focusable="false">
+                    <circle cx="24" cy="24" r="12" stroke="currentColor" stroke-width="3.4"/>
+                    <g stroke="currentColor" stroke-width="3.4" stroke-linecap="round">
+                        <line x1="24" y1="2" x2="24" y2="8"/><line x1="24" y1="40" x2="24" y2="46"/>
+                        <line x1="2" y1="24" x2="8" y2="24"/><line x1="40" y1="24" x2="46" y2="24"/>
+                        <line x1="8.3" y1="8.3" x2="12.5" y2="12.5"/><line x1="35.5" y1="35.5" x2="39.7" y2="39.7"/>
+                        <line x1="39.7" y1="8.3" x2="35.5" y2="12.5"/><line x1="12.5" y1="35.5" x2="8.3" y2="39.7"/>
+                    </g>
+                </svg>
+                <span><span class="brand-ride">Ride</span>&nbsp;<span class="brand-optimizer">Optimizer</span></span>
+            </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -232,7 +244,7 @@
 
     </main>
 
-    <footer class="mt-3 bg-light">
+    <footer class="mt-3">
         <div class="container text-center text-muted">
             <small>Ride Optimizer v0.17.0 - Smart Static Architecture</small>
         </div>
@@ -244,22 +256,38 @@
     <script src="/js/api-client.js?v=6"></script>
     <script src="/js/explore.js?v=3"></script>
 
+    <div id="bottom-nav-more" class="bottom-nav-drawer collapse d-md-none" aria-label="More pages">
+        <a class="bottom-nav-drawer-item active" href="/explore.html" aria-current="page">
+            <i class="bi bi-compass" aria-hidden="true"></i>
+            <span>Explore</span>
+        </a>
+        <a class="bottom-nav-drawer-item" href="/settings.html">
+            <i class="bi bi-gear" aria-hidden="true"></i>
+            <span>Settings</span>
+        </a>
+    </div>
     <nav id="bottom-nav" class="bottom-nav d-md-none" role="navigation" aria-label="Mobile navigation">
-        <button class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
+        <button type="button" class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
             <i class="bi bi-house-door" aria-hidden="true"></i>
             <span>Home</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Routes" onclick="window.location.href='/routes.html'">
+        <button type="button" class="bottom-nav-item" aria-label="Routes" onclick="window.location.href='/routes.html'">
             <i class="bi bi-map" aria-hidden="true"></i>
             <span>Routes</span>
         </button>
-        <button class="bottom-nav-item active" aria-label="Explore" aria-current="page">
-            <i class="bi bi-compass" aria-hidden="true"></i>
-            <span>Explore</span>
+        <button type="button" class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
+            <i class="bi bi-cloud-sun" aria-hidden="true"></i>
+            <span>Weather</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Settings" onclick="window.location.href='/settings.html'">
-            <i class="bi bi-gear" aria-hidden="true"></i>
-            <span>Settings</span>
+        <button type="button" class="bottom-nav-item" aria-label="Reports" onclick="window.location.href='/reports.html'">
+            <i class="bi bi-bar-chart-line" aria-hidden="true"></i>
+            <span>Reports</span>
+        </button>
+        <button type="button" class="bottom-nav-item active" aria-label="More pages"
+                data-bs-toggle="collapse" data-bs-target="#bottom-nav-more"
+                aria-expanded="false" aria-controls="bottom-nav-more">
+            <i class="bi bi-three-dots" aria-hidden="true"></i>
+            <span>More</span>
         </button>
     </nav>
 </body>

--- a/static/img/favicon.svg
+++ b/static/img/favicon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <!-- Fair Weather mark at minimum size: below 24px the four diagonal rays are
+       dropped, keeping the circle + four cardinal ticks (brand book minimum-size rule).
+       Explicit cobalt stroke: favicons can't inherit currentColor. -->
+  <circle cx="24" cy="24" r="12" stroke="#0B6FA6" stroke-width="4.5"/>
+  <g stroke="#0B6FA6" stroke-width="4.5" stroke-linecap="round">
+    <line x1="24" y1="2" x2="24" y2="8"/><line x1="24" y1="40" x2="24" y2="46"/>
+    <line x1="2" y1="24" x2="8" y2="24"/><line x1="40" y1="24" x2="46" y2="24"/>
+  </g>
+</svg>

--- a/static/img/logo.svg
+++ b/static/img/logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <!-- Fair Weather brand mark: circle + eight radiating ticks (wheel hub / sun).
+       Uses currentColor so it recolors per context. -->
+  <circle cx="24" cy="24" r="12" stroke="currentColor" stroke-width="3.4"/>
+  <g stroke="currentColor" stroke-width="3.4" stroke-linecap="round">
+    <line x1="24" y1="2" x2="24" y2="8"/><line x1="24" y1="40" x2="24" y2="46"/>
+    <line x1="2" y1="24" x2="8" y2="24"/><line x1="40" y1="24" x2="46" y2="24"/>
+    <line x1="8.3" y1="8.3" x2="12.5" y2="12.5"/><line x1="35.5" y1="35.5" x2="39.7" y2="39.7"/>
+    <line x1="39.7" y1="8.3" x2="35.5" y2="12.5"/><line x1="12.5" y1="35.5" x2="8.3" y2="39.7"/>
+  </g>
+</svg>

--- a/static/index.html
+++ b/static/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ride Optimizer</title>
     
+    <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
@@ -23,11 +24,11 @@
             border-radius: 8px;
         }
 
-        /* Weather banner styles */
+        /* Weather banner styles — flat cobalt (Fair Weather; gradients retired) */
         .weather-banner {
-            background: linear-gradient(135deg, #4a5fd5 0%, #764ba2 100%);
+            background: var(--accent);
             color: white;
-            border-radius: 8px;
+            border-radius: 16px 16px 0 0;
             padding: var(--space-3) var(--space-4);
             box-shadow: 0 2px 8px rgba(0,0,0,0.15);
             display: flex;
@@ -90,8 +91,8 @@
 
         /* Commute card styles */
         .commute-card {
-            background: white;
-            border-radius: 8px;
+            background: var(--surface);
+            border-radius: 16px;
             padding: var(--space-3);
             margin-bottom: var(--space-3);
             box-shadow: 0 2px 4px rgba(0,0,0,0.1);
@@ -236,35 +237,23 @@
         }
 
         /* â”€â”€ Design system: purple gradient buttons (#280) â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
-        .btn-primary {
-            background: linear-gradient(135deg, #4a5fd5 0%, #764ba2 100%);
-            border: none;
-            transition: opacity 0.2s ease-out, transform 0.2s ease-out;
-        }
-
-        .btn-primary:hover,
-        .btn-primary:focus {
-            opacity: 0.9;
-            transform: translateY(-1px);
-            background: linear-gradient(135deg, #4a5fd5 0%, #764ba2 100%);
-            border: none;
-        }
+        /* Primary buttons: flat cobalt via main.css .btn-primary override (Fair Weather) */
 
         /* Commute compare chevron rotation */
         .commute-chevron { transition: transform 0.2s; display: inline-block; }
         [data-bs-target="#commute-detail"][aria-expanded="true"] .commute-chevron { transform: rotate(180deg); }
 
         .card {
-            border-radius: 8px;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.08);
-            border: 1px solid rgba(0,0,0,0.07);
+            border-radius: 16px;
+            box-shadow: 0 1px 2px rgba(0,0,0,0.08);
+            border: 1px solid var(--line);
         }
 
         .weather-hourly-strip {
-            background: rgba(74, 95, 213, 0.08);
-            border-radius: 0 0 8px 8px;
+            background: rgba(var(--accent-rgb), 0.08);
+            border-radius: 0 0 16px 16px;
             padding: var(--space-2) var(--space-3);
-            margin-top: -8px;
+            margin-top: 0;
         }
     </style>
 </head>
@@ -274,10 +263,19 @@
     <a href="#home-tab" class="skip-link">Skip to navigation</a>
     
     <!-- Top Navigation (Mobile & Desktop) -->
-    <nav class="navbar navbar-expand-lg navbar-dark navbar-gradient" role="navigation" aria-label="Main navigation">
+    <nav class="navbar navbar-expand-lg navbar-fairweather" role="navigation" aria-label="Main navigation">
         <div class="container">
             <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home">
-                <i class="bi bi-bicycle" aria-hidden="true"></i> Ride Optimizer
+                <svg class="brand-mark" viewBox="0 0 48 48" fill="none" aria-hidden="true" focusable="false">
+                    <circle cx="24" cy="24" r="12" stroke="currentColor" stroke-width="3.4"/>
+                    <g stroke="currentColor" stroke-width="3.4" stroke-linecap="round">
+                        <line x1="24" y1="2" x2="24" y2="8"/><line x1="24" y1="40" x2="24" y2="46"/>
+                        <line x1="2" y1="24" x2="8" y2="24"/><line x1="40" y1="24" x2="46" y2="24"/>
+                        <line x1="8.3" y1="8.3" x2="12.5" y2="12.5"/><line x1="35.5" y1="35.5" x2="39.7" y2="39.7"/>
+                        <line x1="39.7" y1="8.3" x2="35.5" y2="12.5"/><line x1="12.5" y1="35.5" x2="8.3" y2="39.7"/>
+                    </g>
+                </svg>
+                <span><span class="brand-ride">Ride</span>&nbsp;<span class="brand-optimizer">Optimizer</span></span>
             </a>
             
             <!-- Mobile Menu Toggle Button -->
@@ -449,27 +447,43 @@
     </main>
 
     <!-- Bottom Navigation (Mobile) -->
+    <div id="bottom-nav-more" class="bottom-nav-drawer collapse d-md-none" aria-label="More pages">
+        <a class="bottom-nav-drawer-item" href="/explore.html">
+            <i class="bi bi-compass" aria-hidden="true"></i>
+            <span>Explore</span>
+        </a>
+        <a class="bottom-nav-drawer-item" href="/settings.html">
+            <i class="bi bi-gear" aria-hidden="true"></i>
+            <span>Settings</span>
+        </a>
+    </div>
     <nav id="bottom-nav" class="bottom-nav d-md-none" role="navigation" aria-label="Mobile navigation">
-        <button class="bottom-nav-item active" aria-label="Home" aria-current="page">
+        <button type="button" class="bottom-nav-item active" aria-label="Home" aria-current="page" onclick="window.location.href='/'">
             <i class="bi bi-house-door" aria-hidden="true"></i>
             <span>Home</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Routes" onclick="window.location.href='/routes.html'">
+        <button type="button" class="bottom-nav-item" aria-label="Routes" onclick="window.location.href='/routes.html'">
             <i class="bi bi-map" aria-hidden="true"></i>
             <span>Routes</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
+        <button type="button" class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
             <i class="bi bi-cloud-sun" aria-hidden="true"></i>
             <span>Weather</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Settings" onclick="window.location.href='/settings.html'">
-            <i class="bi bi-gear" aria-hidden="true"></i>
-            <span>Settings</span>
+        <button type="button" class="bottom-nav-item" aria-label="Reports" onclick="window.location.href='/reports.html'">
+            <i class="bi bi-bar-chart-line" aria-hidden="true"></i>
+            <span>Reports</span>
+        </button>
+        <button type="button" class="bottom-nav-item" aria-label="More pages"
+                data-bs-toggle="collapse" data-bs-target="#bottom-nav-more"
+                aria-expanded="false" aria-controls="bottom-nav-more">
+            <i class="bi bi-three-dots" aria-hidden="true"></i>
+            <span>More</span>
         </button>
     </nav>
     
     <!-- Footer -->
-    <footer class="mt-3 bg-light">
+    <footer class="mt-3">
         <div class="container text-center text-muted">
             <small>Ride Optimizer v0.17.0 - Smart Static Architecture</small>
         </div>

--- a/static/index.html
+++ b/static/index.html
@@ -228,7 +228,7 @@
         /* â”€â”€ Conditions / Route Status rows â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€â”€ */
         .conditions-row,
         .route-status-row {
-            border-bottom: 1px solid #f0f0f0;
+            border-bottom: 1px solid var(--line);
         }
 
         .conditions-row:last-of-type,

--- a/static/index.html
+++ b/static/index.html
@@ -255,6 +255,28 @@
             padding: var(--space-2) var(--space-3);
             margin-top: 0;
         }
+
+        /* -- Help row (#363: "How It Works" relocated out of above-the-fold) -- */
+        .help-row {
+            margin-top: var(--space-3);
+            padding-top: var(--space-2);
+            border-top: 1px solid var(--line);
+        }
+
+        /* -- Route Status: collapse to a labeled summary on mobile (#370b) -- */
+        .route-status-summary-toggle .route-status-chevron {
+            transition: transform 0.2s;
+        }
+
+        @media (max-width: 767.98px) {
+            .route-status-rows {
+                display: none;
+            }
+
+            .route-status-rows.route-status-rows-open {
+                display: block;
+            }
+        }
     </style>
 </head>
 <body>
@@ -351,14 +373,6 @@
 
     <!-- Main Content -->
     <main id="main-content" class="container mt-2 mb-3" role="main">
-            <div class="d-flex justify-content-end mb-1">
-                <button type="button" class="btn btn-sm btn-outline-secondary"
-                        data-bs-toggle="modal" data-bs-target="#howItWorksModal"
-                        aria-label="How It Works">
-                    <i class="bi bi-info-circle me-1" aria-hidden="true"></i>How It Works
-                </button>
-            </div>
-
             <!-- Weather Banner (full-width): current conditions + hourly strip -->
             <div class="mb-2">
                 <div id="weather-banner" class="weather-banner">
@@ -410,6 +424,16 @@
                                         <div class="skeleton skeleton-recommendation-metric"></div>
                                     </div>
                                 </div>
+                                <!-- Static pre-JS trigger (#370a): visible before data loads, replaced by
+                                     dashboard.js's data-aware version (with return-score teaser) once loaded -->
+                                <div class="mt-3">
+                                    <button type="button" class="btn btn-outline-secondary btn-sm commute-compare-toggle"
+                                            data-bs-toggle="collapse" data-bs-target="#commute-detail"
+                                            aria-expanded="false" aria-controls="commute-detail">
+                                        <i class="bi bi-list-ul" aria-hidden="true"></i> See both directions
+                                        <i class="bi bi-chevron-down ms-1 commute-chevron" aria-hidden="true"></i>
+                                    </button>
+                                </div>
                             </div>
                             <!-- Expanded commute detail (both directions) -->
                             <div class="collapse" id="commute-detail">
@@ -443,6 +467,15 @@
                         </div>
                     </div>
                 </div>
+            </div>
+
+            <!-- Muted help row (#363: moved out of above-the-fold) -->
+            <div class="help-row d-flex justify-content-center">
+                <button type="button" class="btn btn-sm btn-link text-muted"
+                        data-bs-toggle="modal" data-bs-target="#howItWorksModal"
+                        aria-label="How It Works">
+                    <i class="bi bi-info-circle me-1" aria-hidden="true"></i>How It Works
+                </button>
             </div>
     </main>
 
@@ -526,17 +559,16 @@
                 toastEl.style.zIndex = '1090';
                 toastEl.style.maxWidth = '340px';
                 toastEl.innerHTML =
-                    '<div class=”toast-header”>' +
-                        '<i class=”bi bi-stars text-primary me-2” aria-hidden=”true”></i>' +
-                        '<strong class=”me-auto”>What\'s New in v0.17.0</strong>' +
-                        '<button type=”button” class=”btn-close” aria-label=”Close”></button>' +
+                    '<div class="toast-header">' +
+                        '<i class="bi bi-stars text-primary me-2" aria-hidden="true"></i>' +
+                        '<strong class="me-auto">What\'s New in v0.17.0</strong>' +
+                        '<button type="button" class="btn-close" aria-label="Close"></button>' +
                     '</div>' +
-                    '<div class=”toast-body”>' +
-                        '<ul class=”mb-0 ps-3 small”>' +
-                            '<li>Explore new roads with tile-coverage route generation</li>' +
-                            '<li>Real road-following routes with GPX export</li>' +
-                            '<li>Location search and multi-directional exploration</li>' +
-                            '<li>Garmin Connect and TrainerRoad integration improvements</li>' +
+                    '<div class="toast-body">' +
+                        '<ul class="mb-0 ps-3 small">' +
+                            '<li>Fair Weather visual refresh — new cobalt &amp; coral color system</li>' +
+                            '<li>Mobile layout reordered: your commute decision leads, map and route status follow</li>' +
+                            '<li>Reports and Explore added to the mobile bottom navigation</li>' +
                         '</ul>' +
                     '</div>';
                 document.body.appendChild(toastEl);

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -880,7 +880,6 @@ async function loadConditionsCard() {
                 const expanded = toggle.getAttribute('aria-expanded') === 'true';
                 toggle.setAttribute('aria-expanded', String(!expanded));
                 fullRows.classList.toggle('conditions-rows-open', !expanded);
-                toggle.querySelector('.conditions-chevron').style.transform = expanded ? '' : 'rotate(180deg)';
             });
             toggle.addEventListener('keydown', e => {
                 if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggle.click(); }
@@ -955,7 +954,6 @@ async function loadRouteStatus() {
                 const expanded = toggle.getAttribute('aria-expanded') === 'true';
                 toggle.setAttribute('aria-expanded', String(!expanded));
                 fullRows.classList.toggle('route-status-rows-open', !expanded);
-                toggle.querySelector('.route-status-chevron').style.transform = expanded ? '' : 'rotate(180deg)';
                 toggle.querySelector('span').textContent = expanded
                     ? `Show all route conditions (${count})`
                     : 'Hide route conditions';

--- a/static/js/dashboard.js
+++ b/static/js/dashboard.js
@@ -625,8 +625,12 @@ function getHeroHeading(contextDir) {
 
 /**
  * Render hero decision card (#286) from a recommendation object.
+ * @param {object} rec - the recommendation to render (primary when isHero, secondary otherwise)
+ * @param {boolean} isHero - true for the primary hero card
+ * @param {object} [secondaryRec] - the other direction's recommendation, used only when isHero
+ *        to build the "Compare routes" teaser text (#370a)
  */
-function renderHeroCard(rec, isHero) {
+function renderHeroCard(rec, isHero, secondaryRec) {
     if (!rec || rec.status !== 'success') return '';
 
     const esc = window.escapeHtml;
@@ -647,6 +651,15 @@ function renderHeroCard(rec, isHero) {
     const timeLabel = rec.time_impact && rec.time_impact.label ? esc(rec.time_impact.label) : null;
     const estMins = rec.time_impact && rec.time_impact.estimated_minutes;
     const departureTime = rec.departure_time ? esc(rec.departure_time) : null;
+
+    // Teaser text for the "Compare routes" collapse trigger (#370a): once the return
+    // direction's score is known, name it explicitly instead of a bare "Compare routes".
+    const secondaryScore = (isHero && secondaryRec && secondaryRec.status === 'success' && typeof secondaryRec.score !== 'undefined')
+        ? (typeof secondaryRec.score === 'number' && secondaryRec.score <= 1 ? Math.round(secondaryRec.score * 100) : Math.round(secondaryRec.score || 0))
+        : null;
+    const compareLabel = secondaryScore !== null
+        ? `Compare both directions — return score: ${secondaryScore}`
+        : 'Compare both directions';
 
     const borderColor = score >= 70 ? '#28a745' : score >= 50 ? '#ffc107' : '#dc3545';
     const windImpact = rec.wind_impact;
@@ -703,13 +716,13 @@ function renderHeroCard(rec, isHero) {
                 ${transitBanner}
                 <div class="mt-3 d-flex gap-2 flex-wrap">
                     ${route.id ? `
-                    <a href="route-detail.html?id=${encodeURIComponent(route.id)}" class="btn btn-primary btn-sm">
+                    <a href="route-detail.html?id=${encodeURIComponent(route.id)}" class="btn btn-cta btn-sm">
                         <i class="bi bi-map me-1"></i>View route
                     </a>` : ''}
-                    <button type="button" class="btn btn-outline-secondary btn-sm"
+                    <button type="button" class="btn btn-outline-secondary btn-sm commute-compare-toggle"
                             data-bs-toggle="collapse" data-bs-target="#commute-detail"
                             aria-expanded="false" aria-controls="commute-detail">
-                        <i class="bi bi-list-ul"></i> Compare routes
+                        <i class="bi bi-list-ul"></i> ${compareLabel}
                         <i class="bi bi-chevron-down ms-1 commute-chevron"></i>
                     </button>
                 </div>
@@ -770,7 +783,7 @@ async function loadRecommendation() {
                 ${heading.sub ? `<span class="ms-1">· ${heading.sub}</span>` : ''}
             </div>`;
 
-        html += renderHeroCard(primary, true);
+        html += renderHeroCard(primary, true, secondary);
 
         if (secondary && secondary.status === 'success') {
             html += `
@@ -917,12 +930,38 @@ async function loadRouteStatus() {
         }
 
         const rows = data.routes.map(routeStatusRow).join('');
+        const count = data.routes.length;
+        // Mobile: collapsed behind a labeled summary toggle with a count, expanded on tap (#370b).
+        // Teaser-before-collapse per DESIGN_PRINCIPLES.md §2 — never a bare chevron.
         const html = `
-            ${rows}
-            <div class="mt-2">
-                <a href="/routes.html" class="small text-muted">All Routes →</a>
+            <button type="button" class="route-status-summary-toggle btn btn-link text-decoration-none d-flex d-md-none w-100 align-items-center gap-2 px-0"
+                    aria-expanded="false" aria-controls="route-status-rows">
+                <i class="bi bi-map" aria-hidden="true"></i>
+                <span class="small fw-semibold text-body">Show all route conditions (${count})</span>
+                <i class="bi bi-chevron-down ms-auto route-status-chevron" aria-hidden="true"></i>
+            </button>
+            <div id="route-status-rows" class="route-status-rows">
+                ${rows}
+                <div class="mt-2">
+                    <a href="/routes.html" class="small text-muted">All Routes →</a>
+                </div>
             </div>`;
         container.innerHTML = html;
+
+        const toggle = container.querySelector('.route-status-summary-toggle');
+        const fullRows = container.querySelector('.route-status-rows');
+        if (toggle && fullRows) {
+            toggle.addEventListener('click', () => {
+                const expanded = toggle.getAttribute('aria-expanded') === 'true';
+                toggle.setAttribute('aria-expanded', String(!expanded));
+                fullRows.classList.toggle('route-status-rows-open', !expanded);
+                toggle.querySelector('.route-status-chevron').style.transform = expanded ? '' : 'rotate(180deg)';
+                toggle.querySelector('span').textContent = expanded
+                    ? `Show all route conditions (${count})`
+                    : 'Hide route conditions';
+            });
+        }
+
         const mobile = document.getElementById('route-status-panel-mobile');
         if (mobile) mobile.innerHTML = html;
     } catch (error) {

--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -83,6 +83,7 @@ function initMap() {
     waypointMarkers = L.layerGroup().addTo(map);
 
     map.on('click', (e) => {
+        clearHighlight();
         setStart(e.latlng.lat, e.latlng.lng);
     });
 }
@@ -321,13 +322,63 @@ function renderNewTiles(newTilesByZoom) {
 
 // ── Route generation ────────────────────────────────────────────
 
-const ROUTE_COLORS = ['#0d6efd', '#fd7e14', '#6f42c1', '#20c997'];
+/**
+ * Tonal colour pairs per direction (#409).
+ * base  = Phase-2 road polyline + badge swatch.
+ * light = Phase-1 dashed preview (lower saturation).
+ */
+const ROUTE_PALETTE = {
+    NE: { base: '#0d6efd', light: '#7ab5fe' },
+    SE: { base: '#e8690e', light: '#f5ac71' },
+    SW: { base: '#6f42c1', light: '#b094dd' },
+    NW: { base: '#0f9e7a', light: '#6fd4bb' },
+};
+const _PALETTE_ORDER = ['NE', 'SE', 'SW', 'NW'];
+function _paletteFor(dirOrIndex) {
+    if (typeof dirOrIndex === 'string' && ROUTE_PALETTE[dirOrIndex]) return ROUTE_PALETTE[dirOrIndex];
+    return ROUTE_PALETTE[_PALETTE_ORDER[dirOrIndex % 4]];
+}
+
 const DIRECTION_LABELS = { NE: 'Northeast', SE: 'Southeast', SW: 'Southwest', NW: 'Northwest' };
 
 // Per-direction Phase-1 polyline references, keyed by direction ('NE', etc.)
 const _phase1Polylines = {};
 // Per-direction Phase-2 polyline references
 const _phase2Polylines = {};
+
+// ── Highlight / deselect state (#407 + #408) ─────────────────────
+
+let _selectedDirection = null;
+const _BASE_STYLE_P1 = { weight: 3, opacity: 0.8 };
+const _BASE_STYLE_P2 = { weight: 4, opacity: 1.0 };
+const _DIM_OPACITY    = 0.25;
+
+function highlightRoute(dir) {
+    if (_selectedDirection === dir) { clearHighlight(); return; }
+    _selectedDirection = dir;
+    Object.keys(_phase1Polylines).forEach(k => {
+        _phase1Polylines[k].setStyle(k === dir ? { weight: 5, opacity: 1.0 } : { opacity: _DIM_OPACITY });
+    });
+    Object.keys(_phase2Polylines).forEach(k => {
+        _phase2Polylines[k].setStyle(k === dir ? { weight: 6, opacity: 1.0 } : { opacity: _DIM_OPACITY });
+    });
+    document.querySelectorAll('.route-badge').forEach(el => {
+        el.classList.toggle('route-badge--selected', el.dataset.direction === dir);
+        el.classList.toggle('route-badge--dimmed',   el.dataset.direction !== dir);
+    });
+    const activeBadge = document.querySelector(`.route-badge[data-direction="${dir}"]`);
+    if (activeBadge) activeBadge.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    const active = _phase2Polylines[dir] || _phase1Polylines[dir];
+    if (active) { try { map.fitBounds(active.getBounds(), { padding: [32, 32] }); } catch (_) {} }
+}
+
+function clearHighlight() {
+    _selectedDirection = null;
+    Object.keys(_phase1Polylines).forEach(k => _phase1Polylines[k].setStyle(_BASE_STYLE_P1));
+    Object.keys(_phase2Polylines).forEach(k => _phase2Polylines[k].setStyle(_BASE_STYLE_P2));
+    document.querySelectorAll('.route-badge').forEach(el =>
+        el.classList.remove('route-badge--selected', 'route-badge--dimmed'));
+}
 
 /**
  * Draw small arrowhead triangles at the midpoint of each segment in `coords`.
@@ -393,6 +444,7 @@ async function generateRoute() {
     spinnerEl.classList.remove('d-none');
     statusEl.textContent = 'Computing exploration routes…';
 
+    clearHighlight();
     waypointMarkers.clearLayers();
     newTilesLayer.clearLayers();
     routeLayer.clearLayers();
@@ -475,7 +527,7 @@ async function generateRoute() {
 }
 
 function renderRoute(route, index) {
-    const color = ROUTE_COLORS[index % ROUTE_COLORS.length];
+    const palette = _paletteFor(route.direction);
     const startPos = startMarker.getLatLng();
     const coords = [[startPos.lat, startPos.lng]];
 
@@ -483,8 +535,8 @@ function renderRoute(route, index) {
         coords.push([wp.lat, wp.lon]);
         const marker = L.circleMarker([wp.lat, wp.lon], {
             radius: 6,
-            color,
-            fillColor: color,
+            color: palette.light,
+            fillColor: palette.light,
             fillOpacity: 0.8,
         }).bindPopup(`${DIRECTION_LABELS[route.direction]} · Waypoint ${i + 1}`);
         waypointMarkers.addLayer(marker);
@@ -494,13 +546,14 @@ function renderRoute(route, index) {
 
     const distanceLabel = window.formatDistance ? window.formatDistance(route.stats.distanceKm, 1) : `${route.stats.distanceKm.toFixed(1)} km`;
     const line = L.polyline(coords, {
-        color,
+        color: palette.light,
         weight: 3,
         dashArray: '8, 8',
         opacity: 0.8,
     }).bindPopup(`${DIRECTION_LABELS[route.direction]} — ${distanceLabel}, ${newTilesLabel(route.stats)}`);
+    line.on('click', (e) => { L.DomEvent.stopPropagation(e); highlightRoute(route.direction); });
     routeLayer.addLayer(line);
-    addArrows(coords, color);
+    addArrows(coords, palette.light);
     _phase1Polylines[route.direction] = line;
 }
 
@@ -512,7 +565,8 @@ function newTilesLabel(stats) {
 }
 
 function addRouteListItem(route, index, targetDistanceKm) {
-    const color = ROUTE_COLORS[index % ROUTE_COLORS.length];
+    const palette = _paletteFor(route.direction);
+    const color = palette.base;
     const distanceLabel = window.formatDistance ? window.formatDistance(route.stats.distanceKm, 1) : `${route.stats.distanceKm.toFixed(1)} km`;
     const dir = route.direction;
 
@@ -533,6 +587,10 @@ function addRouteListItem(route, index, targetDistanceKm) {
     `;
     document.getElementById('route-list').appendChild(badge);
 
+    badge.addEventListener('click', (e) => {
+        if (e.target.closest('.plot-road-btn')) return;
+        highlightRoute(dir);
+    });
     badge.querySelector('.plot-road-btn').addEventListener('click', () => {
         plotRoadRoute(dir, route, targetDistanceKm, color, badge);
     });
@@ -679,6 +737,7 @@ async function plotRoadRoute(direction, route, targetDistanceKm, color, badgeEl)
         const line = L.polyline(latlngs, { color, weight: 4, opacity });
         const distLabel = window.formatDistance ? window.formatDistance(result.distance_km, 1) : `${result.distance_km} km`;
         line.bindPopup(`${DIRECTION_LABELS[direction]} ${label} — ${distLabel}, ${result.duration_min} min`);
+        line.on('click', (e) => { L.DomEvent.stopPropagation(e); highlightRoute(direction); });
         routeLayer.addLayer(line);
         addArrows(latlngs, color);
         return { line, result, distLabel };

--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -41,9 +41,19 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
     initDistanceSlider();
+    initTooltips();
     updateWorkflowState();
     loadCoverage();
 });
+
+// ── Bootstrap tooltips (#360 help icon) ────────────────────────
+
+function initTooltips() {
+    if (typeof bootstrap === 'undefined' || !bootstrap.Tooltip) return;
+    document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach((el) => {
+        new bootstrap.Tooltip(el);
+    });
+}
 
 // ── Distance unit display ──────────────────────────────────────
 
@@ -107,7 +117,8 @@ function updateWorkflowState() {
 
     const btn = document.getElementById('generate-route-btn');
     btn.disabled = !ready;
-    btn.classList.toggle('btn-primary', ready);
+    // Coral (.btn-cta) is reserved for this one enabled CTA on the page (#361).
+    btn.classList.toggle('btn-cta', ready);
     btn.classList.toggle('btn-outline-primary', !ready);
 
     const statusEl = document.getElementById('worker-status');
@@ -204,7 +215,7 @@ async function loadCoverage() {
         renderStats(coverageData, coverageDataSecondary);
         renderTiles(coverageData, coverageDataSecondary);
         fitToCoverage(coverageData);
-        statusEl.textContent = `Updated ${new Date(coverageData.computed_at).toLocaleTimeString()}`;
+        statusEl.textContent = `Updated ${new Date(coverageData.computed_at + 'Z').toLocaleTimeString()}`;
     } catch (e) {
         statusEl.textContent = `Error: ${e.message}`;
     } finally {
@@ -764,6 +775,9 @@ function downloadGpx(coordinates, direction) {
 // ── Cache management ────────────────────────────────────────────
 
 async function clearCache() {
+    if (!confirm('Clear cached coverage tile data? Coverage will be recomputed from your existing activity cache on next load.')) {
+        return;
+    }
     try {
         await api.invalidateCoverageCache();
         if (typeof showToast === 'function') showToast('Coverage cache cleared', 'info');

--- a/static/js/help-modal.js
+++ b/static/js/help-modal.js
@@ -52,12 +52,17 @@
     // Build modal HTML
     // ------------------------------------------------------------------
 
-    function buildModalHTML() {
+    /**
+     * Build the modal markup.
+     * @param {boolean} textOnly - when true (no tutorial assets exist at all),
+     *   render titles + text descriptions with no image containers at all.
+     */
+    function buildModalHTML(textOnly) {
         const cards = TUTORIALS.map((t) => `
             <div class="col-md-6">
                 <div class="card h-100 tutorial-card" data-tutorial-id="${t.id}">
-                    <div class="tutorial-img-wrapper position-relative overflow-hidden"
-                         style="height:176px; background:#f8f9fa;">
+                    ${textOnly ? '' : `<div class="tutorial-img-wrapper position-relative overflow-hidden"
+                         style="height:176px; background:var(--surface-2, #f8f9fa);">
                         <img
                             class="tutorial-img w-100 h-100"
                             style="object-fit:cover; cursor:pointer;"
@@ -76,7 +81,7 @@
                         </div>
                         <span class="tutorial-hover-badge position-absolute bottom-0 end-0 m-2 badge bg-secondary"
                               aria-hidden="true">Hover to play</span>
-                    </div>
+                    </div>`}
                     <div class="card-body pb-2">
                         <h6 class="card-title mb-1">${t.title}</h6>
                         <p class="card-text small text-muted mb-0">${t.description}</p>
@@ -84,6 +89,10 @@
                 </div>
             </div>
         `).join('');
+
+        const intro = textOnly
+            ? 'Quick guides to the main features.'
+            : 'Hover over a tutorial to see it in action.';
 
         return `
 <div class="modal fade" id="helpModal" tabindex="-1"
@@ -98,7 +107,7 @@
                         aria-label="Close help modal"></button>
             </div>
             <div class="modal-body">
-                <p class="text-muted mb-3">Hover over a tutorial to see it in action.</p>
+                <p class="text-muted mb-3">${intro}</p>
                 <div class="row g-3">
                     ${cards}
                 </div>
@@ -194,23 +203,67 @@
     }
 
     // ------------------------------------------------------------------
+    // Asset probing (Issue #374): the tutorial GIF/PNG assets may not be
+    // deployed. Probe the preview images up front; if ALL are missing,
+    // rebuild the modal in text-only mode (titles + descriptions, no image
+    // containers). If only some are missing, the per-image onerror fallback
+    // above handles each one individually.
+    // ------------------------------------------------------------------
+
+    function probeTutorialAssets() {
+        return Promise.all(
+            TUTORIALS.map(
+                (t) =>
+                    new Promise((resolve) => {
+                        const img = new Image();
+                        img.onload = () => resolve(true);
+                        img.onerror = () => resolve(false);
+                        img.src = t.preview;
+                    })
+            )
+        );
+    }
+
+    // ------------------------------------------------------------------
     // Inject modal + help button, wire up events
     // ------------------------------------------------------------------
 
-    function init() {
-        // Inject modal into body
+    function injectModal(textOnly) {
+        const existing = document.getElementById('helpModal');
+        if (existing) existing.remove();
         const wrapper = document.createElement('div');
-        wrapper.innerHTML = buildModalHTML();
+        wrapper.innerHTML = buildModalHTML(textOnly);
         document.body.appendChild(wrapper.firstElementChild);
 
-        // Start lazy loading once modal opens (saves bandwidth until user needs it)
         const modalEl = document.getElementById('helpModal');
-        if (modalEl) {
+        if (modalEl && !textOnly) {
+            // Start lazy loading once modal opens (saves bandwidth until user needs it)
             modalEl.addEventListener('shown.bs.modal', () => {
                 observeImages();
                 attachHoverPlay();
             }, { once: true });
         }
+        return modalEl;
+    }
+
+    function init() {
+        // Inject modal into body (image mode by default)
+        injectModal(false);
+
+        // Probe tutorial assets; if none exist, switch to text-only mode.
+        // Rebuilding is safe: Bootstrap binds the trigger button lazily via
+        // data-bs-target, so a replaced #helpModal keeps working. If the
+        // modal is open right now, leave it — the per-image onerror
+        // fallback is already showing text descriptions.
+        probeTutorialAssets().then((results) => {
+            const anyAvailable = results.some(Boolean);
+            if (!anyAvailable) {
+                const openModal = document.querySelector('#helpModal.show');
+                if (!openModal) {
+                    injectModal(true);
+                }
+            }
+        });
 
         // Inject Help button into navbar if present
         const navList = document.querySelector('.navbar-nav');

--- a/static/js/mobile.js
+++ b/static/js/mobile.js
@@ -28,16 +28,24 @@ function initializeBottomNav() {
     // Handle nav item clicks and keyboard navigation
     const navItems = bottomNav.querySelectorAll('.bottom-nav-item');
     navItems.forEach((item, index) => {
+        // The "More" drawer toggle (Issue #362) is handled entirely by
+        // Bootstrap collapse via data-bs-toggle; don't steal its active
+        // state or aria-current — it highlights only when a drawer page
+        // (Explore/Settings) is the current page.
+        const isDrawerToggle = item.hasAttribute('data-bs-toggle');
+
         // Click handler
         item.addEventListener('click', function(e) {
+            if (isDrawerToggle) return;
             e.preventDefault();
             handleNavItemActivation(this, navItems);
         });
-        
+
         // Keyboard navigation handler
         item.addEventListener('keydown', function(e) {
             // Enter or Space to activate
             if (e.key === 'Enter' || e.key === ' ') {
+                if (isDrawerToggle) return; // native button click triggers Bootstrap collapse
                 e.preventDefault();
                 handleNavItemActivation(this, navItems);
             }
@@ -108,6 +116,8 @@ const PAGE_ROUTES = {
     home:     '/',
     routes:   '/routes.html',
     weather:  '/weather.html',
+    reports:  '/reports.html',
+    explore:  '/explore.html',
     settings: '/settings.html'
 };
 
@@ -234,7 +244,7 @@ function showSwipeFeedback(direction) {
         ${direction === 'left' ? 'right: 20px' : 'left: 20px'};
         transform: translateY(-50%);
         font-size: 48px;
-        color: var(--epic-primary, #667eea);
+        color: var(--accent, #0B6FA6);
         opacity: 0;
         animation: swipeFeedbackAnim 0.3s ease-out;
         pointer-events: none;

--- a/static/js/reports.js
+++ b/static/js/reports.js
@@ -68,7 +68,7 @@ function renderHeadlineStats(s) {
     // preference (#375b) — the value must convert too, or a metric user sees a
     // "Kilometers" label on a number that's still in miles.
     const distUnit = typeof window.getDistanceUnit === 'function' ? window.getDistanceUnit() : 'mi';
-    const toDisplayDistance = (mi) => (mi == null ? null : (distUnit === 'km' ? mi * 1.60934 : mi));
+    const toDisplayDistance = (mi) => (mi == null ? null : (distUnit === 'km' ? window.milesToKm(mi) : mi));
     setText('stat-distance', fmt(toDisplayDistance(s.total_distance_mi)));
     setText('stat-distance-label', distUnit === 'km' ? 'Kilometers' : 'Miles');
     setText('stat-time', fmt(s.total_time_h));

--- a/static/js/reports.js
+++ b/static/js/reports.js
@@ -4,6 +4,10 @@
 
 const api = new APIClient('/api');
 
+// Sport types treated as "cycling" for Personal Records filtering (#376) — matches the
+// activity-type-filter dropdown options minus Run.
+const CYCLING_TYPES = ['Ride', 'GravelRide', 'EBikeRide', 'VirtualRide'];
+
 let currentPeriod = 'this_year';
 let currentGearId = null;   // null = all gear
 let statsData = null;       // last /api/stats response
@@ -50,7 +54,7 @@ async function loadStats() {
         if (resp.status !== 'success') throw new Error(resp.message || 'Unknown error');
         statsData = resp.data;
         renderHeadlineStats(statsData.summary);
-        renderRecords(statsData.records);
+        loadRecords();
         renderTypeBreakdown(statsData.by_type);
         renderMonthlyChart(statsData.by_month);
         renderDistributionChart(statsData.speed_distribution, 'speed-chart', 'speed-chart-label', 'mph');
@@ -64,18 +68,89 @@ async function loadStats() {
 
 function renderHeadlineStats(s) {
     setText('stat-rides', fmt(s.total_rides));
-    setText('stat-distance', fmt(s.total_distance_mi));
+    // Backend returns distance in miles (`_mi` fields). Label is dynamic per unit
+    // preference (#375b) — the value must convert too, or a metric user sees a
+    // "Kilometers" label on a number that's still in miles.
+    const distUnit = typeof window.getDistanceUnit === 'function' ? window.getDistanceUnit() : 'mi';
+    const toDisplayDistance = (mi) => (mi == null ? null : (distUnit === 'km' ? mi * 1.60934 : mi));
+    setText('stat-distance', fmt(toDisplayDistance(s.total_distance_mi)));
+    setText('stat-distance-label', distUnit === 'km' ? 'Kilometers' : 'Miles');
     setText('stat-time', fmt(s.total_time_h));
     setText('stat-elevation', fmtInt(s.total_elevation_ft));
-    setText('stat-avg-distance', s.total_rides ? `avg ${fmt(s.avg_distance_mi)} mi / ride` : '');
+    setText('stat-avg-distance', s.total_rides ? `avg ${fmt(toDisplayDistance(s.avg_distance_mi))} ${distUnit} / ride` : '');
     setText('stat-avg-speed', s.avg_speed_mph ? `avg ${fmt(s.avg_speed_mph)} mph` : '');
     setText('stat-avg-elevation', s.avg_elevation_ft ? `avg ${fmtInt(s.avg_elevation_ft)} ft / ride` : '');
-    setText('stat-hr', s.avg_heartrate ? `${fmt(s.avg_heartrate)} bpm` : '—');
-    setText('stat-kj', s.total_kilojoules ? fmtInt(s.total_kilojoules) : '—');
-    setText('stat-kudos', fmt(s.total_kudos));
+
+    // Secondary stats (Avg HR / Kilojoules / Kudos): hide whichever are null/zero, and
+    // reflow the remaining columns evenly rather than leaving a blank gap (#369a).
+    const extras = [
+        { col: 'stat-hr-col', has: !!s.avg_heartrate, render: () => setText('stat-hr', `${fmt(s.avg_heartrate)} bpm`) },
+        { col: 'stat-kj-col', has: !!s.total_kilojoules, render: () => setText('stat-kj', fmtInt(s.total_kilojoules)) },
+        { col: 'stat-kudos-col', has: !!s.total_kudos, render: () => setText('stat-kudos', fmt(s.total_kudos)) },
+    ];
+    const visible = extras.filter(e => e.has);
+    const colClass = visible.length === 1 ? 'col-12' : visible.length === 2 ? 'col-6' : 'col-4';
+    extras.forEach(e => {
+        const col = document.getElementById(e.col);
+        if (!col) return;
+        if (e.has) {
+            e.render();
+            col.className = colClass;
+            col.style.display = '';
+        } else {
+            col.style.display = 'none';
+        }
+    });
+    const row = document.getElementById('extra-stats-row');
+    if (row) row.style.display = visible.length ? '' : 'none';
 }
 
-function renderRecords(r) {
+// Personal Records are computed server-side from ALL cached activity types (including
+// WeightTraining etc.), so "Fastest Speed" can surface a non-cycling session (#376). Re-derive
+// the record-worthy metrics from the already-available /api/activities feed, filtered to cycling
+// sport types, so the qualifier we display is actually true.
+async function loadRecords() {
+    const qualifierEl = document.getElementById('records-qualifier');
+    try {
+        const resp = await api.get(`/activities?period=${currentPeriod}&sort=date_desc&limit=1000`);
+        if (resp.status !== 'success') {
+            renderRecords((statsData && statsData.records) || {}, false);
+            return;
+        }
+        const activities = resp.data.activities || [];
+        const cycling = activities.filter(a => CYCLING_TYPES.includes(a.sport_type));
+        if (!cycling.length) {
+            renderRecords((statsData && statsData.records) || {}, false);
+            return;
+        }
+
+        const longest = cycling.reduce((a, b) => (b.distance_mi > a.distance_mi ? b : a));
+        const mostElev = cycling.reduce((a, b) => (b.elevation_ft > a.elevation_ft ? b : a));
+        const fastest = cycling.reduce((a, b) => (b.speed_mph > a.speed_mph ? b : a));
+        const cyclingIds = new Set(cycling.map(a => a.id));
+
+        const records = {
+            longest_ride: { distance_mi: longest.distance_mi, name: longest.name, date: longest.date },
+            most_elevation: { elevation_ft: mostElev.elevation_ft, name: mostElev.name, date: mostElev.date },
+            fastest_speed: { speed_mph: fastest.speed_mph, name: fastest.name, date: fastest.date },
+        };
+
+        // Kilojoules isn't exposed per-activity by /api/activities, so we can't recompute this
+        // one client-side — only show it if the server's record activity happens to be a cycling
+        // activity (verifiable via id); otherwise omit rather than mislabel it.
+        const kj = statsData && statsData.records && statsData.records.most_kilojoules;
+        if (kj && cyclingIds.has(kj.id)) records.most_kilojoules = kj;
+
+        renderRecords(records, true);
+    } catch (e) {
+        renderRecords((statsData && statsData.records) || {}, false);
+    }
+}
+
+function renderRecords(r, cyclingOnly) {
+    const qualifierEl = document.getElementById('records-qualifier');
+    if (qualifierEl) qualifierEl.textContent = cyclingOnly ? '(cycling only)' : '';
+
     if (!r || !Object.keys(r).length) return;
 
     if (r.longest_ride) {
@@ -189,7 +264,7 @@ function gearDisplayName(g) {
 function renderGearCards(data) {
     const container = document.getElementById('gear-cards');
     const statusEl = document.getElementById('gear-cache-status');
-    statusEl.textContent = data.gear_cache_available ? '' : 'No gear names — click Sync Gear';
+    statusEl.textContent = data.gear_cache_available ? '' : 'No gear names — sync gear from Settings → Strava';
 
     if (!data.gear.length && !data.unassigned.total_rides) {
         container.innerHTML = '<div class="text-muted small">No gear data. Re-fetch activities from Strava after syncing gear.</div>';
@@ -260,89 +335,14 @@ function selectGear(gearId) {
 }
 
 function bindGearControls() {
+    // Sync Gear / Repair Gear Names now live in Settings → Strava (#369b) — only the
+    // Clear Filter control remains here, and only shown while a gear filter is active.
     document.getElementById('clear-gear-filter-btn').addEventListener('click', () => {
         currentGearId = null;
         document.querySelectorAll('.gear-card').forEach(c => c.classList.remove('active'));
         document.getElementById('clear-gear-filter-btn').style.display = 'none';
         loadActivities();
     });
-
-    document.getElementById('refresh-gear-btn').addEventListener('click', async () => {
-        const btn = document.getElementById('refresh-gear-btn');
-        btn.disabled = true;
-        btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Syncing…';
-        try {
-            const resp = await api.post('/stats/refresh-gear', {});
-            if (resp.status === 'success') {
-                showToast(resp.message, 'success');
-                await loadGear();
-            } else {
-                showToast(resp.message || 'Sync failed', 'error');
-            }
-        } catch (e) {
-            showToast(`Gear sync failed: ${e.message}`, 'error');
-        } finally {
-            btn.disabled = false;
-            btn.innerHTML = '<i class="bi bi-arrow-clockwise" aria-hidden="true"></i> Sync Gear';
-        }
-    });
-
-    document.getElementById('backfill-gear-btn').addEventListener('click', startBackfill);
-}
-
-let _backfillPollInterval = null;
-
-async function startBackfill() {
-    const btn = document.getElementById('backfill-gear-btn');
-    const statusEl = document.getElementById('gear-cache-status');
-    btn.disabled = true;
-    btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Backfilling…';
-
-    try {
-        const resp = await api.post('/stats/backfill-gear-ids', {});
-        if (resp.status === 'started' || resp.status === 'already_running') {
-            _backfillPollInterval = setInterval(pollBackfill, 1500);
-        } else {
-            showToast(resp.message || 'Failed to start backfill', 'error');
-            resetBackfillBtn();
-        }
-    } catch (e) {
-        showToast(`Backfill failed: ${e.message}`, 'error');
-        resetBackfillBtn();
-    }
-}
-
-async function pollBackfill() {
-    const btn = document.getElementById('backfill-gear-btn');
-    const statusEl = document.getElementById('gear-cache-status');
-    try {
-        const resp = await api.get('/stats/backfill-gear-ids/status');
-        if (resp.status === 'running') {
-            statusEl.textContent = resp.label || 'Backfilling…';
-        } else if (resp.status === 'done') {
-            clearInterval(_backfillPollInterval);
-            _backfillPollInterval = null;
-            showToast(resp.label, 'success');
-            statusEl.textContent = '';
-            resetBackfillBtn();
-            await loadGear();
-            loadActivities();
-        } else if (resp.status === 'error') {
-            clearInterval(_backfillPollInterval);
-            _backfillPollInterval = null;
-            showToast(resp.label || 'Backfill error', 'error');
-            statusEl.textContent = '';
-            resetBackfillBtn();
-        }
-    } catch (e) {
-        // ignore transient poll errors
-    }
-}
-
-function resetBackfillBtn() {
-    const btn = document.getElementById('backfill-gear-btn');
-    btn.disabled = false;
-    btn.innerHTML = '<i class="bi bi-patch-check" aria-hidden="true"></i> Backfill Gear IDs';
 }
 
 // -----------------------------------------------------------------------

--- a/static/js/reports.js
+++ b/static/js/reports.js
@@ -4,10 +4,6 @@
 
 const api = new APIClient('/api');
 
-// Sport types treated as "cycling" for Personal Records filtering (#376) — matches the
-// activity-type-filter dropdown options minus Run.
-const CYCLING_TYPES = ['Ride', 'GravelRide', 'EBikeRide', 'VirtualRide'];
-
 let currentPeriod = 'this_year';
 let currentGearId = null;   // null = all gear
 let statsData = null;       // last /api/stats response
@@ -54,7 +50,7 @@ async function loadStats() {
         if (resp.status !== 'success') throw new Error(resp.message || 'Unknown error');
         statsData = resp.data;
         renderHeadlineStats(statsData.summary);
-        loadRecords();
+        renderRecords(statsData.records);
         renderTypeBreakdown(statsData.by_type);
         renderMonthlyChart(statsData.by_month);
         renderDistributionChart(statsData.speed_distribution, 'speed-chart', 'speed-chart-label', 'mph');
@@ -105,51 +101,12 @@ function renderHeadlineStats(s) {
     if (row) row.style.display = visible.length ? '' : 'none';
 }
 
-// Personal Records are computed server-side from ALL cached activity types (including
-// WeightTraining etc.), so "Fastest Speed" can surface a non-cycling session (#376). Re-derive
-// the record-worthy metrics from the already-available /api/activities feed, filtered to cycling
-// sport types, so the qualifier we display is actually true.
-async function loadRecords() {
+// Personal Records are computed server-side, filtered to cycling sport types only (#376, #434) —
+// so "Fastest Speed" can't surface a non-cycling session, and the record search isn't capped at
+// the 1000-activity page-size limit /api/activities used to impose.
+function renderRecords(r) {
     const qualifierEl = document.getElementById('records-qualifier');
-    try {
-        const resp = await api.get(`/activities?period=${currentPeriod}&sort=date_desc&limit=1000`);
-        if (resp.status !== 'success') {
-            renderRecords((statsData && statsData.records) || {}, false);
-            return;
-        }
-        const activities = resp.data.activities || [];
-        const cycling = activities.filter(a => CYCLING_TYPES.includes(a.sport_type));
-        if (!cycling.length) {
-            renderRecords((statsData && statsData.records) || {}, false);
-            return;
-        }
-
-        const longest = cycling.reduce((a, b) => (b.distance_mi > a.distance_mi ? b : a));
-        const mostElev = cycling.reduce((a, b) => (b.elevation_ft > a.elevation_ft ? b : a));
-        const fastest = cycling.reduce((a, b) => (b.speed_mph > a.speed_mph ? b : a));
-        const cyclingIds = new Set(cycling.map(a => a.id));
-
-        const records = {
-            longest_ride: { distance_mi: longest.distance_mi, name: longest.name, date: longest.date },
-            most_elevation: { elevation_ft: mostElev.elevation_ft, name: mostElev.name, date: mostElev.date },
-            fastest_speed: { speed_mph: fastest.speed_mph, name: fastest.name, date: fastest.date },
-        };
-
-        // Kilojoules isn't exposed per-activity by /api/activities, so we can't recompute this
-        // one client-side — only show it if the server's record activity happens to be a cycling
-        // activity (verifiable via id); otherwise omit rather than mislabel it.
-        const kj = statsData && statsData.records && statsData.records.most_kilojoules;
-        if (kj && cyclingIds.has(kj.id)) records.most_kilojoules = kj;
-
-        renderRecords(records, true);
-    } catch (e) {
-        renderRecords((statsData && statsData.records) || {}, false);
-    }
-}
-
-function renderRecords(r, cyclingOnly) {
-    const qualifierEl = document.getElementById('records-qualifier');
-    if (qualifierEl) qualifierEl.textContent = cyclingOnly ? '(cycling only)' : '';
+    if (qualifierEl) qualifierEl.textContent = (r && Object.keys(r).length) ? '(cycling only)' : '';
 
     if (!r || !Object.keys(r).length) return;
 

--- a/static/js/routes.js
+++ b/static/js/routes.js
@@ -65,7 +65,9 @@
         if (!legendEl) return;
 
         const mode = getColorBy();
-        if (mode === 'default' || state.displayedRoutes.size === 0) {
+        // Show the legend as soon as a non-default color mode is chosen, even before
+        // any routes are plotted on the map (Issue #376) — it previews what the colors mean.
+        if (mode === 'default') {
             legendEl.style.display = 'none';
             return;
         }
@@ -688,10 +690,13 @@
         card.innerHTML = `
             <div class="card-body py-2 px-3">
                 <div class="d-flex align-items-center gap-2">
-                    <input class="form-check-input compare-checkbox flex-shrink-0 mt-0" type="checkbox"
-                           id="compare-${route.id}" data-route-id="${route.id}"
-                           ${isSelected ? 'checked' : ''}
-                           onclick="event.stopPropagation()" title="Compare">
+                    <div class="form-check compare-toggle flex-shrink-0" onclick="event.stopPropagation()">
+                        <input class="form-check-input compare-checkbox mt-0" type="checkbox"
+                               id="compare-${route.id}" data-route-id="${route.id}"
+                               ${isSelected ? 'checked' : ''}
+                               title="Compare">
+                        <label class="form-check-label small text-muted" for="compare-${route.id}">Compare</label>
+                    </div>
                     <span class="fw-semibold text-truncate flex-grow-1" style="font-size:.875rem;cursor:pointer" title="${route.name}" data-route-link>
                         ${favIcon}${plusBadge}${route.name}
                     </span>
@@ -714,7 +719,7 @@
 
         card.style.cursor = 'pointer';
         function handleCardActivation(e) {
-            if (e.target.closest('.compare-checkbox') || e.target.closest('[data-route-link]') || e.target.closest('[data-route-uses]')) {
+            if (e.target.closest('.compare-toggle') || e.target.closest('[data-route-link]') || e.target.closest('[data-route-uses]')) {
                 return;
             }
             toggleRouteOnMap(route);
@@ -907,10 +912,10 @@
         const summary = byId('results-summary');
         if (!summary) return;
 
-        summary.className = count > 0 ? 'alert alert-info' : 'alert alert-warning';
+        summary.className = count > 0 ? 'text-muted small mb-2' : 'text-warning small mb-2';
         summary.innerHTML = count > 0
-            ? `<i class="bi bi-info-circle"></i> Showing ${count} route${count === 1 ? '' : 's'}`
-            : '<i class="bi bi-exclamation-triangle"></i> No routes match the current filters';
+            ? `<i class="bi bi-info-circle" aria-hidden="true"></i> Showing ${count} route${count === 1 ? '' : 's'}`
+            : '<i class="bi bi-exclamation-triangle" aria-hidden="true"></i> No routes match the current filters';
     }
 
     function displayRoutesTimestamp(timestamp) {
@@ -1058,12 +1063,36 @@
         // Apply filters immediately
         state.filteredRoutes = applyClientFilters(state.routes, getFilters());
         renderRoutes(state.filteredRoutes);
+        updateMoreFiltersBadge();
         announce(`Applied ${preset} distance filter`);
+    }
+
+    // Count how many of the "More Filters" collapsible controls are set to a
+    // non-default value, so the toggle button can show "More Filters (N)" (Issue #364).
+    function countActiveFilters() {
+        const f = getFilters();
+        let count = 0;
+        if (f.favorite) count++;
+        if (f.commute) count++;
+        if (f.sport_type) count++;
+        if (f.difficulty) count++;
+        if (f.min_distance) count++;
+        if (f.max_distance) count++;
+        if (f.date_range) count++;
+        return count;
+    }
+
+    function updateMoreFiltersBadge() {
+        const countEl = byId('more-filters-count');
+        if (!countEl) return;
+        const n = countActiveFilters();
+        countEl.textContent = n > 0 ? ` (${n})` : '';
     }
 
     function applyFilters() {
         state.filteredRoutes = applyClientFilters(state.routes, getFilters());
         renderRoutes(state.filteredRoutes);
+        updateMoreFiltersBadge();
     }
 
     function bindEvents() {
@@ -1129,17 +1158,35 @@
     async function loadSavedPlans() {
         const section = byId('saved-plans-section');
         const list = byId('saved-plans-list');
+        const titleEl = byId('saved-plans-title');
+        const toggleBtn = byId('toggle-plans-btn');
+        const card = byId('saved-plans-card');
         if (!section || !list) return;
 
         try {
             const response = await window.apiClient.getPlans();
             const plans = Array.isArray(response.plans) ? response.plans : [];
+
+            if (titleEl) titleEl.textContent = `Saved Plans (${plans.length})`;
+
             if (!plans.length) {
-                section.style.display = 'none';
+                // Persistent stub entry point: always visible, muted, disabled toggle
+                // when there is nothing to expand yet (Issue #372b).
+                if (card) card.classList.remove('saved-plans-active');
+                if (toggleBtn) {
+                    toggleBtn.disabled = true;
+                    toggleBtn.setAttribute('aria-disabled', 'true');
+                }
+                list.innerHTML = '';
                 return;
             }
 
-            section.style.display = '';
+            if (card) card.classList.add('saved-plans-active');
+            if (toggleBtn) {
+                toggleBtn.disabled = false;
+                toggleBtn.removeAttribute('aria-disabled');
+            }
+
             list.innerHTML = plans.map(plan => {
                 const date = plan.created_at
                     ? new Date(plan.created_at).toLocaleDateString('en-US', { month: 'short', day: 'numeric' })
@@ -1176,17 +1223,6 @@
                     }
                 });
             });
-
-            const toggleBtn = byId('toggle-plans-btn');
-            const body = byId('saved-plans-body');
-            if (toggleBtn && body) {
-                toggleBtn.onclick = () => {
-                    const collapsed = body.style.display === 'none';
-                    body.style.display = collapsed ? '' : 'none';
-                    toggleBtn.innerHTML = collapsed ? '<i class="bi bi-chevron-up"></i>' : '<i class="bi bi-chevron-down"></i>';
-                    toggleBtn.setAttribute('aria-expanded', collapsed);
-                };
-            }
         } catch (err) {
             console.error('Failed to load saved plans:', err);
         }

--- a/static/js/weather.js
+++ b/static/js/weather.js
@@ -55,8 +55,37 @@ function renderForecast(days) {
     });
 }
 
+function renderTodayGlance(today) {
+    const card = document.getElementById('today-glance');
+    const content = document.getElementById('today-glance-content');
+    if (!card || !content) return;
+
+    content.innerHTML = `
+        <div class="window-metric mb-0">
+            <i class="bi bi-speedometer2 text-success"></i>
+            <span>${today.comfort_score}/100 comfort</span>
+        </div>
+        <div class="window-metric mb-0">
+            <i class="bi bi-thermometer-half"></i>
+            <span>${today.temp_max_f}° / ${today.temp_min_f}°F</span>
+        </div>
+        <div class="window-metric mb-0">
+            <i class="bi bi-wind"></i>
+            <span>${today.wind_mph} mph ${today.wind_direction || ''}</span>
+        </div>
+        <div class="window-metric mb-0">
+            <i class="bi bi-droplet"></i>
+            <span>${today.precip_prob}% precip</span>
+        </div>
+    `;
+    card.classList.remove('d-none');
+}
+
 function maybeShowTransitAlert(today) {
-    if (today.comfort_score >= TRANSIT_COMFORT_THRESHOLD) return;
+    if (today.comfort_score >= TRANSIT_COMFORT_THRESHOLD) {
+        renderTodayGlance(today);
+        return;
+    }
 
     const alert = document.getElementById('transit-alert');
     const reason = document.getElementById('transit-reason');
@@ -126,23 +155,90 @@ function renderWindowMetrics(windowData, contentId) {
     `;
 }
 
+/** Format an hour-of-day (0–23) as a locale-friendly 12-hour label, e.g. "7 AM". */
+function formatHour12(hour24) {
+    const d = new Date(2000, 0, 1, ((hour24 % 24) + 24) % 24, 0, 0);
+    return d.toLocaleTimeString('en-US', { hour: 'numeric', hour12: true });
+}
+
+/**
+ * Derive a "(7–9 AM)" style range label from a commute window's `hours` array.
+ * Each entry's `hour` field is an "HH:MM" string for the start of that hourly
+ * bucket, so the window's end is the last bucket's hour + 1 (#373).
+ */
+function formatWindowRangeLabel(hours) {
+    if (!hours || !hours.length) return '';
+
+    const startHour = parseInt(hours[0].hour.split(':')[0], 10);
+    const lastHour = parseInt(hours[hours.length - 1].hour.split(':')[0], 10);
+    const endHour = lastHour + 1;
+
+    const startLabel = formatHour12(startHour);
+    const endLabel = formatHour12(endHour);
+    const startMeridiem = startLabel.split(' ')[1];
+    const endMeridiem = endLabel.split(' ')[1];
+
+    if (startMeridiem === endMeridiem) {
+        return `(${startLabel.split(' ')[0]}–${endLabel})`;
+    }
+    return `(${startLabel}–${endLabel})`;
+}
+
+function updateWindowTimeRange(windowData, labelId) {
+    const el = document.getElementById(labelId);
+    if (!el) return;
+    const label = formatWindowRangeLabel(windowData && windowData.hours);
+    el.textContent = label || '';
+}
+
 async function loadCommuteWindows() {
     try {
         const res = await fetch('/api/weather/commute-windows');
         const data = await res.json();
         if (!data || data.status !== 'success') throw new Error(data?.message || 'No window data');
 
+        updateWindowTimeRange(data.morning, 'morning-time-range');
+        updateWindowTimeRange(data.evening, 'evening-time-range');
         renderWindowMetrics(data.morning, 'morning-content');
         renderWindowMetrics(data.evening, 'evening-content');
     } catch (err) {
         console.error('Failed to load commute windows:', err);
         document.getElementById('morning-content').innerHTML = '';
         document.getElementById('evening-content').innerHTML = '';
+        document.getElementById('morning-time-range').textContent = '';
+        document.getElementById('evening-time-range').textContent = '';
         document.getElementById('windows-error').classList.remove('d-none');
     }
+}
+
+function initComfortLegendPopover() {
+    const icon = document.getElementById('comfort-legend-icon');
+    if (!icon || typeof bootstrap === 'undefined') return;
+
+    const popover = new bootstrap.Popover(icon, { trigger: 'manual', html: false });
+
+    const hide = () => popover.hide();
+    const toggle = (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        popover.toggle();
+    };
+
+    // Manual trigger (rather than the built-in "focus"/"click" triggers) so the
+    // same handler reliably opens on both mouse click and touch tap, and closes
+    // on outside interaction — Bootstrap's own triggers are inconsistent on iOS Safari.
+    icon.addEventListener('click', toggle);
+    icon.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter' || e.key === ' ') toggle(e);
+        if (e.key === 'Escape') hide();
+    });
+    document.addEventListener('click', (e) => {
+        if (e.target !== icon) hide();
+    });
 }
 
 document.addEventListener('DOMContentLoaded', () => {
     loadForecast();
     loadCommuteWindows();
+    initComfortLegendPopover();
 });

--- a/static/reports.html
+++ b/static/reports.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Reports - Ride Optimizer</title>
+    <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="/css/main.css">
@@ -166,9 +167,20 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <nav class="navbar navbar-expand-lg navbar-dark navbar-gradient" role="navigation" aria-label="Main navigation">
+    <nav class="navbar navbar-expand-lg navbar-fairweather" role="navigation" aria-label="Main navigation">
         <div class="container">
-            <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home"><i class="bi bi-bicycle" aria-hidden="true"></i> Ride Optimizer</a>
+            <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home">
+                <svg class="brand-mark" viewBox="0 0 48 48" fill="none" aria-hidden="true" focusable="false">
+                    <circle cx="24" cy="24" r="12" stroke="currentColor" stroke-width="3.4"/>
+                    <g stroke="currentColor" stroke-width="3.4" stroke-linecap="round">
+                        <line x1="24" y1="2" x2="24" y2="8"/><line x1="24" y1="40" x2="24" y2="46"/>
+                        <line x1="2" y1="24" x2="8" y2="24"/><line x1="40" y1="24" x2="46" y2="24"/>
+                        <line x1="8.3" y1="8.3" x2="12.5" y2="12.5"/><line x1="35.5" y1="35.5" x2="39.7" y2="39.7"/>
+                        <line x1="39.7" y1="8.3" x2="35.5" y2="12.5"/><line x1="12.5" y1="35.5" x2="8.3" y2="39.7"/>
+                    </g>
+                </svg>
+                <span><span class="brand-ride">Ride</span>&nbsp;<span class="brand-optimizer">Optimizer</span></span>
+            </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -435,7 +447,7 @@
         </div>
     </main>
 
-    <footer class="mt-3 bg-light">
+    <footer class="mt-3">
         <div class="container text-center text-muted">
             <small>Ride Optimizer v0.17.0 - Smart Static Architecture</small>
         </div>
@@ -447,22 +459,38 @@
     <script src="/js/reports.js?v=1"></script>
 
     <!-- Bottom Navigation (Mobile) -->
+    <div id="bottom-nav-more" class="bottom-nav-drawer collapse d-md-none" aria-label="More pages">
+        <a class="bottom-nav-drawer-item" href="/explore.html">
+            <i class="bi bi-compass" aria-hidden="true"></i>
+            <span>Explore</span>
+        </a>
+        <a class="bottom-nav-drawer-item" href="/settings.html">
+            <i class="bi bi-gear" aria-hidden="true"></i>
+            <span>Settings</span>
+        </a>
+    </div>
     <nav id="bottom-nav" class="bottom-nav d-md-none" role="navigation" aria-label="Mobile navigation">
-        <button class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
+        <button type="button" class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
             <i class="bi bi-house-door" aria-hidden="true"></i>
             <span>Home</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Routes" onclick="window.location.href='/routes.html'">
+        <button type="button" class="bottom-nav-item" aria-label="Routes" onclick="window.location.href='/routes.html'">
             <i class="bi bi-map" aria-hidden="true"></i>
             <span>Routes</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
+        <button type="button" class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
             <i class="bi bi-cloud-sun" aria-hidden="true"></i>
             <span>Weather</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Settings" onclick="window.location.href='/settings.html'">
-            <i class="bi bi-gear" aria-hidden="true"></i>
-            <span>Settings</span>
+        <button type="button" class="bottom-nav-item active" aria-label="Reports" aria-current="page" onclick="window.location.href='/reports.html'">
+            <i class="bi bi-bar-chart-line" aria-hidden="true"></i>
+            <span>Reports</span>
+        </button>
+        <button type="button" class="bottom-nav-item" aria-label="More pages"
+                data-bs-toggle="collapse" data-bs-target="#bottom-nav-more"
+                aria-expanded="false" aria-controls="bottom-nav-more">
+            <i class="bi bi-three-dots" aria-hidden="true"></i>
+            <span>More</span>
         </button>
     </nav>
 </body>

--- a/static/reports.html
+++ b/static/reports.html
@@ -32,6 +32,14 @@
             margin-top: var(--space-1);
         }
 
+        /* Secondary stat cards (#369a) — visibly smaller than the four primary stats above */
+        .stat-card-secondary {
+            padding: var(--space-2) var(--space-1);
+        }
+        .stat-card-secondary .stat-value {
+            font-size: var(--font-size-base);
+        }
+
         .record-card {
             display: flex;
             flex-direction: column;
@@ -98,11 +106,12 @@
             color: var(--color-text-muted);
         }
 
+        /* Consolidated trend chart tabs (#366c) — taller than the old 64px per-chart cards */
         .bar-chart {
             display: flex;
             align-items: flex-end;
             gap: 2px;
-            height: 64px;
+            height: 120px;
         }
         .bar-chart .bar {
             flex: 1;
@@ -114,6 +123,11 @@
             transition: opacity 0.15s;
         }
         .bar-chart .bar:hover { opacity: 1; }
+
+        .trend-tabs .nav-link {
+            font-size: var(--font-size-sm);
+            padding: 4px 12px;
+        }
 
         .activity-row {
             font-size: var(--font-size-sm);
@@ -225,7 +239,7 @@
             <div class="col-6 col-md-3">
                 <div class="card stat-card">
                     <div class="stat-value" id="stat-distance">—</div>
-                    <div class="stat-label">Miles</div>
+                    <div class="stat-label" id="stat-distance-label">Miles</div>
                     <div class="stat-sub" id="stat-avg-distance"></div>
                 </div>
             </div>
@@ -245,22 +259,22 @@
             </div>
         </div>
 
-        <!-- Extra stats row: HR, power, kudos -->
+        <!-- Extra stats row: HR, power, kudos — hidden/resized when empty (#369a) -->
         <div class="row g-2 mb-2" id="extra-stats-row">
-            <div class="col-4">
-                <div class="card stat-card">
+            <div class="col-4" id="stat-hr-col">
+                <div class="card stat-card stat-card-secondary">
                     <div class="stat-value" id="stat-hr">—</div>
                     <div class="stat-label">Avg HR</div>
                 </div>
             </div>
-            <div class="col-4">
-                <div class="card stat-card">
+            <div class="col-4" id="stat-kj-col">
+                <div class="card stat-card stat-card-secondary">
                     <div class="stat-value" id="stat-kj">—</div>
                     <div class="stat-label">Kilojoules</div>
                 </div>
             </div>
-            <div class="col-4">
-                <div class="card stat-card">
+            <div class="col-4" id="stat-kudos-col">
+                <div class="card stat-card stat-card-secondary">
                     <div class="stat-value" id="stat-kudos">—</div>
                     <div class="stat-label">Kudos</div>
                 </div>
@@ -268,14 +282,59 @@
         </div>
 
         <div class="row g-2">
-            <!-- Left column: PRs + type breakdown + activity chart -->
+            <!-- Left column: trend chart + PRs + type breakdown (#366b) -->
             <div class="col-lg-5">
+
+                <!-- Your Trend: consolidated Distance / Speed / Elevation tabs (#366c) -->
+                <div class="card mb-2">
+                    <div class="card-body py-2 px-3">
+                        <div class="section-header">
+                            <h6><i class="bi bi-graph-up" aria-hidden="true"></i> Your Trend</h6>
+                        </div>
+                        <ul class="nav nav-tabs nav-tabs-sm trend-tabs mb-2" id="trend-tabs" role="tablist">
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link active" id="tab-monthly" data-bs-toggle="tab" data-bs-target="#pane-monthly"
+                                        type="button" role="tab" aria-controls="pane-monthly" aria-selected="true">Distance</button>
+                            </li>
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link" id="tab-speed" data-bs-toggle="tab" data-bs-target="#pane-speed"
+                                        type="button" role="tab" aria-controls="pane-speed" aria-selected="false">Speed</button>
+                            </li>
+                            <li class="nav-item" role="presentation">
+                                <button class="nav-link" id="tab-elevation" data-bs-toggle="tab" data-bs-target="#pane-elevation"
+                                        type="button" role="tab" aria-controls="pane-elevation" aria-selected="false">Elevation</button>
+                            </li>
+                        </ul>
+                        <div class="tab-content" id="trend-tab-content">
+                            <div class="tab-pane fade show active" id="pane-monthly" role="tabpanel" aria-labelledby="tab-monthly">
+                                <div class="bar-chart" id="monthly-chart" role="group" aria-label="Monthly distance bar chart">
+                                    <div class="text-muted small">Loading…</div>
+                                </div>
+                                <div id="monthly-chart-label" class="text-muted" style="font-size:10px; margin-top:var(--space-1); text-align:center;"></div>
+                            </div>
+                            <div class="tab-pane fade" id="pane-speed" role="tabpanel" aria-labelledby="tab-speed">
+                                <div class="bar-chart" id="speed-chart" role="group" aria-label="Speed distribution histogram">
+                                    <div class="text-muted small">Loading…</div>
+                                </div>
+                                <div id="speed-chart-label" class="text-muted" style="font-size:10px; margin-top:var(--space-1); text-align:center;"></div>
+                            </div>
+                            <div class="tab-pane fade" id="pane-elevation" role="tabpanel" aria-labelledby="tab-elevation">
+                                <div class="bar-chart" id="elevation-chart" role="group" aria-label="Elevation gain distribution histogram">
+                                    <div class="text-muted small">Loading…</div>
+                                </div>
+                                <div id="elevation-chart-label" class="text-muted" style="font-size:10px; margin-top:var(--space-1); text-align:center;"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
                 <!-- Personal Records -->
                 <div class="card mb-2">
                     <div class="card-body py-2 px-3">
                         <div class="section-header mb-2">
-                            <h6><i class="bi bi-trophy" aria-hidden="true"></i> Personal Records</h6>
+                            <h6><i class="bi bi-trophy" aria-hidden="true"></i> Personal Records
+                                <span id="records-qualifier" class="text-muted" style="text-transform:none; letter-spacing:normal; font-weight:400;"></span>
+                            </h6>
                         </div>
                         <div class="row g-2" id="records-grid">
                             <div class="col-6">
@@ -326,79 +385,13 @@
                     </div>
                 </div>
 
-                <!-- Monthly distance chart -->
-                <div class="card mb-2">
-                    <div class="card-body py-2 px-3">
-                        <div class="section-header">
-                            <h6><i class="bi bi-graph-up" aria-hidden="true"></i> Monthly Distance</h6>
-                        </div>
-                        <div class="bar-chart" id="monthly-chart" role="img" aria-label="Monthly distance bar chart">
-                            <div class="text-muted small">Loading…</div>
-                        </div>
-                        <div id="monthly-chart-label" class="text-muted" style="font-size:10px; margin-top:var(--space-1); text-align:center;"></div>
-                    </div>
-                </div>
-
-                <!-- Speed distribution -->
-                <div class="card mb-2">
-                    <div class="card-body py-2 px-3">
-                        <div class="section-header">
-                            <h6><i class="bi bi-speedometer2" aria-hidden="true"></i> Speed Distribution</h6>
-                        </div>
-                        <div class="bar-chart" id="speed-chart" role="img" aria-label="Speed distribution histogram">
-                            <div class="text-muted small">Loading…</div>
-                        </div>
-                        <div id="speed-chart-label" class="text-muted" style="font-size:10px; margin-top:var(--space-1); text-align:center;"></div>
-                    </div>
-                </div>
-
-                <!-- Elevation distribution -->
-                <div class="card mb-2">
-                    <div class="card-body py-2 px-3">
-                        <div class="section-header">
-                            <h6><i class="bi bi-arrow-up-right" aria-hidden="true"></i> Elevation per Ride</h6>
-                        </div>
-                        <div class="bar-chart" id="elevation-chart" role="img" aria-label="Elevation gain distribution histogram">
-                            <div class="text-muted small">Loading…</div>
-                        </div>
-                        <div id="elevation-chart-label" class="text-muted" style="font-size:10px; margin-top:var(--space-1); text-align:center;"></div>
-                    </div>
-                </div>
-
             </div>
 
-            <!-- Right column: Gear + activity list -->
+            <!-- Right column: Activities + Gear (#366a) -->
             <div class="col-lg-7">
 
-                <!-- Gear breakdown -->
-                <div class="card mb-2">
-                    <div class="card-body py-2 px-3">
-                        <div class="section-header flex-wrap">
-                            <h6><i class="bi bi-bicycle" aria-hidden="true"></i> Gear</h6>
-                            <div class="d-flex flex-wrap gap-1 align-items-center">
-                                <span id="gear-cache-status" class="text-muted" style="font-size:10px;"></span>
-                                <button type="button" class="btn btn-outline-secondary btn-sm py-0 px-1"
-                                        id="refresh-gear-btn" title="Fetch gear names from Strava" style="font-size:11px;">
-                                    <i class="bi bi-arrow-clockwise" aria-hidden="true"></i> Sync Gear
-                                </button>
-                                <button type="button" class="btn btn-outline-secondary btn-sm py-0 px-1"
-                                        id="backfill-gear-btn" title="Patch gear IDs on cached activities without re-fetching everything" style="font-size:11px;">
-                                    <i class="bi bi-patch-check" aria-hidden="true"></i> Backfill Gear IDs
-                                </button>
-                                <button type="button" class="btn btn-outline-secondary btn-sm py-0 px-1"
-                                        id="clear-gear-filter-btn" title="Show all rides" style="font-size:11px; display:none;">
-                                    <i class="bi bi-x-circle" aria-hidden="true"></i> Clear Filter
-                                </button>
-                            </div>
-                        </div>
-                        <div id="gear-cards" class="row g-1">
-                            <div class="text-muted small">Loading…</div>
-                        </div>
-                    </div>
-                </div>
-
                 <!-- Activity list (filtered by selected gear) -->
-                <div class="card">
+                <div class="card mb-2">
                     <div class="card-body py-2 px-3">
                         <div class="section-header flex-wrap">
                             <h6><i class="bi bi-list-ul" aria-hidden="true"></i> Activities
@@ -443,6 +436,25 @@
                     </div>
                 </div>
 
+                <!-- Gear breakdown -->
+                <div class="card mb-2">
+                    <div class="card-body py-2 px-3">
+                        <div class="section-header flex-wrap">
+                            <h6><i class="bi bi-bicycle" aria-hidden="true"></i> Gear</h6>
+                            <div class="d-flex flex-wrap gap-1 align-items-center">
+                                <span id="gear-cache-status" class="text-muted" style="font-size:10px;"></span>
+                                <button type="button" class="btn btn-outline-secondary btn-sm py-0 px-1"
+                                        id="clear-gear-filter-btn" title="Show all rides" style="font-size:11px; display:none;">
+                                    <i class="bi bi-x-circle" aria-hidden="true"></i> Clear Filter
+                                </button>
+                            </div>
+                        </div>
+                        <div id="gear-cards" class="row g-1">
+                            <div class="text-muted small">Loading…</div>
+                        </div>
+                    </div>
+                </div>
+
             </div>
         </div>
     </main>
@@ -456,7 +468,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="/js/common.js"></script>
     <script src="/js/api-client.js?v=4"></script>
-    <script src="/js/reports.js?v=1"></script>
+    <script src="/js/reports.js?v=2"></script>
 
     <!-- Bottom Navigation (Mobile) -->
     <div id="bottom-nav-more" class="bottom-nav-drawer collapse d-md-none" aria-label="More pages">

--- a/static/route-detail.html
+++ b/static/route-detail.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Route Details - Ride Optimizer</title>
+    <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="">
@@ -32,10 +33,19 @@
     </style>
 </head>
 <body>
-    <nav class="navbar navbar-expand-lg navbar-dark navbar-gradient" role="navigation" aria-label="Main navigation">
+    <nav class="navbar navbar-expand-lg navbar-fairweather" role="navigation" aria-label="Main navigation">
         <div class="container">
             <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home">
-                <i class="bi bi-bicycle" aria-hidden="true"></i> Ride Optimizer
+                <svg class="brand-mark" viewBox="0 0 48 48" fill="none" aria-hidden="true" focusable="false">
+                    <circle cx="24" cy="24" r="12" stroke="currentColor" stroke-width="3.4"/>
+                    <g stroke="currentColor" stroke-width="3.4" stroke-linecap="round">
+                        <line x1="24" y1="2" x2="24" y2="8"/><line x1="24" y1="40" x2="24" y2="46"/>
+                        <line x1="2" y1="24" x2="8" y2="24"/><line x1="40" y1="24" x2="46" y2="24"/>
+                        <line x1="8.3" y1="8.3" x2="12.5" y2="12.5"/><line x1="35.5" y1="35.5" x2="39.7" y2="39.7"/>
+                        <line x1="39.7" y1="8.3" x2="35.5" y2="12.5"/><line x1="12.5" y1="35.5" x2="8.3" y2="39.7"/>
+                    </g>
+                </svg>
+                <span><span class="brand-ride">Ride</span>&nbsp;<span class="brand-optimizer">Optimizer</span></span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -77,26 +87,42 @@
         </div>
     </main>
 
+    <div id="bottom-nav-more" class="bottom-nav-drawer collapse d-md-none" aria-label="More pages">
+        <a class="bottom-nav-drawer-item" href="/explore.html">
+            <i class="bi bi-compass" aria-hidden="true"></i>
+            <span>Explore</span>
+        </a>
+        <a class="bottom-nav-drawer-item" href="/settings.html">
+            <i class="bi bi-gear" aria-hidden="true"></i>
+            <span>Settings</span>
+        </a>
+    </div>
     <nav id="bottom-nav" class="bottom-nav d-md-none" role="navigation" aria-label="Mobile navigation">
-        <button class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
+        <button type="button" class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
             <i class="bi bi-house-door" aria-hidden="true"></i>
             <span>Home</span>
         </button>
-        <button class="bottom-nav-item active" aria-label="Routes" aria-current="page" onclick="window.location.href='/routes.html'">
+        <button type="button" class="bottom-nav-item active" aria-label="Routes" aria-current="page" onclick="window.location.href='/routes.html'">
             <i class="bi bi-map" aria-hidden="true"></i>
             <span>Routes</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
+        <button type="button" class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
             <i class="bi bi-cloud-sun" aria-hidden="true"></i>
             <span>Weather</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Settings" onclick="window.location.href='/settings.html'">
-            <i class="bi bi-gear" aria-hidden="true"></i>
-            <span>Settings</span>
+        <button type="button" class="bottom-nav-item" aria-label="Reports" onclick="window.location.href='/reports.html'">
+            <i class="bi bi-bar-chart-line" aria-hidden="true"></i>
+            <span>Reports</span>
+        </button>
+        <button type="button" class="bottom-nav-item" aria-label="More pages"
+                data-bs-toggle="collapse" data-bs-target="#bottom-nav-more"
+                aria-expanded="false" aria-controls="bottom-nav-more">
+            <i class="bi bi-three-dots" aria-hidden="true"></i>
+            <span>More</span>
         </button>
     </nav>
 
-    <footer class="mt-3 bg-light">
+    <footer class="mt-3">
         <div class="container text-center text-muted">
             <small>Ride Optimizer v0.17.0 - Smart Static Architecture</small>
         </div>

--- a/static/route-detail.html
+++ b/static/route-detail.html
@@ -18,6 +18,11 @@
         @media (max-width: 991.98px) {
             #route-map { height: 320px; }
         }
+        @media (max-width: 767.98px) {
+            /* #371c: fixed 320px map fills the whole viewport on short mobile screens;
+               cap it so content peeks above/below. */
+            #route-map { max-height: 50vh; }
+        }
         .metric-card {
             height: 100%;
         }
@@ -27,12 +32,22 @@
             gap: var(--space-1);
             padding: var(--space-1) var(--space-2);
             border-radius: 999px;
-            background: #f8f9fa;
+            background: var(--surface-2);
             margin: 0 var(--space-2) var(--space-2) 0;
+        }
+        /* Demoted secondary metric (popularity/uses) — same chip shape, muted ink */
+        .detail-chip-muted {
+            color: var(--ink-soft);
+        }
+        .performance-placeholder {
+            color: var(--ink-soft);
         }
     </style>
 </head>
 <body>
+    <!-- Skip Links for Accessibility -->
+    <a href="#main-content" class="skip-link">Skip to main content</a>
+
     <nav class="navbar navbar-expand-lg navbar-fairweather" role="navigation" aria-label="Main navigation">
         <div class="container">
             <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home">
@@ -63,9 +78,6 @@
         </div>
     </nav>
 
-    <!-- Skip Links for Accessibility -->
-    <a href="#main-content" class="skip-link">Skip to main content</a>
-
     <main id="main-content" class="container mt-4" role="main">
         <div class="row mb-3">
             <div class="col-12">
@@ -78,6 +90,7 @@
         <div id="route-detail-live-region" class="visually-hidden" aria-live="polite" aria-atomic="true"></div>
 
         <div id="route-details">
+            <h1 class="mb-3">Route Details</h1>
             <div class="text-center py-5">
                 <div class="spinner-border text-primary" role="status">
                     <span class="visually-hidden">Loading route details...</span>
@@ -165,6 +178,7 @@
 
             function renderError(message, variant = 'danger') {
                 byId('route-details').innerHTML = `
+                    <h1 class="mb-3">Route Details</h1>
                     <div class="alert alert-${variant}" role="alert">
                         <i class="bi bi-exclamation-triangle"></i> ${message}
                     </div>
@@ -206,18 +220,66 @@
 
                 L.marker(start).addTo(mapInstance).bindTooltip('Start');
                 L.marker(end).addTo(mapInstance).bindTooltip('End');
+
+                // #371c: container height now comes from CSS (incl. the mobile max-height:
+                // 50vh rule) rather than an inline style, so re-measure after first paint
+                // in case layout wasn't final at init time.
+                setTimeout(() => {
+                    if (mapInstance) {
+                        mapInstance.invalidateSize();
+                    }
+                }, 100);
             }
 
             function renderPerformanceCharts(route) {
-                // Only show if we have route history with multiple data points
-                if (!Array.isArray(route.routes) || route.routes.length < 2) {
+                const content = byId('performance-content');
+                if (!content) return;
+
+                const dataPoints = Array.isArray(route.routes) ? route.routes.length : 0;
+                const usesCount = Array.isArray(route.activity_ids) ? route.activity_ids.length : 0;
+
+                // #371b/#376: card is always rendered now (never hidden). Fall back to an
+                // informative placeholder when there isn't enough history to chart trends.
+                if (dataPoints < 2) {
+                    if (dataPoints === 0 && usesCount > 0) {
+                        // Long-ride-style routes track uses via activity_ids, not route.routes.
+                        content.innerHTML = `
+                            <p class="performance-placeholder mb-0">
+                                <i class="bi bi-info-circle" aria-hidden="true"></i>
+                                History: ${usesCount} recorded ride${usesCount === 1 ? '' : 's'}. Not enough performance data yet to chart trends.
+                            </p>
+                        `;
+                    } else {
+                        content.innerHTML = `
+                            <p class="performance-placeholder mb-0">
+                                <i class="bi bi-info-circle" aria-hidden="true"></i>
+                                Not enough rides yet to chart trends — ride this route again to see performance over time.
+                            </p>
+                        `;
+                    }
                     return;
                 }
 
-                const metricsCard = byId('performance-metrics-card');
-                if (metricsCard) {
-                    metricsCard.style.display = 'block';
-                }
+                content.innerHTML = `
+                    <div class="row g-4">
+                        <div class="col-12 col-lg-6">
+                            <h3 class="h6 text-muted mb-3">Average Speed Over Time</h3>
+                            <canvas id="speed-chart" style="max-height: var(--chart-height);"></canvas>
+                        </div>
+                        <div class="col-12 col-lg-6">
+                            <h3 class="h6 text-muted mb-3">Duration Trends</h3>
+                            <canvas id="duration-chart" style="max-height: var(--chart-height);"></canvas>
+                        </div>
+                        <div class="col-12 col-lg-6">
+                            <h3 class="h6 text-muted mb-3">Heart Rate (if available)</h3>
+                            <canvas id="heartrate-chart" style="max-height: var(--chart-height);"></canvas>
+                        </div>
+                        <div class="col-12 col-lg-6">
+                            <h3 class="h6 text-muted mb-3">Power Output (if available)</h3>
+                            <canvas id="power-chart" style="max-height: var(--chart-height);"></canvas>
+                        </div>
+                    </div>
+                `;
 
                 // Sort routes by timestamp
                 const sortedRoutes = [...route.routes].sort((a, b) =>
@@ -454,11 +516,12 @@
                 const weatherMarkup = route.weather
                     ? `
                         <hr class="my-2">
+                        <h3 class="h6 text-muted mb-2">Weather at ride time</h3>
                         <div class="row g-2">
                             ${route.weather.temp_c != null ? `
                                 <div class="col-6">
                                     <div class="d-flex align-items-center gap-2">
-                                        <i class="bi bi-thermometer-half text-danger"></i>
+                                        <i class="bi bi-thermometer-half" style="color: var(--accent);" aria-hidden="true"></i>
                                         <div>
                                             <div class="small text-muted">Temperature</div>
                                             <div class="fw-semibold">${window.formatTemperature(route.weather.temp_c)}</div>
@@ -469,7 +532,7 @@
                             ${route.weather.wind_speed_kph != null ? `
                                 <div class="col-6">
                                     <div class="d-flex align-items-center gap-2">
-                                        <i class="bi bi-wind text-info"></i>
+                                        <i class="bi bi-wind" style="color: var(--accent);" aria-hidden="true"></i>
                                         <div>
                                             <div class="small text-muted">Wind</div>
                                             <div class="fw-semibold">${window.formatSpeed(route.weather.wind_speed_kph)}${route.weather.wind_direction_cardinal ? ` ${route.weather.wind_direction_cardinal}` : ''}</div>
@@ -480,7 +543,7 @@
                             ${route.weather.precipitation_mm != null ? `
                                 <div class="col-6">
                                     <div class="d-flex align-items-center gap-2">
-                                        <i class="bi bi-cloud-rain text-primary"></i>
+                                        <i class="bi bi-cloud-rain" style="color: var(--accent);" aria-hidden="true"></i>
                                         <div>
                                             <div class="small text-muted">Precipitation</div>
                                             <div class="fw-semibold">${route.weather.precipitation_mm} mm</div>
@@ -491,7 +554,7 @@
                             ${route.weather.conditions ? `
                                 <div class="col-6">
                                     <div class="d-flex align-items-center gap-2">
-                                        <i class="bi bi-cloud-sun text-secondary"></i>
+                                        <i class="bi bi-cloud-sun" style="color: var(--ink-soft);" aria-hidden="true"></i>
                                         <div>
                                             <div class="small text-muted">Conditions</div>
                                             <div class="fw-semibold">${route.weather.conditions}</div>
@@ -502,6 +565,14 @@
                         </div>
                     `
                     : '';
+
+                // #371a: Uses is a popularity/social signal — demote it out of the primary
+                // metrics grid. Backfill the freed slot with avg speed (derivable from the
+                // distance/duration already in the API response) when possible; otherwise
+                // fall back to a 3-up grid rather than showing a placeholder value.
+                const avgSpeedKmh = (route.distance > 0 && route.duration > 0)
+                    ? route.distance / (route.duration / 60)
+                    : null;
 
                 // Long rides store uses as parallel arrays: activity_ids + activity_dates
                 const longRideUsesMarkup = route.type === 'long_ride' && Array.isArray(route.activity_ids) && route.activity_ids.length > 1
@@ -533,12 +604,13 @@
                                     ${route.sport_type ? `<span class="detail-chip"><i class="bi bi-bicycle"></i> ${route.sport_type}</span>` : ''}
                                     ${route.difficulty ? `<span class="detail-chip"><i class="bi bi-bar-chart"></i> ${route.difficulty}</span>` : ''}
                                     ${route.is_favorite ? `<span class="detail-chip"><i class="bi bi-star-fill text-warning"></i> Favorite</span>` : ''}
+                                    <span class="detail-chip detail-chip-muted"><i class="bi bi-arrow-repeat" aria-hidden="true"></i> ${route.uses || 0} use${route.uses === 1 ? '' : 's'}</span>
                                 </div>
                             </div>
                             <div class="text-md-end d-flex flex-column align-items-md-end gap-1">
                                 ${route.is_plus_route ? '<div class="text-muted">PLUS route</div>' : ''}
                                 <div class="d-flex gap-2 flex-wrap justify-content-md-end">
-                                    <button class="btn btn-sm btn-primary" id="save-plan-btn" title="Save this route as a plan to ride again">
+                                    <button class="btn btn-sm btn-cta" id="save-plan-btn" title="Save this route as a plan to ride again">
                                         <i class="bi bi-calendar-plus"></i> Ride Again
                                     </button>
                                     ${route.type === 'long_ride' && route.id
@@ -555,46 +627,59 @@
                                 <div class="card">
                                     <div class="card-body">
                                         <div class="row g-2 mb-3">
-                                            <div class="col-6">
+                                            <div class="col-4">
                                                 <div class="d-flex align-items-center gap-2">
                                                     <i class="bi bi-rulers text-primary"></i>
                                                     <div>
                                                         <div class="small text-muted">Distance</div>
-                                                        <div class="fw-semibold">${window.formatDistance(route.distance)}</div>
+                                                        <div class="fw-semibold tabular-nums">${window.formatDistance(route.distance)}</div>
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="col-6">
+                                            <div class="col-4">
                                                 <div class="d-flex align-items-center gap-2">
-                                                    <i class="bi bi-clock text-info"></i>
+                                                    <i class="bi bi-clock" style="color: var(--accent);" aria-hidden="true"></i>
                                                     <div>
                                                         <div class="small text-muted">Duration</div>
-                                                        <div class="fw-semibold">${formatDuration(route.duration)}</div>
+                                                        <div class="fw-semibold tabular-nums">${formatDuration(route.duration)}</div>
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="col-6">
+                                            <div class="col-4">
                                                 <div class="d-flex align-items-center gap-2">
                                                     <i class="bi bi-graph-up-arrow text-success"></i>
                                                     <div>
                                                         <div class="small text-muted">Elevation</div>
-                                                        <div class="fw-semibold">${window.formatElevation(route.elevation)}</div>
+                                                        <div class="fw-semibold tabular-nums">${window.formatElevation(route.elevation)}</div>
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="col-6">
-                                                <div class="d-flex align-items-center gap-2">
-                                                    <i class="bi bi-arrow-repeat text-warning"></i>
-                                                    <div>
-                                                        <div class="small text-muted">Uses</div>
-                                                        <div class="fw-semibold">${route.uses || 0}</div>
+                                            ${avgSpeedKmh != null ? `
+                                                <div class="col-4">
+                                                    <div class="d-flex align-items-center gap-2">
+                                                        <i class="bi bi-speedometer2 text-primary"></i>
+                                                        <div>
+                                                            <div class="small text-muted">Avg Speed</div>
+                                                            <div class="fw-semibold tabular-nums">${window.formatSpeed(avgSpeedKmh)}</div>
+                                                        </div>
                                                     </div>
                                                 </div>
-                                            </div>
+                                            ` : ''}
                                         </div>
                                         ${weatherMarkup}
                                     </div>
                                 </div>
+
+                                <!-- Performance Metrics Charts (#371b: moved into stats column, above history/uses) -->
+                                <div class="card mt-3" id="performance-metrics-card">
+                                    <div class="card-body">
+                                        <h2 id="performance" class="h5 mb-4">
+                                            <i class="bi bi-graph-up" aria-hidden="true"></i> Performance Trends
+                                        </h2>
+                                        <div id="performance-content"></div>
+                                    </div>
+                                </div>
+
                                 ${routeHistoryMarkup}
                                 ${longRideUsesMarkup}
                             </div>
@@ -602,35 +687,8 @@
                                 <div style="position: sticky; top: var(--space-3);">
                                     <div class="card">
                                         <div class="card-body p-0">
-                                            <div id="route-map" style="height: var(--map-height-standard); border-radius: 8px;" aria-label="Interactive route map"></div>
+                                            <div id="route-map" aria-label="Interactive route map"></div>
                                         </div>
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-
-                        <!-- Performance Metrics Charts -->
-                        <div class="card mt-3" id="performance-metrics-card" style="display: none;">
-                            <div class="card-body">
-                                <h2 class="h5 mb-4">
-                                    <i class="bi bi-graph-up"></i> Performance Trends
-                                </h2>
-                                <div class="row g-4">
-                                    <div class="col-12 col-lg-6">
-                                        <h3 class="h6 text-muted mb-3">Average Speed Over Time</h3>
-                                        <canvas id="speed-chart" style="max-height: var(--chart-height);"></canvas>
-                                    </div>
-                                    <div class="col-12 col-lg-6">
-                                        <h3 class="h6 text-muted mb-3">Duration Trends</h3>
-                                        <canvas id="duration-chart" style="max-height: var(--chart-height);"></canvas>
-                                    </div>
-                                    <div class="col-12 col-lg-6">
-                                        <h3 class="h6 text-muted mb-3">Heart Rate (if available)</h3>
-                                        <canvas id="heartrate-chart" style="max-height: var(--chart-height);"></canvas>
-                                    </div>
-                                    <div class="col-12 col-lg-6">
-                                        <h3 class="h6 text-muted mb-3">Power Output (if available)</h3>
-                                        <canvas id="power-chart" style="max-height: var(--chart-height);"></canvas>
                                     </div>
                                 </div>
                             </div>
@@ -669,7 +727,7 @@
                                 elevation: route.elevation,
                             });
                             savePlanBtn.innerHTML = '<i class="bi bi-check-lg"></i> Saved';
-                            savePlanBtn.classList.replace('btn-primary', 'btn-success');
+                            savePlanBtn.classList.replace('btn-cta', 'btn-success');
                             announce('Plan saved');
                         } catch (err) {
                             savePlanBtn.disabled = false;

--- a/static/route-detail.html
+++ b/static/route-detail.html
@@ -627,7 +627,7 @@
                                 <div class="card">
                                     <div class="card-body">
                                         <div class="row g-2 mb-3">
-                                            <div class="col-4">
+                                            <div class="col-6 col-md-4">
                                                 <div class="d-flex align-items-center gap-2">
                                                     <i class="bi bi-rulers text-primary"></i>
                                                     <div>
@@ -636,7 +636,7 @@
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="col-4">
+                                            <div class="col-6 col-md-4">
                                                 <div class="d-flex align-items-center gap-2">
                                                     <i class="bi bi-clock" style="color: var(--accent);" aria-hidden="true"></i>
                                                     <div>
@@ -645,7 +645,7 @@
                                                     </div>
                                                 </div>
                                             </div>
-                                            <div class="col-4">
+                                            <div class="col-6 col-md-4">
                                                 <div class="d-flex align-items-center gap-2">
                                                     <i class="bi bi-graph-up-arrow text-success"></i>
                                                     <div>
@@ -655,7 +655,7 @@
                                                 </div>
                                             </div>
                                             ${avgSpeedKmh != null ? `
-                                                <div class="col-4">
+                                                <div class="col-6 col-md-4">
                                                     <div class="d-flex align-items-center gap-2">
                                                         <i class="bi bi-speedometer2 text-primary"></i>
                                                         <div>

--- a/static/routes.html
+++ b/static/routes.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Routes - Ride Optimizer</title>
+    <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" crossorigin="">
@@ -43,9 +44,20 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <nav class="navbar navbar-expand-lg navbar-dark navbar-gradient" role="navigation" aria-label="Main navigation">
+    <nav class="navbar navbar-expand-lg navbar-fairweather" role="navigation" aria-label="Main navigation">
         <div class="container">
-            <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home"><i class="bi bi-bicycle" aria-hidden="true"></i> Ride Optimizer</a>
+            <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home">
+                <svg class="brand-mark" viewBox="0 0 48 48" fill="none" aria-hidden="true" focusable="false">
+                    <circle cx="24" cy="24" r="12" stroke="currentColor" stroke-width="3.4"/>
+                    <g stroke="currentColor" stroke-width="3.4" stroke-linecap="round">
+                        <line x1="24" y1="2" x2="24" y2="8"/><line x1="24" y1="40" x2="24" y2="46"/>
+                        <line x1="2" y1="24" x2="8" y2="24"/><line x1="40" y1="24" x2="46" y2="24"/>
+                        <line x1="8.3" y1="8.3" x2="12.5" y2="12.5"/><line x1="35.5" y1="35.5" x2="39.7" y2="39.7"/>
+                        <line x1="39.7" y1="8.3" x2="35.5" y2="12.5"/><line x1="12.5" y1="35.5" x2="8.3" y2="39.7"/>
+                    </g>
+                </svg>
+                <span><span class="brand-ride">Ride</span>&nbsp;<span class="brand-optimizer">Optimizer</span></span>
+            </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -265,22 +277,38 @@
     </main>
 
     <!-- Bottom Navigation (Mobile) -->
+    <div id="bottom-nav-more" class="bottom-nav-drawer collapse d-md-none" aria-label="More pages">
+        <a class="bottom-nav-drawer-item" href="/explore.html">
+            <i class="bi bi-compass" aria-hidden="true"></i>
+            <span>Explore</span>
+        </a>
+        <a class="bottom-nav-drawer-item" href="/settings.html">
+            <i class="bi bi-gear" aria-hidden="true"></i>
+            <span>Settings</span>
+        </a>
+    </div>
     <nav id="bottom-nav" class="bottom-nav d-md-none" role="navigation" aria-label="Mobile navigation">
-        <button class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
+        <button type="button" class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
             <i class="bi bi-house-door" aria-hidden="true"></i>
             <span>Home</span>
         </button>
-        <button class="bottom-nav-item active" aria-label="Routes" aria-current="page">
+        <button type="button" class="bottom-nav-item active" aria-label="Routes" aria-current="page" onclick="window.location.href='/routes.html'">
             <i class="bi bi-map" aria-hidden="true"></i>
             <span>Routes</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
+        <button type="button" class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
             <i class="bi bi-cloud-sun" aria-hidden="true"></i>
             <span>Weather</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Settings" onclick="window.location.href='/settings.html'">
-            <i class="bi bi-gear" aria-hidden="true"></i>
-            <span>Settings</span>
+        <button type="button" class="bottom-nav-item" aria-label="Reports" onclick="window.location.href='/reports.html'">
+            <i class="bi bi-bar-chart-line" aria-hidden="true"></i>
+            <span>Reports</span>
+        </button>
+        <button type="button" class="bottom-nav-item" aria-label="More pages"
+                data-bs-toggle="collapse" data-bs-target="#bottom-nav-more"
+                aria-expanded="false" aria-controls="bottom-nav-more">
+            <i class="bi bi-three-dots" aria-hidden="true"></i>
+            <span>More</span>
         </button>
     </nav>
 
@@ -304,7 +332,7 @@
         </div>
     </div>
 
-    <footer class="mt-3 bg-light">
+    <footer class="mt-3">
         <div class="container text-center text-muted">
             <small>Ride Optimizer v0.17.0 - Smart Static Architecture</small>
         </div>

--- a/static/routes.html
+++ b/static/routes.html
@@ -35,9 +35,57 @@
         }
 
         #results-summary {
-            padding: var(--space-1) var(--space-2);
-            margin-bottom: var(--space-2);
+            padding: var(--space-1) 0;
             font-size: var(--font-size-sm);
+        }
+
+        /* More Filters toggle: chevron flips when expanded, never a bare icon (§7) */
+        #more-filters-toggle {
+            min-height: 44px;
+        }
+        #more-filters-toggle .more-filters-chevron {
+            transition: transform 0.2s ease;
+        }
+        #more-filters-toggle[aria-expanded="true"] .more-filters-chevron {
+            transform: rotate(180deg);
+        }
+        #more-filters-count:not(:empty) {
+            font-weight: 600;
+            color: var(--accent);
+        }
+
+        /* Saved Plans: always-visible stub, highlighted once plans exist */
+        #saved-plans-card {
+            border-color: var(--line);
+        }
+        #toggle-plans-btn {
+            min-height: 44px;
+        }
+        #saved-plans-card.saved-plans-active {
+            border-color: var(--accent);
+        }
+        #saved-plans-card .saved-plans-chevron {
+            transition: transform 0.2s ease;
+        }
+        #toggle-plans-btn[aria-expanded="true"] .saved-plans-chevron {
+            transform: rotate(180deg);
+        }
+        #toggle-plans-btn:disabled {
+            opacity: 0.6;
+        }
+
+        /* Compare checkbox: enlarge the tappable area beyond the visual checkbox+label
+           without inflating the compact card row height (§7 touch target). */
+        .compare-toggle {
+            padding: 10px 6px;
+            margin: -10px 0 -10px -6px;
+            border-radius: var(--radius-sm, 4px);
+            min-height: 44px;
+            display: flex;
+            align-items: center;
+        }
+        .compare-toggle:hover {
+            background: var(--surface-2);
         }
     </style>
 </head>
@@ -96,9 +144,29 @@
                         <input type="text" id="search-query" class="form-control form-control-sm"
                                placeholder="Search routes…" aria-label="Search routes">
                     </div>
+                    <div style="min-width: 144px;">
+                        <label for="sort-by" class="form-label mb-0 small">Sort</label>
+                        <select id="sort-by" class="form-select form-select-sm">
+                            <option value="name">Name (A–Z)</option>
+                            <option value="name-desc">Name (Z–A)</option>
+                            <option value="distance">Distance ↑</option>
+                            <option value="distance-desc">Distance ↓</option>
+                            <option value="elevation">Elevation ↑</option>
+                            <option value="elevation-desc">Elevation ↓</option>
+                            <option value="uses">Most Used</option>
+                            <option value="recent">Most Recent</option>
+                        </select>
+                    </div>
+                    <button type="button" class="btn btn-sm btn-outline-secondary ms-auto" id="more-filters-toggle"
+                            data-bs-toggle="collapse" data-bs-target="#more-filters-panel"
+                            aria-expanded="false" aria-controls="more-filters-panel">
+                        <i class="bi bi-sliders" aria-hidden="true"></i> More Filters<span id="more-filters-count"></span>
+                        <i class="bi bi-chevron-down more-filters-chevron" aria-hidden="true"></i>
+                    </button>
                 </div>
-                <!-- Row 2: Dropdown filters + sort -->
-                <div class="d-flex flex-wrap gap-2 align-items-end">
+                <!-- Row 2: Advanced filters, collapsed by default (Issue #364) -->
+                <div class="collapse" id="more-filters-panel">
+                    <div class="d-flex flex-wrap gap-2 align-items-end pt-2 mt-1 border-top">
                     <div style="min-width: 112px;">
                         <label for="filter-favorite" class="form-label mb-0 small">Favorites</label>
                         <select id="filter-favorite" class="form-select form-select-sm">
@@ -155,47 +223,40 @@
                             <option value="365">Last 12 months</option>
                         </select>
                     </div>
-                    <div style="min-width: 144px;">
-                        <label for="sort-by" class="form-label mb-0 small">Sort</label>
-                        <select id="sort-by" class="form-select form-select-sm">
-                            <option value="name">Name (A–Z)</option>
-                            <option value="name-desc">Name (Z–A)</option>
-                            <option value="distance">Distance ↑</option>
-                            <option value="distance-desc">Distance ↓</option>
-                            <option value="elevation">Elevation ↑</option>
-                            <option value="elevation-desc">Elevation ↓</option>
-                            <option value="uses">Most Used</option>
-                            <option value="recent">Most Recent</option>
-                        </select>
                     </div>
                 </div>
             </div>
         </div>
 
-        <!-- Saved Plans -->
-        <div id="saved-plans-section" class="mb-3" style="display: none;">
-            <div class="card">
-                <div class="card-header d-flex justify-content-between align-items-center py-2">
-                    <span class="small fw-semibold"><i class="bi bi-calendar-check" aria-hidden="true"></i> Saved Plans</span>
-                    <button type="button" class="btn btn-sm btn-outline-secondary" id="toggle-plans-btn" aria-expanded="true" aria-label="Toggle saved plans">
-                        <i class="bi bi-chevron-up" aria-hidden="true"></i>
+        <!-- Saved Plans: persistent entry point, always visible even with zero plans (Issue #372b) -->
+        <div id="saved-plans-section" class="mb-3">
+            <div class="card" id="saved-plans-card">
+                <div class="card-header py-2">
+                    <button type="button" class="btn btn-sm btn-link text-decoration-none p-0 fw-semibold d-flex align-items-center gap-1 w-100"
+                            id="toggle-plans-btn" data-bs-toggle="collapse" data-bs-target="#saved-plans-collapse"
+                            aria-expanded="false" aria-controls="saved-plans-collapse" disabled>
+                        <i class="bi bi-calendar-check" aria-hidden="true"></i>
+                        <span id="saved-plans-title">Saved Plans (0)</span>
+                        <i class="bi bi-chevron-down saved-plans-chevron ms-auto" aria-hidden="true"></i>
                     </button>
                 </div>
-                <div class="card-body py-2" id="saved-plans-body">
-                    <div id="saved-plans-list"></div>
+                <div class="collapse" id="saved-plans-collapse">
+                    <div class="card-body py-2" id="saved-plans-body">
+                        <div id="saved-plans-list"></div>
+                    </div>
                 </div>
             </div>
         </div>
 
         <!-- Results summary -->
-        <div id="results-summary" class="alert alert-info">
+        <p id="results-summary" class="text-muted small mb-2">
             <i class="bi bi-info-circle" aria-hidden="true"></i> Loading routes…
-        </div>
+        </p>
 
         <!-- Side-by-side: scrollable route list (left) + sticky map (right) -->
         <div class="row g-2">
-            <!-- Route list -->
-            <div class="col-lg-5">
+            <!-- Route list: primary decision surface, gets more space than the map (§3) -->
+            <div class="col-lg-7">
                 <div id="routes-container" class="route-list-scroll">
                     <!-- Skeleton loaders -->
                     <div class="row g-3">
@@ -238,8 +299,8 @@
                 <div id="pagination-container" class="mt-3"></div>
             </div>
 
-            <!-- Map (sticky) -->
-            <div class="col-lg-7">
+            <!-- Map (sticky), confirmatory support column (§3) -->
+            <div class="col-lg-5">
                 <div class="card map-panel-sticky">
                     <div class="card-header d-flex flex-wrap justify-content-between align-items-center gap-2 py-2">
                         <span class="small fw-semibold">

--- a/static/settings.html
+++ b/static/settings.html
@@ -4,19 +4,81 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Settings - Ride Optimizer</title>
-    
+
     <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
-    
+
     <!-- Custom CSS -->
     <link rel="stylesheet" href="/css/main.css">
+
+    <!-- Page-specific styles (#368/#376 design-review restructure) -->
+    <style>
+        .card-header-btn {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: var(--space-2, 8px);
+            width: 100%;
+            border: none;
+            text-align: left;
+            cursor: pointer;
+            min-height: 44px;
+            font: inherit;
+        }
+        .card-header-btn:focus-visible {
+            outline: 2px solid var(--accent);
+            outline-offset: -2px;
+        }
+        .card-header-btn .chevron {
+            transition: transform 0.2s;
+            flex-shrink: 0;
+        }
+        .card-header-btn[aria-expanded="true"] .chevron {
+            transform: rotate(180deg);
+        }
+        .card-header-status {
+            font-weight: 400;
+            color: #fff;
+        }
+        .card-header-status .text-muted {
+            color: rgba(255, 255, 255, 0.8) !important;
+        }
+        .danger-zone-toggle {
+            min-height: 44px;
+        }
+        .danger-zone-body {
+            border: 1px solid var(--danger);
+            border-radius: 10px;
+            padding: 16px;
+            margin-top: 8px;
+            background: rgba(196, 72, 58, 0.06);
+        }
+        .about-card-header {
+            background: var(--surface-2);
+            color: var(--ink);
+        }
+        .save-behavior-line {
+            font-size: 0.875rem;
+            color: var(--ink-soft);
+        }
+        .requires-tr-note {
+            font-size: 0.875rem;
+        }
+        .workflow-explainer {
+            font-size: 0.875rem;
+            color: var(--ink-soft);
+        }
+        .step-badge {
+            font-weight: 700;
+        }
+    </style>
 </head>
 <body>
     <!-- Skip Links for Accessibility -->
     <a href="#main-content" class="skip-link">Skip to main content</a>
-    
+
     <!-- Navigation -->
     <nav class="navbar navbar-expand-lg navbar-fairweather" role="navigation" aria-label="Main navigation">
         <div class="container">
@@ -59,7 +121,7 @@
             </div>
         </div>
     </nav>
-    
+
     <!-- Main Content -->
     <main id="main-content" class="container mt-2 mb-3" role="main">
         <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
@@ -70,7 +132,7 @@
                 <i class="bi bi-exclamation-circle" aria-hidden="true"></i> Unsaved changes
             </span>
         </div>
-        
+
         <!-- Settings Form -->
         <form id="settings-form" aria-label="Application settings form">
             <div class="row">
@@ -98,7 +160,7 @@
                                         <i class="bi bi-info-circle"></i> Distance and temperature units used throughout the app
                                     </div>
                                 </div>
-                                
+
                                 <div class="mb-3">
                                     <label for="default-view" class="form-label fw-bold">
                                         Default View
@@ -112,7 +174,7 @@
                                         <i class="bi bi-info-circle"></i> Page to show when you open the app
                                     </div>
                                 </div>
-                                
+
                                 <div class="mb-0">
                                     <label class="form-label fw-bold d-block mb-2">Display Options</label>
                                     <div class="form-check mb-2">
@@ -121,16 +183,10 @@
                                             Show detailed weather information
                                         </label>
                                     </div>
-                                    <div class="form-check mb-2">
+                                    <div class="form-check">
                                         <input class="form-check-input" type="checkbox" id="show-elevation" checked>
                                         <label class="form-check-label" for="show-elevation">
                                             Show elevation data
-                                        </label>
-                                    </div>
-                                    <div class="form-check">
-                                        <input class="form-check-input" type="checkbox" id="auto-save" checked>
-                                        <label class="form-check-label" for="auto-save">
-                                            Auto-save preferences
                                         </label>
                                     </div>
                                 </div>
@@ -138,7 +194,7 @@
                         </div>
                     </div>
                 </div>
-            
+
                 <!-- Data Management -->
                 <div class="col-md-6 mb-4">
                     <div class="card h-100">
@@ -150,7 +206,7 @@
                         <div class="card-body">
                             <fieldset>
                                 <legend class="visually-hidden">Data management options</legend>
-                                
+
                                 <div class="mb-3">
                                     <label class="form-label fw-bold d-block mb-2">Export Data</label>
                                     <div class="d-grid gap-2">
@@ -165,16 +221,23 @@
                                         <i class="bi bi-info-circle"></i> Download your data as JSON files for backup
                                     </div>
                                 </div>
-                                
-                                <div class="mb-3">
+
+                                <div class="mb-0">
                                     <label for="import-file" class="form-label fw-bold">Import Data</label>
                                     <input type="file" class="form-control" id="import-file" accept=".json" aria-describedby="import-file-help">
                                     <div id="import-file-help" class="form-text">
                                         <i class="bi bi-info-circle"></i> Import previously exported JSON files
                                     </div>
                                 </div>
-                                
-                                <div class="mb-0">
+
+                                <hr>
+
+                                <button type="button" class="btn btn-outline-danger btn-sm danger-zone-toggle" id="danger-zone-toggle"
+                                        data-bs-toggle="collapse" data-bs-target="#danger-zone-body"
+                                        aria-expanded="false" aria-controls="danger-zone-body">
+                                    <i class="bi bi-exclamation-triangle" aria-hidden="true"></i> Show Danger Zone
+                                </button>
+                                <div class="collapse danger-zone-body" id="danger-zone-body">
                                     <label class="form-label fw-bold d-block mb-2 text-danger">
                                         <i class="bi bi-exclamation-triangle"></i> Danger Zone
                                     </label>
@@ -195,265 +258,330 @@
                     </div>
                 </div>
             </div>
-        
-            <!-- Connections -->
-            <div class="row mb-4">
+
+            <!-- Strava -->
+            <div class="row mb-3">
                 <div class="col-12">
                     <div class="card">
-                        <div class="card-header bg-primary text-white">
-                            <h2 class="h5 mb-0">
-                                <i class="bi bi-plug" aria-hidden="true"></i> Connections
-                            </h2>
-                        </div>
-                        <div class="card-body">
-
-                            <!-- Strava -->
-                            <h3 class="h6 fw-bold mb-2"><i class="bi bi-arrow-repeat me-1" aria-hidden="true"></i>Strava</h3>
-                            <div class="mb-3 d-flex align-items-center gap-3 flex-wrap">
-                                <div id="strava-connection-status">
+                        <button type="button" class="card-header bg-primary text-white card-header-btn" id="strava-card-toggle"
+                                data-bs-toggle="collapse" data-bs-target="#strava-card-body"
+                                aria-expanded="false" aria-controls="strava-card-body">
+                            <span class="h5 mb-0"><i class="bi bi-arrow-repeat me-1" aria-hidden="true"></i> Strava</span>
+                            <span class="d-flex align-items-center gap-2">
+                                <span id="strava-connection-status" class="card-header-status">
                                     <span class="text-muted small"><i class="bi bi-hourglass-split"></i> Checking Strava…</span>
-                                </div>
-                                <a href="/api/strava/connect" class="btn btn-sm btn-outline-primary" id="strava-connect-btn" style="display:none">
-                                    <i class="bi bi-link-45deg"></i> Connect to Strava
-                                </a>
-                                <button type="button" class="btn btn-sm btn-outline-danger" id="strava-disconnect-btn" style="display:none">
-                                    <i class="bi bi-x-lg" aria-hidden="true"></i> Disconnect
-                                </button>
-                            </div>
+                                </span>
+                                <i class="bi bi-chevron-down chevron" aria-hidden="true"></i>
+                            </span>
+                        </button>
+                        <div class="collapse" id="strava-card-body">
+                            <div class="card-body">
 
-                            <div id="cache-info" class="mb-3">
-                                <span class="text-muted small"><i class="bi bi-hourglass-split"></i> Loading cache info…</span>
-                            </div>
-
-                            <!-- Strava Sync section -->
-                            <div class="mb-3">
-                                <label class="form-label fw-bold d-block mb-1">Sync from Strava</label>
-                                <p class="small text-muted mb-2">Fetch activities from Strava and merge into local cache. Runs independently — you can sync while analysis is running.</p>
-
-                                <div class="mb-2">
-                                    <p class="small fw-semibold text-body-secondary mb-1">How far back to fetch</p>
-                                    <div class="d-flex flex-wrap gap-1 mb-1">
-                                        <button type="button" class="btn btn-sm btn-outline-secondary fetch-preset active" data-preset="latest">Latest</button>
-                                        <button type="button" class="btn btn-sm btn-outline-secondary fetch-preset" data-preset="1yr" id="preset-1yr">+1 year back</button>
-                                        <button type="button" class="btn btn-sm btn-outline-secondary fetch-preset" data-preset="2yr" id="preset-2yr">+2 years back</button>
-                                        <button type="button" class="btn btn-sm btn-outline-secondary fetch-preset" data-preset="alltime">All time</button>
-                                        <button type="button" class="btn btn-sm btn-outline-secondary fetch-preset" data-preset="custom">Custom…</button>
-                                    </div>
-                                    <div id="custom-date-fields" class="d-flex flex-wrap gap-2 align-items-end mt-2" style="display:none">
-                                        <div>
-                                            <label class="form-label small mb-0" for="fetch-after">From</label>
-                                            <input type="date" class="form-control form-control-sm" id="fetch-after">
-                                        </div>
-                                        <div>
-                                            <label class="form-label small mb-0" for="fetch-before">To (optional)</label>
-                                            <input type="date" class="form-control form-control-sm" id="fetch-before">
-                                        </div>
-                                    </div>
-                                    <p id="date-preset-hint" class="small text-muted mb-0 mt-1"></p>
+                                <div class="mb-3 d-flex align-items-center gap-3 flex-wrap">
+                                    <a href="/api/strava/connect" class="btn btn-sm btn-outline-primary" id="strava-connect-btn" style="display:none">
+                                        <i class="bi bi-link-45deg"></i> Connect to Strava
+                                    </a>
+                                    <button type="button" class="btn btn-sm btn-outline-danger" id="strava-disconnect-btn" style="display:none">
+                                        <i class="bi bi-x-lg" aria-hidden="true"></i> Disconnect
+                                    </button>
                                 </div>
 
-                                <button type="button" class="btn btn-primary" id="fetch-btn">
-                                    <i class="bi bi-cloud-download" aria-hidden="true"></i> Fetch Activities
-                                </button>
+                                <div id="cache-info" class="mb-3">
+                                    <span class="text-muted small"><i class="bi bi-hourglass-split"></i> Loading cache info…</span>
+                                </div>
 
-                                <!-- Fetch progress -->
-                                <div id="fetch-progress" class="mt-2" style="display:none">
+                                <!-- Gear admin (moved from Reports — #369b) -->
+                                <div class="mb-3 d-flex flex-wrap gap-2 align-items-center">
+                                    <span class="small fw-semibold text-body-secondary">Gear:</span>
+                                    <span id="gear-cache-status-settings" class="text-muted small"></span>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" id="sync-gear-btn" title="Fetch gear names from Strava">
+                                        <i class="bi bi-arrow-clockwise" aria-hidden="true"></i> Sync Gear
+                                    </button>
+                                    <button type="button" class="btn btn-outline-secondary btn-sm" id="repair-gear-btn" title="Patch gear IDs on cached activities without re-fetching everything">
+                                        <i class="bi bi-patch-check" aria-hidden="true"></i> Repair Gear Names
+                                    </button>
+                                </div>
+                                <div id="gear-admin-feedback" class="mb-2" style="display:none"></div>
+
+                                <!-- Strava Sync section -->
+                                <div class="mb-3">
+                                    <label class="form-label fw-bold d-block mb-1">Sync from Strava</label>
+                                    <p class="workflow-explainer mb-2">
+                                        Fetching downloads activities into your local cache — it doesn't analyze them.
+                                        Run Step 1 to fetch, then Step 2 to group the cached activities into routes.
+                                    </p>
+
+                                    <div class="mb-2">
+                                        <p class="small fw-semibold text-body-secondary mb-1">How far back to fetch</p>
+                                        <div class="d-flex flex-wrap gap-1 mb-1">
+                                            <button type="button" class="btn btn-sm btn-outline-secondary fetch-preset active" data-preset="latest">Latest</button>
+                                            <button type="button" class="btn btn-sm btn-outline-secondary fetch-preset" data-preset="1yr" id="preset-1yr">+1 year back</button>
+                                            <button type="button" class="btn btn-sm btn-outline-secondary fetch-preset" data-preset="2yr" id="preset-2yr">+2 years back</button>
+                                            <button type="button" class="btn btn-sm btn-outline-secondary fetch-preset" data-preset="alltime">All time</button>
+                                            <button type="button" class="btn btn-sm btn-outline-secondary fetch-preset" data-preset="custom"
+                                                    aria-expanded="false" aria-controls="custom-date-fields">Custom…</button>
+                                        </div>
+                                        <div id="custom-date-fields" class="d-flex flex-wrap gap-2 align-items-end mt-2" style="display:none">
+                                            <div>
+                                                <label class="form-label small mb-0" for="fetch-after">From</label>
+                                                <input type="date" class="form-control form-control-sm" id="fetch-after">
+                                            </div>
+                                            <div>
+                                                <label class="form-label small mb-0" for="fetch-before">To (optional)</label>
+                                                <input type="date" class="form-control form-control-sm" id="fetch-before">
+                                            </div>
+                                        </div>
+                                        <p id="date-preset-hint" class="small text-muted mb-0 mt-1"></p>
+                                    </div>
+
+                                    <button type="button" class="btn btn-primary" id="fetch-btn">
+                                        <span class="step-badge">Step 1:</span> <i class="bi bi-cloud-download" aria-hidden="true"></i> Fetch Activities
+                                    </button>
+
+                                    <!-- Fetch progress -->
+                                    <div id="fetch-progress" class="mt-2" style="display:none">
+                                        <div class="d-flex align-items-center gap-2 mb-1">
+                                            <span class="spinner-border spinner-border-sm text-primary flex-shrink-0"
+                                                  id="fetch-spinner" role="status" aria-hidden="true"></span>
+                                            <span id="fetch-status" class="small fw-medium text-body"></span>
+                                        </div>
+                                        <div class="progress progress-xs">
+                                            <div class="progress-bar progress-bar-striped progress-bar-animated bg-primary"
+                                                 role="progressbar" style="width:100%"></div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <hr class="my-3">
+
+                                <!-- Analysis section -->
+                                <div class="mb-3">
+                                    <label class="form-label fw-bold d-block mb-1">Run Analysis</label>
+                                    <p class="small text-muted mb-2">Re-run route grouping on cached activities.</p>
+                                </div>
+
+                                <div>
+                                    <button type="button" class="btn btn-success" id="run-analysis-btn">
+                                        <span class="step-badge">Step 2:</span> <i class="bi bi-play-fill" aria-hidden="true"></i> Run Analysis
+                                    </button>
+                                </div>
+
+                                <!-- Progress panel (hidden until analysis starts) -->
+                                <div id="analysis-progress" class="mt-3" style="display:none">
                                     <div class="d-flex align-items-center gap-2 mb-1">
-                                        <span class="spinner-border spinner-border-sm text-primary flex-shrink-0"
-                                              id="fetch-spinner" role="status" aria-hidden="true"></span>
-                                        <span id="fetch-status" class="small fw-medium text-body"></span>
+                                        <span class="spinner-border spinner-border-sm text-success flex-shrink-0"
+                                              id="analysis-spinner" role="status" aria-hidden="true"></span>
+                                        <span id="analysis-status" class="small fw-medium text-body"></span>
                                     </div>
-                                    <div class="progress progress-xs">
-                                        <div class="progress-bar progress-bar-striped progress-bar-animated bg-primary"
-                                             role="progressbar" style="width:100%"></div>
+                                    <div class="progress progress-xs mb-2">
+                                        <div class="progress-bar progress-bar-striped progress-bar-animated bg-success"
+                                             id="analysis-progress-bar" role="progressbar" style="width:100%"
+                                             aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
+                                    </div>
+                                    <div id="preview-ready-msg" class="small text-success" style="display:none">
+                                        <i class="bi bi-check-circle-fill me-1" aria-hidden="true"></i>
+                                        Preview ready —
+                                        <a href="/routes.html" class="text-success fw-medium">view routes →</a>
                                     </div>
                                 </div>
+
                             </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
 
-                            <hr class="my-3">
-
-                            <!-- Analysis section -->
-                            <div class="mb-3">
-                                <label class="form-label fw-bold d-block mb-1">Run Analysis</label>
-                                <p class="small text-muted mb-2">Re-run route grouping on cached activities.</p>
-                            </div>
-
-                            <div>
-                                <button type="button" class="btn btn-success" id="run-analysis-btn">
-                                    <i class="bi bi-play-fill" aria-hidden="true"></i> Run Analysis
-                                </button>
-                            </div>
-
-                            <!-- Progress panel (hidden until analysis starts) -->
-                            <div id="analysis-progress" class="mt-3" style="display:none">
-                                <div class="d-flex align-items-center gap-2 mb-1">
-                                    <span class="spinner-border spinner-border-sm text-success flex-shrink-0"
-                                          id="analysis-spinner" role="status" aria-hidden="true"></span>
-                                    <span id="analysis-status" class="small fw-medium text-body"></span>
-                                </div>
-                                <div class="progress progress-xs mb-2">
-                                    <div class="progress-bar progress-bar-striped progress-bar-animated bg-success"
-                                         id="analysis-progress-bar" role="progressbar" style="width:100%"
-                                         aria-valuenow="100" aria-valuemin="0" aria-valuemax="100"></div>
-                                </div>
-                                <div id="preview-ready-msg" class="small text-success" style="display:none">
-                                    <i class="bi bi-check-circle-fill me-1" aria-hidden="true"></i>
-                                    Preview ready —
-                                    <a href="/routes.html" class="text-success fw-medium">view routes →</a>
-                                </div>
-                            </div>
-
-                            <hr class="my-4">
-
-                            <!-- intervals.icu -->
-                            <h3 class="h6 fw-bold mb-2"><i class="bi bi-activity me-1" aria-hidden="true"></i>intervals.icu</h3>
-                            <div class="mb-3 d-flex align-items-center gap-3 flex-wrap">
-                                <div id="icu-connection-status">
+            <!-- intervals.icu -->
+            <div class="row mb-3">
+                <div class="col-12">
+                    <div class="card">
+                        <button type="button" class="card-header bg-primary text-white card-header-btn" id="icu-card-toggle"
+                                data-bs-toggle="collapse" data-bs-target="#icu-card-body"
+                                aria-expanded="false" aria-controls="icu-card-body">
+                            <span class="h5 mb-0"><i class="bi bi-activity me-1" aria-hidden="true"></i> intervals.icu</span>
+                            <span class="d-flex align-items-center gap-2">
+                                <span id="icu-connection-status" class="card-header-status">
                                     <span class="text-muted small"><i class="bi bi-hourglass-split"></i> Checking intervals.icu…</span>
-                                </div>
-                                <button type="button" class="btn btn-sm btn-outline-danger" id="icu-disconnect-btn" style="display:none">
-                                    <i class="bi bi-x-lg" aria-hidden="true"></i> Disconnect
-                                </button>
-                            </div>
-
-                            <p class="small text-muted mb-3">
-                                Connect intervals.icu to enable direct links from each activity to its intervals.icu page.
-                            </p>
-
-                            <div class="row g-3">
-                                <div class="col-md-4">
-                                    <label class="form-label fw-bold" for="icu-athlete-id">Athlete ID</label>
-                                    <input type="text" class="form-control" id="icu-athlete-id" placeholder="e.g. i12345"
-                                           autocomplete="off" spellcheck="false">
-                                    <div class="form-text">
-                                        Find it at intervals.icu → Settings → <strong>API</strong> — listed as "Athlete id".
-                                    </div>
-                                </div>
-                                <div class="col-md-5">
-                                    <label class="form-label fw-bold" for="icu-api-key">API Key</label>
-                                    <input type="password" class="form-control" id="icu-api-key" placeholder="your API key"
-                                           autocomplete="new-password" spellcheck="false">
-                                    <div class="form-text">
-                                        Find it at intervals.icu → Settings → <strong>API</strong> — copy the key shown there.
-                                    </div>
-                                </div>
-                                <div class="col-md-3 d-flex align-items-end">
-                                    <button type="button" class="btn btn-primary w-100" id="icu-connect-btn">
-                                        <i class="bi bi-link-45deg" aria-hidden="true"></i> Connect
+                                </span>
+                                <i class="bi bi-chevron-down chevron" aria-hidden="true"></i>
+                            </span>
+                        </button>
+                        <div class="collapse" id="icu-card-body">
+                            <div class="card-body">
+                                <div class="mb-3 d-flex align-items-center gap-3 flex-wrap">
+                                    <button type="button" class="btn btn-sm btn-outline-danger" id="icu-disconnect-btn" style="display:none">
+                                        <i class="bi bi-x-lg" aria-hidden="true"></i> Disconnect
                                     </button>
                                 </div>
-                            </div>
-                            <div id="icu-connect-feedback" class="mt-2" style="display:none"></div>
 
-                            <hr class="my-3">
+                                <p class="small text-muted mb-3">
+                                    Connect intervals.icu to enable direct links from each activity to its intervals.icu page.
+                                </p>
 
-                            <!-- OpenRouteService -->
-                            <h3 class="h6 fw-bold mb-2"><i class="bi bi-signpost-split me-1" aria-hidden="true"></i>OpenRouteService (Road Routing)</h3>
-                            <div class="mb-3 d-flex align-items-center gap-3 flex-wrap">
-                                <div id="ors-connection-status">
-                                    <span class="text-muted small"><i class="bi bi-hourglass-split"></i> Checking…</span>
-                                </div>
-                                <button type="button" class="btn btn-sm btn-outline-danger" id="ors-disconnect-btn" style="display:none">
-                                    <i class="bi bi-x-lg" aria-hidden="true"></i> Disconnect
-                                </button>
-                            </div>
-
-                            <p class="small text-muted mb-3">
-                                Required for the Explore page's "Plot road route" feature. Get a free key at
-                                <a href="https://openrouteservice.org/dev/#/signup" target="_blank" rel="noopener">openrouteservice.org</a>
-                                (free tier: 2,000 req/day). Paste the token from your ORS dashboard below.
-                            </p>
-
-                            <div class="row g-3">
-                                <div class="col-md-9">
-                                    <label class="form-label fw-bold" for="ors-api-key">API Key</label>
-                                    <input type="password" class="form-control" id="ors-api-key"
-                                           placeholder="your ORS API key"
-                                           autocomplete="new-password" spellcheck="false">
-                                    <div class="form-text">
-                                        Sign in to openrouteservice.org → Dashboard → <strong>API Keys</strong> — copy the token shown there.
-                                    </div>
-                                </div>
-                                <div class="col-md-3 d-flex align-items-end">
-                                    <button type="button" class="btn btn-primary w-100" id="ors-save-btn">
-                                        <i class="bi bi-floppy" aria-hidden="true"></i> Save
-                                    </button>
-                                </div>
-                            </div>
-                            <div id="ors-save-feedback" class="mt-2" style="display:none"></div>
-
-                            <hr class="my-3">
-
-                            <!-- Garmin Connect -->
-                            <h3 class="h6 fw-bold mb-2"><i class="bi bi-smartwatch me-1" aria-hidden="true"></i>Garmin Connect</h3>
-                            <div class="mb-3 d-flex align-items-center gap-3 flex-wrap">
-                                <div id="garmin-connection-status">
-                                    <span class="text-muted small"><i class="bi bi-hourglass-split"></i> Checking Garmin…</span>
-                                </div>
-                            </div>
-
-                            <p class="small text-muted mb-3">
-                                Import cycling activities from Garmin Connect as a secondary data source alongside Strava.
-                            </p>
-
-                            <div id="garmin-connect-form">
                                 <div class="row g-3">
                                     <div class="col-md-4">
-                                        <label class="form-label fw-bold" for="garmin-email">Email</label>
-                                        <input type="email" class="form-control" id="garmin-email" placeholder="you@example.com"
-                                               autocomplete="email" spellcheck="false">
+                                        <label class="form-label fw-bold" for="icu-athlete-id">Athlete ID</label>
+                                        <input type="text" class="form-control" id="icu-athlete-id" placeholder="e.g. i12345"
+                                               autocomplete="off" spellcheck="false">
+                                        <div class="form-text">
+                                            Find it at intervals.icu → Settings → <strong>API</strong> — listed as "Athlete id".
+                                        </div>
                                     </div>
                                     <div class="col-md-5">
-                                        <label class="form-label fw-bold" for="garmin-password">Password</label>
-                                        <input type="password" class="form-control" id="garmin-password" placeholder="Garmin password"
-                                               autocomplete="new-password">
+                                        <label class="form-label fw-bold" for="icu-api-key">API Key</label>
+                                        <input type="password" class="form-control" id="icu-api-key" placeholder="your API key"
+                                               autocomplete="new-password" spellcheck="false">
+                                        <div class="form-text">
+                                            Find it at intervals.icu → Settings → <strong>API</strong> — copy the key shown there.
+                                        </div>
                                     </div>
                                     <div class="col-md-3 d-flex align-items-end">
-                                        <button type="button" class="btn btn-primary w-100" id="garmin-connect-btn">
+                                        <button type="button" class="btn btn-primary w-100" id="icu-connect-btn">
                                             <i class="bi bi-link-45deg" aria-hidden="true"></i> Connect
                                         </button>
                                     </div>
                                 </div>
-                                <div id="garmin-connect-feedback" class="mt-2" style="display:none"></div>
+                                <div id="icu-connect-feedback" class="mt-2" style="display:none"></div>
                             </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
 
-                            <div id="garmin-connected-state" style="display:none">
-                                <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
-                                    <span class="badge bg-success"><i class="bi bi-check-circle"></i> Connected</span>
-                                    <span class="text-muted small" id="garmin-display-name"></span>
-                                </div>
-                                <div class="d-flex gap-2 flex-wrap">
-                                    <button type="button" class="btn btn-sm btn-outline-primary" id="garmin-sync-btn">
-                                        <i class="bi bi-arrow-repeat" aria-hidden="true"></i> Sync Activities
-                                    </button>
-                                    <button type="button" class="btn btn-sm btn-outline-danger" id="garmin-disconnect-btn">
+            <!-- OpenRouteService -->
+            <div class="row mb-3">
+                <div class="col-12">
+                    <div class="card">
+                        <button type="button" class="card-header bg-primary text-white card-header-btn" id="ors-card-toggle"
+                                data-bs-toggle="collapse" data-bs-target="#ors-card-body"
+                                aria-expanded="false" aria-controls="ors-card-body">
+                            <span class="h5 mb-0"><i class="bi bi-signpost-split me-1" aria-hidden="true"></i> OpenRouteService</span>
+                            <span class="d-flex align-items-center gap-2">
+                                <span id="ors-connection-status" class="card-header-status">
+                                    <span class="text-muted small"><i class="bi bi-hourglass-split"></i> Checking…</span>
+                                </span>
+                                <i class="bi bi-chevron-down chevron" aria-hidden="true"></i>
+                            </span>
+                        </button>
+                        <div class="collapse" id="ors-card-body">
+                            <div class="card-body">
+                                <div class="mb-3 d-flex align-items-center gap-3 flex-wrap">
+                                    <button type="button" class="btn btn-sm btn-outline-danger" id="ors-disconnect-btn" style="display:none">
                                         <i class="bi bi-x-lg" aria-hidden="true"></i> Disconnect
                                     </button>
                                 </div>
-                                <div id="garmin-sync-feedback" class="mt-2" style="display:none"></div>
-                            </div>
 
-                            <hr class="my-3">
+                                <p class="small text-muted mb-3">
+                                    Required for the Explore page's "Plot road route" feature. Get a free key at
+                                    <a href="https://openrouteservice.org/dev/#/signup" target="_blank" rel="noopener">openrouteservice.org</a>
+                                    (free tier: 2,000 req/day). Paste the token from your ORS dashboard below.
+                                </p>
 
-                            <!-- TrainerRoad -->
-                            <div class="d-flex align-items-start gap-2"
-                                 style="cursor:pointer"
-                                 data-bs-toggle="collapse" data-bs-target="#trainerroad-section"
-                                 aria-expanded="false" aria-controls="trainerroad-section"
-                                 role="button">
-                                <i class="bi bi-chevron-right tr-chevron" aria-hidden="true"></i>
-                                <div class="flex-grow-1">
-                                    <h3 class="h6 fw-bold mb-0">
-                                        <i class="bi bi-calendar-week me-1" aria-hidden="true"></i>TrainerRoad Calendar
-                                    </h3>
-                                    <p class="small text-muted mb-0">Sync structured workouts from your TrainerRoad plan</p>
+                                <div class="row g-3">
+                                    <div class="col-md-9">
+                                        <label class="form-label fw-bold" for="ors-api-key">API Key</label>
+                                        <input type="password" class="form-control" id="ors-api-key"
+                                               placeholder="your ORS API key"
+                                               autocomplete="new-password" spellcheck="false">
+                                        <div class="form-text">
+                                            Sign in to openrouteservice.org → Dashboard → <strong>API Keys</strong> — copy the token shown there.
+                                        </div>
+                                    </div>
+                                    <div class="col-md-3 d-flex align-items-end">
+                                        <button type="button" class="btn btn-primary w-100" id="ors-save-btn">
+                                            <i class="bi bi-floppy" aria-hidden="true"></i> Save
+                                        </button>
+                                    </div>
                                 </div>
-                                <div id="tr-status-badge">
+                                <div id="ors-save-feedback" class="mt-2" style="display:none"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Garmin Connect -->
+            <div class="row mb-3">
+                <div class="col-12">
+                    <div class="card">
+                        <button type="button" class="card-header bg-primary text-white card-header-btn" id="garmin-card-toggle"
+                                data-bs-toggle="collapse" data-bs-target="#garmin-card-body"
+                                aria-expanded="false" aria-controls="garmin-card-body">
+                            <span class="h5 mb-0"><i class="bi bi-smartwatch me-1" aria-hidden="true"></i> Garmin Connect</span>
+                            <span class="d-flex align-items-center gap-2">
+                                <span id="garmin-connection-status" class="card-header-status">
+                                    <span class="text-muted small"><i class="bi bi-hourglass-split"></i> Checking Garmin…</span>
+                                </span>
+                                <i class="bi bi-chevron-down chevron" aria-hidden="true"></i>
+                            </span>
+                        </button>
+                        <div class="collapse" id="garmin-card-body">
+                            <div class="card-body">
+                                <p class="small text-muted mb-3">
+                                    Import cycling activities from Garmin Connect as a secondary data source alongside Strava.
+                                </p>
+
+                                <div id="garmin-connect-form">
+                                    <div class="row g-3">
+                                        <div class="col-md-4">
+                                            <label class="form-label fw-bold" for="garmin-email">Email</label>
+                                            <input type="email" class="form-control" id="garmin-email" placeholder="you@example.com"
+                                                   autocomplete="email" spellcheck="false">
+                                        </div>
+                                        <div class="col-md-5">
+                                            <label class="form-label fw-bold" for="garmin-password">Password</label>
+                                            <input type="password" class="form-control" id="garmin-password" placeholder="Garmin password"
+                                                   autocomplete="new-password">
+                                        </div>
+                                        <div class="col-md-3 d-flex align-items-end">
+                                            <button type="button" class="btn btn-primary w-100" id="garmin-connect-btn">
+                                                <i class="bi bi-link-45deg" aria-hidden="true"></i> Connect
+                                            </button>
+                                        </div>
+                                    </div>
+                                    <div id="garmin-connect-feedback" class="mt-2" style="display:none"></div>
+                                </div>
+
+                                <div id="garmin-connected-state" style="display:none">
+                                    <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+                                        <span class="badge bg-success"><i class="bi bi-check-circle"></i> Connected</span>
+                                        <span class="text-muted small" id="garmin-display-name"></span>
+                                    </div>
+                                    <div class="d-flex gap-2 flex-wrap">
+                                        <button type="button" class="btn btn-sm btn-outline-primary" id="garmin-sync-btn">
+                                            <i class="bi bi-arrow-repeat" aria-hidden="true"></i> Sync Activities
+                                        </button>
+                                        <button type="button" class="btn btn-sm btn-outline-danger" id="garmin-disconnect-btn">
+                                            <i class="bi bi-x-lg" aria-hidden="true"></i> Disconnect
+                                        </button>
+                                    </div>
+                                    <div id="garmin-sync-feedback" class="mt-2" style="display:none"></div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- TrainerRoad Calendar + nested Outdoor Workout Preferences (#368) -->
+            <div class="row mb-4">
+                <div class="col-12">
+                    <div class="card">
+                        <button type="button" class="card-header bg-primary text-white card-header-btn" id="tr-card-toggle"
+                                data-bs-toggle="collapse" data-bs-target="#tr-card-body"
+                                aria-expanded="false" aria-controls="tr-card-body">
+                            <span class="h5 mb-0"><i class="bi bi-calendar-week me-1" aria-hidden="true"></i> TrainerRoad Calendar</span>
+                            <span class="d-flex align-items-center gap-2">
+                                <span id="tr-status-badge" class="card-header-status">
                                     <span class="badge bg-secondary">Not connected</span>
-                                </div>
-                            </div>
+                                </span>
+                                <i class="bi bi-chevron-down chevron" aria-hidden="true"></i>
+                            </span>
+                        </button>
+                        <div class="collapse" id="tr-card-body">
+                            <div class="card-body">
+                                <p class="small text-muted mb-3">Sync structured workouts from your TrainerRoad plan</p>
 
-                            <div class="collapse mt-3" id="trainerroad-section">
                                 <!-- Connect form (shown when disconnected) -->
                                 <div id="tr-connect-form">
                                     <div class="row g-3">
@@ -497,58 +625,50 @@
                                     </div>
                                     <div id="tr-sync-feedback" class="mt-2" style="display:none"></div>
                                 </div>
-                            </div>
 
-                        </div>
-                    </div>
-                </div>
-            </div>
+                                <hr class="my-4">
 
-            <!-- Outdoor Workout Preferences (#338) -->
-            <div class="row mb-4">
-                <div class="col-12">
-                    <div class="card">
-                        <div class="card-header bg-primary text-white">
-                            <h2 class="h5 mb-0">
-                                <i class="bi bi-sun" aria-hidden="true"></i> Outdoor Workout Preferences
-                            </h2>
-                        </div>
-                        <div class="card-body">
-                            <p class="small text-muted mb-3">
-                                When a TrainerRoad workout is scheduled, these thresholds determine whether
-                                to recommend riding outdoors or on the trainer.
-                            </p>
-                            <div class="row g-3">
-                                <div class="col-md-6">
-                                    <label class="form-label fw-bold" for="outdoor-min-temp">
-                                        Minimum temperature for outdoor workouts
-                                    </label>
-                                    <div class="d-flex align-items-center gap-2">
-                                        <input type="range" class="form-range flex-grow-1"
-                                               id="outdoor-min-temp" min="0" max="80" step="5" value="40"
-                                               aria-describedby="outdoor-min-temp-value">
-                                        <span id="outdoor-min-temp-value" class="badge bg-secondary"
-                                              style="min-width: 48px">40°F</span>
-                                    </div>
-                                    <div class="form-text">
-                                        <i class="bi bi-info-circle" aria-hidden="true"></i>
-                                        Below this temperature, indoor trainer is recommended regardless of workout type.
-                                    </div>
-                                </div>
-                                <div class="col-md-6">
-                                    <label class="form-label fw-bold d-block">
-                                        Precipitation
-                                    </label>
-                                    <div class="form-check mt-2">
-                                        <input class="form-check-input" type="checkbox"
-                                               id="outdoor-allow-rain">
-                                        <label class="form-check-label" for="outdoor-allow-rain">
-                                            Allow outdoor workouts in light rain
+                                <!-- Outdoor Workout Preferences (#338), nested under TrainerRoad per #368 -->
+                                <h3 class="h6 fw-bold mb-2"><i class="bi bi-sun" aria-hidden="true"></i> Outdoor Workout Preferences</h3>
+                                <p class="small text-muted mb-2">
+                                    When a TrainerRoad workout is scheduled, these thresholds determine whether
+                                    to recommend riding outdoors or on the trainer.
+                                </p>
+                                <p class="small text-muted requires-tr-note" id="outdoor-prefs-requires-note" style="display:none">
+                                    <i class="bi bi-info-circle" aria-hidden="true"></i> Requires TrainerRoad — connect above to put these thresholds to use.
+                                </p>
+                                <div class="row g-3">
+                                    <div class="col-md-6">
+                                        <label class="form-label fw-bold" for="outdoor-min-temp">
+                                            Minimum temperature for outdoor workouts
                                         </label>
+                                        <div class="d-flex align-items-center gap-2">
+                                            <input type="range" class="form-range flex-grow-1"
+                                                   id="outdoor-min-temp" min="0" max="80" step="5" value="40"
+                                                   aria-describedby="outdoor-min-temp-value">
+                                            <span id="outdoor-min-temp-value" class="badge bg-secondary"
+                                                  style="min-width: 48px">40°F</span>
+                                        </div>
+                                        <div class="form-text">
+                                            <i class="bi bi-info-circle" aria-hidden="true"></i>
+                                            Below this temperature, indoor trainer is recommended regardless of workout type.
+                                        </div>
                                     </div>
-                                    <div class="form-text">
-                                        <i class="bi bi-info-circle" aria-hidden="true"></i>
-                                        When unchecked, any active precipitation triggers indoor recommendation.
+                                    <div class="col-md-6">
+                                        <label class="form-label fw-bold d-block">
+                                            Precipitation
+                                        </label>
+                                        <div class="form-check mt-2">
+                                            <input class="form-check-input" type="checkbox"
+                                                   id="outdoor-allow-rain">
+                                            <label class="form-check-label" for="outdoor-allow-rain">
+                                                Allow outdoor workouts in light rain
+                                            </label>
+                                        </div>
+                                        <div class="form-text">
+                                            <i class="bi bi-info-circle" aria-hidden="true"></i>
+                                            When unchecked, any active precipitation triggers indoor recommendation.
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -557,11 +677,31 @@
                 </div>
             </div>
 
-            <!-- About Section -->
-            <div class="row">
+            <!-- Form Actions (moved above About per #368) -->
+            <div class="row mt-2">
+                <div class="col-12">
+                    <div class="d-flex gap-2 flex-wrap align-items-center">
+                        <button type="submit" class="btn btn-cta btn-lg" id="save-settings">
+                            <i class="bi bi-check-circle" aria-hidden="true"></i> Save Settings
+                        </button>
+                        <button type="button" class="btn btn-outline-secondary btn-lg" id="reset-settings">
+                            <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Reset to Defaults
+                        </button>
+                        <div class="form-check ms-2 save-behavior-line">
+                            <input class="form-check-input" type="checkbox" id="auto-save" checked>
+                            <label class="form-check-label" for="auto-save">
+                                Auto-save preferences on change
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- About Section (moved to bottom per #368) -->
+            <div class="row mt-4">
                 <div class="col-12">
                     <div class="card">
-                        <div class="card-header bg-primary text-white">
+                        <div class="card-header about-card-header">
                             <h2 class="h5 mb-0">
                                 <i class="bi bi-info-circle" aria-hidden="true"></i> About
                             </h2>
@@ -591,23 +731,9 @@
                     </div>
                 </div>
             </div>
-            
-            <!-- Form Actions -->
-            <div class="row mt-4">
-                <div class="col-12">
-                    <div class="d-flex gap-2 flex-wrap align-items-center">
-                        <button type="submit" class="btn btn-primary btn-lg" id="save-settings">
-                            <i class="bi bi-check-circle" aria-hidden="true"></i> Save Settings
-                        </button>
-                        <button type="button" class="btn btn-outline-secondary btn-lg" id="reset-settings">
-                            <i class="bi bi-arrow-counterclockwise" aria-hidden="true"></i> Reset to Defaults
-                        </button>
-                    </div>
-                </div>
-            </div>
         </form>
     </main>
-    
+
     <!-- Bottom Navigation (Mobile) -->
     <div id="bottom-nav-more" class="bottom-nav-drawer collapse d-md-none" aria-label="More pages">
         <a class="bottom-nav-drawer-item" href="/explore.html">
@@ -643,17 +769,17 @@
             <span>More</span>
         </button>
     </nav>
-    
+
     <!-- Footer -->
     <footer class="mt-3">
         <div class="container text-center text-muted">
             <small>Ride Optimizer v0.17.0 - Smart Static Architecture</small>
         </div>
     </footer>
-    
+
     <!-- Scripts -->
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
-    
+
     <!-- Custom JavaScript -->
     <script src="/js/common.js"></script>
     <script src="/js/help-modal.js"></script>
@@ -661,6 +787,35 @@
     <script src="/js/api-client.js"></script>
 
     <script>
+        // Canonical temperature (always stored/sent as Fahrenheit) + current display unit for the
+        // outdoor-min-temp slider. See #375a.
+        let _outdoorMinTempF = 40;
+        let _isMetricTemp = false;
+
+        function fToC(f) { return Math.round((f - 32) * 5 / 9); }
+        function cToF(c) { return Math.round((c * 9 / 5) + 32); }
+
+        function setOutdoorTempSliderUnit(isMetric) {
+            const slider = document.getElementById('outdoor-min-temp');
+            const label = document.getElementById('outdoor-min-temp-value');
+            if (!slider || !label) return;
+            _isMetricTemp = isMetric;
+            if (isMetric) {
+                slider.min = -20;
+                slider.max = 30;
+                slider.step = 5;
+                const c = fToC(_outdoorMinTempF);
+                slider.value = Math.min(Math.max(c, -20), 30);
+                label.textContent = slider.value + '°C';
+            } else {
+                slider.min = 0;
+                slider.max = 80;
+                slider.step = 5;
+                slider.value = Math.min(Math.max(_outdoorMinTempF, 0), 80);
+                label.textContent = slider.value + '°F';
+            }
+        }
+
         // Initialize page
         document.addEventListener('DOMContentLoaded', function() {
             console.log('✓ Settings page initialized');
@@ -670,6 +825,8 @@
 
             // Setup event listeners
             setupEventListeners();
+            bindGearAdminControls();
+            setupDangerZoneToggle();
 
             // Load cache info and wire analysis button
             loadStravaStatus();
@@ -725,17 +882,17 @@
                 if (typeof showToast === 'function') showToast('Strava connection failed: ' + params.get('strava_error'), 'error');
                 history.replaceState({}, '', '/settings.html');
             }
-            
+
             // Setup form validation
             setupFormValidation();
         });
-        
+
         function setupFormValidation() {
             const form = document.getElementById('settings-form');
             if (form) {
                 form.addEventListener('submit', function(e) {
                     e.preventDefault();
-                    
+
                     // Validate form
                     if (form.checkValidity()) {
                         saveSettings();
@@ -748,7 +905,32 @@
                 });
             }
         }
-        
+
+        // Toggle collapse state + aria on a card-header-btn/collapse pair based on connected state
+        function setCardExpanded(toggleId, bodyId, expand) {
+            const toggleBtn = document.getElementById(toggleId);
+            const bodyEl = document.getElementById(bodyId);
+            if (!toggleBtn || !bodyEl || typeof bootstrap === 'undefined') return;
+            const collapse = bootstrap.Collapse.getOrCreateInstance(bodyEl, { toggle: false });
+            if (expand) {
+                collapse.show();
+            } else {
+                collapse.hide();
+            }
+        }
+
+        function setupDangerZoneToggle() {
+            const toggleBtn = document.getElementById('danger-zone-toggle');
+            const bodyEl = document.getElementById('danger-zone-body');
+            if (!toggleBtn || !bodyEl) return;
+            bodyEl.addEventListener('shown.bs.collapse', () => {
+                toggleBtn.innerHTML = '<i class="bi bi-exclamation-triangle" aria-hidden="true"></i> Hide Danger Zone';
+            });
+            bodyEl.addEventListener('hidden.bs.collapse', () => {
+                toggleBtn.innerHTML = '<i class="bi bi-exclamation-triangle" aria-hidden="true"></i> Show Danger Zone';
+            });
+        }
+
         function applySettingsToForm(settings) {
             if (settings.unit_system || settings.unitSystem) {
                 document.getElementById('unit-system').value = settings.unit_system || settings.unitSystem;
@@ -769,16 +951,16 @@
                     settings.auto_save !== undefined ? settings.auto_save : settings.autoSave;
             }
 
-            // Outdoor workout preferences
+            // Outdoor workout preferences — canonical value always stored/sent in Fahrenheit;
+            // only the displayed slider converts to Celsius when unit_system is metric (#375a).
             if (settings.outdoor_min_temp_f !== undefined) {
-                const slider = document.getElementById('outdoor-min-temp');
-                const label = document.getElementById('outdoor-min-temp-value');
-                slider.value = settings.outdoor_min_temp_f;
-                label.textContent = settings.outdoor_min_temp_f + '°F';
+                _outdoorMinTempF = settings.outdoor_min_temp_f;
             }
             if (settings.outdoor_allow_rain !== undefined) {
                 document.getElementById('outdoor-allow-rain').checked = settings.outdoor_allow_rain;
             }
+            const unitSystem = document.getElementById('unit-system').value;
+            setOutdoorTempSliderUnit(unitSystem === 'metric');
         }
 
         async function loadUserPreferences() {
@@ -795,28 +977,44 @@
             const local = JSON.parse(localStorage.getItem('rideOptimizerSettings') || '{}');
             applySettingsToForm(local);
         }
-        
+
         function setupEventListeners() {
             // Settings reset button (save is handled by form submit)
             document.getElementById('reset-settings').addEventListener('click', resetSettings);
 
-            // Outdoor temp slider live display
+            // Outdoor temp slider live display (unit-aware — #375a)
             const tempSlider = document.getElementById('outdoor-min-temp');
             const tempLabel = document.getElementById('outdoor-min-temp-value');
             if (tempSlider && tempLabel) {
                 tempSlider.addEventListener('input', function() {
-                    tempLabel.textContent = this.value + '°F';
+                    const val = Number(this.value);
+                    if (_isMetricTemp) {
+                        _outdoorMinTempF = cToF(val);
+                        tempLabel.textContent = val + '°C';
+                    } else {
+                        _outdoorMinTempF = val;
+                        tempLabel.textContent = val + '°F';
+                    }
                 });
             }
-            
+
+            // Keep the outdoor temp slider's display unit in sync if the user changes Unit System
+            // before saving.
+            const unitSelect = document.getElementById('unit-system');
+            if (unitSelect) {
+                unitSelect.addEventListener('change', function() {
+                    setOutdoorTempSliderUnit(this.value === 'metric');
+                });
+            }
+
             // Export buttons
             document.getElementById('export-preferences').addEventListener('click', exportPreferences);
             document.getElementById('export-favorites').addEventListener('click', exportFavorites);
-            
+
             // Clear buttons
             document.getElementById('clear-favorites').addEventListener('click', clearFavorites);
             document.getElementById('clear-all-data').addEventListener('click', clearAllData);
-            
+
             // Auto-save on settings change
             const settingsInputs = document.querySelectorAll('input, select');
             settingsInputs.forEach(input => {
@@ -832,15 +1030,15 @@
                 });
             });
         }
-        
+
         function markUnsavedChanges() {
             document.getElementById('unsaved-indicator').style.display = 'inline';
         }
-        
+
         function clearUnsavedChanges() {
             document.getElementById('unsaved-indicator').style.display = 'none';
         }
-        
+
         async function saveSettings() {
             const serverPayload = {
                 unit_system: document.getElementById('unit-system').value,
@@ -848,7 +1046,7 @@
                 show_weather_details: document.getElementById('show-weather-details').checked,
                 show_elevation: document.getElementById('show-elevation').checked,
                 auto_save: document.getElementById('auto-save').checked,
-                outdoor_min_temp_f: parseInt(document.getElementById('outdoor-min-temp').value, 10),
+                outdoor_min_temp_f: _outdoorMinTempF,
                 outdoor_allow_rain: document.getElementById('outdoor-allow-rain').checked,
             };
 
@@ -882,7 +1080,7 @@
                 setTimeout(() => { saveBtn.innerHTML = original; }, 2000);
             }
         }
-        
+
         async function resetSettings() {
             if (confirm('Are you sure you want to reset all settings to defaults?')) {
                 localStorage.removeItem('rideOptimizerSettings');
@@ -900,8 +1098,8 @@
                 document.getElementById('show-weather-details').checked = true;
                 document.getElementById('show-elevation').checked = true;
                 document.getElementById('auto-save').checked = true;
-                document.getElementById('outdoor-min-temp').value = 40;
-                document.getElementById('outdoor-min-temp-value').textContent = '40°F';
+                _outdoorMinTempF = 40;
+                setOutdoorTempSliderUnit(false);
                 document.getElementById('outdoor-allow-rain').checked = false;
 
                 clearUnsavedChanges();
@@ -913,47 +1111,47 @@
                 }
             }
         }
-        
+
         function exportPreferences() {
             const settings = JSON.parse(localStorage.getItem('rideOptimizerSettings') || '{}');
             const dataStr = JSON.stringify(settings, null, 2);
             const dataBlob = new Blob([dataStr], { type: 'application/json' });
             const url = URL.createObjectURL(dataBlob);
-            
+
             const link = document.createElement('a');
             link.href = url;
             link.download = `ride-optimizer-preferences-${new Date().toISOString().split('T')[0]}.json`;
             link.click();
-            
+
             URL.revokeObjectURL(url);
-            
+
             if (typeof showToast === 'function') {
                 showToast('Preferences exported successfully!', 'success');
             }
         }
-        
+
         function exportFavorites() {
             const favorites = JSON.parse(localStorage.getItem('favoriteRoutes') || '[]');
             const dataStr = JSON.stringify(favorites, null, 2);
             const dataBlob = new Blob([dataStr], { type: 'application/json' });
             const url = URL.createObjectURL(dataBlob);
-            
+
             const link = document.createElement('a');
             link.href = url;
             link.download = `ride-optimizer-favorites-${new Date().toISOString().split('T')[0]}.json`;
             link.click();
-            
+
             URL.revokeObjectURL(url);
-            
+
             if (typeof showToast === 'function') {
                 showToast('Favorites exported successfully!', 'success');
             }
         }
-        
+
         function clearFavorites() {
             if (confirm('Are you sure you want to clear all favorites? This cannot be undone.')) {
                 localStorage.removeItem('favoriteRoutes');
-                
+
                 if (typeof showToast === 'function') {
                     showToast('Favorites cleared', 'warning');
                 } else {
@@ -961,7 +1159,7 @@
                 }
             }
         }
-        
+
         function clearAllData() {
             if (confirm('Are you sure you want to clear ALL local data? This includes settings, favorites, and hidden routes. This cannot be undone.')) {
                 if (confirm('This is your last chance. Are you absolutely sure?')) {
@@ -987,7 +1185,7 @@
         function updateRunBtnLabel() {
             const btn = document.getElementById('run-analysis-btn');
             if (btn.disabled) return;
-            btn.innerHTML = '<i class="bi bi-play-fill" aria-hidden="true"></i> Run Analysis';
+            btn.innerHTML = '<span class="step-badge">Step 2:</span> <i class="bi bi-play-fill" aria-hidden="true"></i> Run Analysis';
             btn.onclick = null;
         }
 
@@ -997,8 +1195,10 @@
                     document.querySelectorAll('.fetch-preset').forEach(b => b.classList.remove('active'));
                     this.classList.add('active');
                     _currentFetchPreset = this.dataset.preset;
-                    document.getElementById('custom-date-fields').style.display =
-                        _currentFetchPreset === 'custom' ? '' : 'none';
+                    const isCustom = _currentFetchPreset === 'custom';
+                    document.getElementById('custom-date-fields').style.display = isCustom ? '' : 'none';
+                    const customBtn = document.querySelector('.fetch-preset[data-preset="custom"]');
+                    if (customBtn) customBtn.setAttribute('aria-expanded', isCustom ? 'true' : 'false');
                     updateDatePresetHint();
                 });
             });
@@ -1090,9 +1290,11 @@
                     statusEl.innerHTML = '<span class="badge bg-secondary"><i class="bi bi-x-circle"></i> Not connected</span>';
                     disconnectBtn.style.display = 'none';
                 }
+                setCardExpanded('icu-card-toggle', 'icu-card-body', !!s.connected);
             } catch (e) {
                 statusEl.innerHTML = '<span class="text-muted small">Not configured</span>';
                 disconnectBtn.style.display = 'none';
+                setCardExpanded('icu-card-toggle', 'icu-card-body', false);
             }
 
             disconnectBtn.addEventListener('click', async () => {
@@ -1160,12 +1362,14 @@
                     statusEl.innerHTML = '<span class="badge bg-success"><i class="bi bi-check-circle"></i> ORS configured</span>';
                     disconnectBtn.style.display = '';
                 } else {
-                    statusEl.innerHTML = '<span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle"></i> Not configured — road routing unavailable</span>';
+                    statusEl.innerHTML = '<span class="badge bg-warning text-dark"><i class="bi bi-exclamation-triangle"></i> Not configured</span>';
                     disconnectBtn.style.display = 'none';
                 }
+                setCardExpanded('ors-card-toggle', 'ors-card-body', !!s.configured);
             } catch (e) {
                 statusEl.innerHTML = '<span class="text-muted small">Status unknown</span>';
                 disconnectBtn.style.display = 'none';
+                setCardExpanded('ors-card-toggle', 'ors-card-body', false);
             }
 
             disconnectBtn.addEventListener('click', async () => {
@@ -1228,8 +1432,10 @@
             const statusEl = document.getElementById('garmin-connection-status');
             const connectForm = document.getElementById('garmin-connect-form');
             const connectedState = document.getElementById('garmin-connected-state');
+            let connected = false;
             try {
                 const s = await window.apiClient.fetch('/garmin/status');
+                connected = !!s.connected;
                 if (s.connected) {
                     statusEl.innerHTML = '<span class="badge bg-success"><i class="bi bi-check-circle"></i> Garmin connected</span>';
                     const nameEl = document.getElementById('garmin-display-name');
@@ -1244,6 +1450,7 @@
             } catch (e) {
                 statusEl.innerHTML = '<span class="text-muted small">Not configured</span>';
             }
+            setCardExpanded('garmin-card-toggle', 'garmin-card-body', connected);
 
             document.getElementById('garmin-connect-btn').addEventListener('click', async () => {
                 const btn = document.getElementById('garmin-connect-btn');
@@ -1344,9 +1551,12 @@
             const statusBadge = document.getElementById('tr-status-badge');
             const connectForm = document.getElementById('tr-connect-form');
             const connectedState = document.getElementById('tr-connected-state');
+            const requiresNote = document.getElementById('outdoor-prefs-requires-note');
+            let connected = false;
 
             try {
                 const s = await window.apiClient.getTrainerRoadStatus();
+                connected = !!s.connected;
                 if (s.connected) {
                     statusBadge.innerHTML = '<span class="badge bg-success"><i class="bi bi-check-circle"></i> Connected</span>';
                     connectForm.style.display = 'none';
@@ -1371,6 +1581,8 @@
             } catch (e) {
                 statusBadge.innerHTML = '<span class="text-muted small">Not configured</span>';
             }
+            setCardExpanded('tr-card-toggle', 'tr-card-body', connected);
+            if (requiresNote) requiresNote.style.display = connected ? 'none' : '';
 
             // Connect button
             document.getElementById('tr-connect-btn').addEventListener('click', async () => {
@@ -1485,8 +1697,10 @@
             const statusEl = document.getElementById('strava-connection-status');
             const connectBtn = document.getElementById('strava-connect-btn');
             const disconnectBtn = document.getElementById('strava-disconnect-btn');
+            let connected = false;
             try {
                 const s = await window.apiClient.getStravaStatus();
+                connected = !!s.connected;
                 if (s.connected) {
                     const exp = new Date(s.expires_at * 1000).toLocaleDateString();
                     statusEl.innerHTML = `<span class="badge bg-success"><i class="bi bi-check-circle"></i> Strava connected</span> <span class="text-muted small">token expires ${exp}</span>`;
@@ -1501,6 +1715,7 @@
             } catch (e) {
                 statusEl.innerHTML = '<span class="text-warning small"><i class="bi bi-exclamation-triangle"></i> Could not check Strava status</span>';
             }
+            setCardExpanded('strava-card-toggle', 'strava-card-body', connected);
 
             disconnectBtn.addEventListener('click', async () => {
                 if (!confirm('Disconnect Strava? This will remove your saved credentials and you will need to re-authenticate.')) return;
@@ -1561,7 +1776,7 @@
                 pollAnalysisStatus();
             } catch (e) {
                 btn.disabled = false;
-                btn.innerHTML = '<i class="bi bi-play-fill"></i> Run Analysis';
+                btn.innerHTML = '<span class="step-badge">Step 2:</span> <i class="bi bi-play-fill"></i> Run Analysis';
                 progressEl.style.display = 'none';
                 statusEl.textContent = 'Failed to start: ' + (e.message || 'Unknown error');
                 if (typeof showToast === 'function') showToast('Failed to start analysis', 'error');
@@ -1698,7 +1913,7 @@
                 pollFetchStatus();
             } catch (e) {
                 btn.disabled = false;
-                btn.innerHTML = '<i class="bi bi-cloud-download"></i> Fetch Activities';
+                btn.innerHTML = '<span class="step-badge">Step 1:</span> <i class="bi bi-cloud-download"></i> Fetch Activities';
                 progressEl.style.display = 'none';
                 if (typeof showToast === 'function') showToast('Failed to start fetch: ' + (e.message || 'Unknown error'), 'error');
             }
@@ -1719,19 +1934,111 @@
                         clearInterval(poll);
                         spinnerEl.style.display = 'none';
                         btn.disabled = false;
-                        btn.innerHTML = '<i class="bi bi-cloud-download"></i> Fetch Activities';
+                        btn.innerHTML = '<span class="step-badge">Step 1:</span> <i class="bi bi-cloud-download"></i> Fetch Activities';
                         if (typeof showToast === 'function') showToast(job.label || 'Fetch complete', 'success');
                         loadCacheInfo();
                     } else if (job.status === 'error') {
                         clearInterval(poll);
                         spinnerEl.style.display = 'none';
                         btn.disabled = false;
-                        btn.innerHTML = '<i class="bi bi-cloud-download"></i> Fetch Activities';
+                        btn.innerHTML = '<span class="step-badge">Step 1:</span> <i class="bi bi-cloud-download"></i> Fetch Activities';
                         statusEl.textContent = job.label || 'Fetch failed';
                         if (typeof showToast === 'function') showToast(job.label || 'Fetch failed', 'error');
                     }
                 } catch (_) {}
             }, 3000);
+        }
+
+        // ── Gear admin (moved from Reports — #369b) ──────────────
+
+        function bindGearAdminControls() {
+            const syncBtn = document.getElementById('sync-gear-btn');
+            const repairBtn = document.getElementById('repair-gear-btn');
+            if (!syncBtn || !repairBtn) return;
+
+            syncBtn.addEventListener('click', async () => {
+                const feedback = document.getElementById('gear-admin-feedback');
+                syncBtn.disabled = true;
+                syncBtn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Syncing…';
+                feedback.style.display = 'none';
+                try {
+                    const resp = await window.apiClient.fetch('/stats/refresh-gear', {
+                        method: 'POST',
+                        body: JSON.stringify({}),
+                    });
+                    if (resp.status === 'success') {
+                        feedback.style.display = '';
+                        feedback.innerHTML = `<span class="text-success small"><i class="bi bi-check-circle"></i> ${window.escapeHtml(resp.message || 'Gear synced')}</span>`;
+                        if (typeof showToast === 'function') showToast(resp.message || 'Gear synced', 'success');
+                    } else {
+                        feedback.style.display = '';
+                        feedback.innerHTML = `<span class="text-danger small"><i class="bi bi-x-circle"></i> ${window.escapeHtml(resp.message || 'Sync failed')}</span>`;
+                    }
+                } catch (e) {
+                    feedback.style.display = '';
+                    feedback.innerHTML = `<span class="text-danger small"><i class="bi bi-x-circle"></i> ${window.escapeHtml(e.message || 'Sync failed')}</span>`;
+                } finally {
+                    syncBtn.disabled = false;
+                    syncBtn.innerHTML = '<i class="bi bi-arrow-clockwise" aria-hidden="true"></i> Sync Gear';
+                }
+            });
+
+            repairBtn.addEventListener('click', startGearRepair);
+        }
+
+        let _gearRepairPollInterval = null;
+
+        async function startGearRepair() {
+            const btn = document.getElementById('repair-gear-btn');
+            const statusEl = document.getElementById('gear-cache-status-settings');
+            btn.disabled = true;
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Repairing…';
+
+            try {
+                const resp = await window.apiClient.fetch('/stats/backfill-gear-ids', {
+                    method: 'POST',
+                    body: JSON.stringify({}),
+                });
+                if (resp.status === 'started' || resp.status === 'already_running') {
+                    _gearRepairPollInterval = setInterval(pollGearRepair, 1500);
+                } else {
+                    if (typeof showToast === 'function') showToast(resp.message || 'Failed to start repair', 'error');
+                    resetGearRepairBtn();
+                }
+            } catch (e) {
+                if (typeof showToast === 'function') showToast(`Repair failed: ${e.message}`, 'error');
+                resetGearRepairBtn();
+            }
+        }
+
+        async function pollGearRepair() {
+            const statusEl = document.getElementById('gear-cache-status-settings');
+            try {
+                const resp = await window.apiClient.fetch('/stats/backfill-gear-ids/status');
+                if (resp.status === 'running') {
+                    statusEl.textContent = resp.label || 'Repairing…';
+                } else if (resp.status === 'done') {
+                    clearInterval(_gearRepairPollInterval);
+                    _gearRepairPollInterval = null;
+                    if (typeof showToast === 'function') showToast(resp.label || 'Gear names repaired', 'success');
+                    statusEl.textContent = '';
+                    resetGearRepairBtn();
+                } else if (resp.status === 'error') {
+                    clearInterval(_gearRepairPollInterval);
+                    _gearRepairPollInterval = null;
+                    if (typeof showToast === 'function') showToast(resp.label || 'Repair error', 'error');
+                    statusEl.textContent = '';
+                    resetGearRepairBtn();
+                }
+            } catch (e) {
+                // ignore transient poll errors
+            }
+        }
+
+        function resetGearRepairBtn() {
+            const btn = document.getElementById('repair-gear-btn');
+            btn.disabled = false;
+            btn.innerHTML = '<i class="bi bi-patch-check" aria-hidden="true"></i> Repair Gear Names';
         }
     </script>
 </body>

--- a/static/settings.html
+++ b/static/settings.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Settings - Ride Optimizer</title>
     
+    <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
@@ -17,10 +18,19 @@
     <a href="#main-content" class="skip-link">Skip to main content</a>
     
     <!-- Navigation -->
-    <nav class="navbar navbar-expand-lg navbar-dark navbar-gradient" role="navigation" aria-label="Main navigation">
+    <nav class="navbar navbar-expand-lg navbar-fairweather" role="navigation" aria-label="Main navigation">
         <div class="container">
             <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home">
-                <i class="bi bi-bicycle" aria-hidden="true"></i> Ride Optimizer
+                <svg class="brand-mark" viewBox="0 0 48 48" fill="none" aria-hidden="true" focusable="false">
+                    <circle cx="24" cy="24" r="12" stroke="currentColor" stroke-width="3.4"/>
+                    <g stroke="currentColor" stroke-width="3.4" stroke-linecap="round">
+                        <line x1="24" y1="2" x2="24" y2="8"/><line x1="24" y1="40" x2="24" y2="46"/>
+                        <line x1="2" y1="24" x2="8" y2="24"/><line x1="40" y1="24" x2="46" y2="24"/>
+                        <line x1="8.3" y1="8.3" x2="12.5" y2="12.5"/><line x1="35.5" y1="35.5" x2="39.7" y2="39.7"/>
+                        <line x1="39.7" y1="8.3" x2="35.5" y2="12.5"/><line x1="12.5" y1="35.5" x2="8.3" y2="39.7"/>
+                    </g>
+                </svg>
+                <span><span class="brand-ride">Ride</span>&nbsp;<span class="brand-optimizer">Optimizer</span></span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -560,7 +570,7 @@
                             <p class="lead"><strong>Ride Optimizer</strong> - Intelligent route recommendations based on weather, wind, and your riding history.</p>
                             <dl class="row mb-0">
                                 <dt class="col-md-3">Version:</dt>
-                                <dd class="col-md-9">0.14.0</dd>
+                                <dd class="col-md-9">0.17.0</dd>
 
                                 <dt class="col-md-3">Data Source:</dt>
                                 <dd class="col-md-9">Strava API</dd>
@@ -599,27 +609,43 @@
     </main>
     
     <!-- Bottom Navigation (Mobile) -->
+    <div id="bottom-nav-more" class="bottom-nav-drawer collapse d-md-none" aria-label="More pages">
+        <a class="bottom-nav-drawer-item" href="/explore.html">
+            <i class="bi bi-compass" aria-hidden="true"></i>
+            <span>Explore</span>
+        </a>
+        <a class="bottom-nav-drawer-item active" href="/settings.html" aria-current="page">
+            <i class="bi bi-gear" aria-hidden="true"></i>
+            <span>Settings</span>
+        </a>
+    </div>
     <nav id="bottom-nav" class="bottom-nav d-md-none" role="navigation" aria-label="Mobile navigation">
-        <button class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
+        <button type="button" class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
             <i class="bi bi-house-door" aria-hidden="true"></i>
             <span>Home</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Routes" onclick="window.location.href='/routes.html'">
+        <button type="button" class="bottom-nav-item" aria-label="Routes" onclick="window.location.href='/routes.html'">
             <i class="bi bi-map" aria-hidden="true"></i>
             <span>Routes</span>
         </button>
-        <button class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
+        <button type="button" class="bottom-nav-item" aria-label="Weather" onclick="window.location.href='/weather.html'">
             <i class="bi bi-cloud-sun" aria-hidden="true"></i>
             <span>Weather</span>
         </button>
-        <button class="bottom-nav-item active" aria-label="Settings" aria-current="page">
-            <i class="bi bi-gear" aria-hidden="true"></i>
-            <span>Settings</span>
+        <button type="button" class="bottom-nav-item" aria-label="Reports" onclick="window.location.href='/reports.html'">
+            <i class="bi bi-bar-chart-line" aria-hidden="true"></i>
+            <span>Reports</span>
+        </button>
+        <button type="button" class="bottom-nav-item active" aria-label="More pages"
+                data-bs-toggle="collapse" data-bs-target="#bottom-nav-more"
+                aria-expanded="false" aria-controls="bottom-nav-more">
+            <i class="bi bi-three-dots" aria-hidden="true"></i>
+            <span>More</span>
         </button>
     </nav>
     
     <!-- Footer -->
-    <footer class="mt-3 bg-light">
+    <footer class="mt-3">
         <div class="container text-center text-muted">
             <small>Ride Optimizer v0.17.0 - Smart Static Architecture</small>
         </div>

--- a/static/settings.html
+++ b/static/settings.html
@@ -48,6 +48,12 @@
         .danger-zone-toggle {
             min-height: 44px;
         }
+        .danger-zone-toggle .chevron {
+            transition: transform 0.2s;
+        }
+        .danger-zone-toggle[aria-expanded="true"] .chevron {
+            transform: rotate(180deg);
+        }
         .danger-zone-body {
             border: 1px solid var(--danger);
             border-radius: 10px;
@@ -235,7 +241,8 @@
                                 <button type="button" class="btn btn-outline-danger btn-sm danger-zone-toggle" id="danger-zone-toggle"
                                         data-bs-toggle="collapse" data-bs-target="#danger-zone-body"
                                         aria-expanded="false" aria-controls="danger-zone-body">
-                                    <i class="bi bi-exclamation-triangle" aria-hidden="true"></i> Show Danger Zone
+                                    <i class="bi bi-exclamation-triangle" aria-hidden="true"></i> <span class="danger-zone-toggle-label">Show Danger Zone</span>
+                                    <i class="bi bi-chevron-down ms-1 chevron" aria-hidden="true"></i>
                                 </button>
                                 <div class="collapse danger-zone-body" id="danger-zone-body">
                                     <label class="form-label fw-bold d-block mb-2 text-danger">
@@ -923,11 +930,12 @@
             const toggleBtn = document.getElementById('danger-zone-toggle');
             const bodyEl = document.getElementById('danger-zone-body');
             if (!toggleBtn || !bodyEl) return;
+            const label = toggleBtn.querySelector('.danger-zone-toggle-label');
             bodyEl.addEventListener('shown.bs.collapse', () => {
-                toggleBtn.innerHTML = '<i class="bi bi-exclamation-triangle" aria-hidden="true"></i> Hide Danger Zone';
+                if (label) label.textContent = 'Hide Danger Zone';
             });
             bodyEl.addEventListener('hidden.bs.collapse', () => {
-                toggleBtn.innerHTML = '<i class="bi bi-exclamation-triangle" aria-hidden="true"></i> Show Danger Zone';
+                if (label) label.textContent = 'Show Danger Zone';
             });
         }
 

--- a/static/setup.html
+++ b/static/setup.html
@@ -4,11 +4,12 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Setup — Ride Optimizer</title>
+    <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="/css/main.css">
     <style>
-        body { background: #f8f9fa; }
+        body { background: var(--bg); }
 
         .setup-container {
             max-width: 600px;
@@ -17,18 +18,18 @@
         }
 
         .wizard-header {
-            background: linear-gradient(135deg, #4a5fd5 0%, #764ba2 100%);
+            background: var(--accent); /* flat cobalt — Fair Weather, gradients retired */
             color: white;
-            border-radius: 8px 8px 0 0;
+            border-radius: 16px 16px 0 0;
             padding: var(--space-5);
             text-align: center;
         }
 
         .wizard-body {
-            background: white;
-            border: 1px solid #dee2e6;
+            background: var(--surface);
+            border: 1px solid var(--line);
             border-top: none;
-            border-radius: 0 0 8px 8px;
+            border-radius: 0 0 16px 16px;
             padding: var(--space-5);
         }
 
@@ -61,7 +62,7 @@
 
         .success-icon {
             font-size: 4rem;
-            color: #198754;
+            color: var(--success);
         }
     </style>
 </head>

--- a/static/weather.html
+++ b/static/weather.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Weather Forecast - Ride Optimizer</title>
+    <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.0/font/bootstrap-icons.css">
     <link rel="stylesheet" href="/css/main.css">
@@ -25,9 +26,9 @@
         }
 
         .forecast-card {
-            background: var(--surface-card, #fff);
-            border: 1px solid rgba(0,0,0,0.08);
-            border-radius: 8px;
+            background: var(--surface);
+            border: 1px solid var(--line);
+            border-radius: 16px;
             padding: var(--space-2);
             text-align: center;
             transition: box-shadow 0.2s;
@@ -36,17 +37,17 @@
             box-shadow: 0 4px 12px rgba(0,0,0,0.12);
         }
         .forecast-card.today {
-            border-color: #667eea;
+            border-color: var(--accent);
             border-width: 2px;
         }
         .forecast-day {
             font-size: var(--font-size-xs);
             font-weight: 600;
             text-transform: uppercase;
-            color: #6c757d;
+            color: var(--ink-soft);
         }
         .forecast-card.today .forecast-day {
-            color: #667eea;
+            color: var(--accent);
         }
         .forecast-icon {
             font-size: var(--font-size-lg);
@@ -79,9 +80,9 @@
         .comfort-pill.unfavorable { background: #fee2e2; color: #991b1b; }
 
         .commute-window-card {
-            border-radius: 8px;
+            border-radius: 16px;
             padding: var(--space-3);
-            border: 1px solid rgba(0,0,0,0.08);
+            border: 1px solid var(--line);
         }
         .commute-window-card.morning { border-left: 4px solid #f59e0b; }
         .commute-window-card.evening { border-left: 4px solid #6366f1; }
@@ -116,10 +117,19 @@
 <body>
     <a href="#main-content" class="skip-link">Skip to main content</a>
 
-    <nav class="navbar navbar-expand-lg navbar-dark navbar-gradient" role="navigation" aria-label="Main navigation">
+    <nav class="navbar navbar-expand-lg navbar-fairweather" role="navigation" aria-label="Main navigation">
         <div class="container">
             <a class="navbar-brand" href="/" aria-label="Ride Optimizer Home">
-                <i class="bi bi-bicycle" aria-hidden="true"></i> Ride Optimizer
+                <svg class="brand-mark" viewBox="0 0 48 48" fill="none" aria-hidden="true" focusable="false">
+                    <circle cx="24" cy="24" r="12" stroke="currentColor" stroke-width="3.4"/>
+                    <g stroke="currentColor" stroke-width="3.4" stroke-linecap="round">
+                        <line x1="24" y1="2" x2="24" y2="8"/><line x1="24" y1="40" x2="24" y2="46"/>
+                        <line x1="2" y1="24" x2="8" y2="24"/><line x1="40" y1="24" x2="46" y2="24"/>
+                        <line x1="8.3" y1="8.3" x2="12.5" y2="12.5"/><line x1="35.5" y1="35.5" x2="39.7" y2="39.7"/>
+                        <line x1="39.7" y1="8.3" x2="35.5" y2="12.5"/><line x1="12.5" y1="35.5" x2="8.3" y2="39.7"/>
+                    </g>
+                </svg>
+                <span><span class="brand-ride">Ride</span>&nbsp;<span class="brand-optimizer">Optimizer</span></span>
             </a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
@@ -230,28 +240,44 @@
         </div>
     </main>
 
-    <footer class="mt-3 bg-light">
+    <footer class="mt-3">
         <div class="container text-center text-muted">
             <small>Ride Optimizer v0.17.0 - Smart Static Architecture</small>
         </div>
     </footer>
 
+    <div id="bottom-nav-more" class="bottom-nav-drawer collapse d-md-none" aria-label="More pages">
+        <a class="bottom-nav-drawer-item" href="/explore.html">
+            <i class="bi bi-compass" aria-hidden="true"></i>
+            <span>Explore</span>
+        </a>
+        <a class="bottom-nav-drawer-item" href="/settings.html">
+            <i class="bi bi-gear" aria-hidden="true"></i>
+            <span>Settings</span>
+        </a>
+    </div>
     <nav id="bottom-nav" class="bottom-nav d-md-none" role="navigation" aria-label="Mobile navigation">
-        <button class="bottom-nav-item" onclick="window.location.href='/'" aria-label="Home">
+        <button type="button" class="bottom-nav-item" aria-label="Home" onclick="window.location.href='/'">
             <i class="bi bi-house-door" aria-hidden="true"></i>
             <span>Home</span>
         </button>
-        <button class="bottom-nav-item" onclick="window.location.href='/routes.html'" aria-label="Routes">
+        <button type="button" class="bottom-nav-item" aria-label="Routes" onclick="window.location.href='/routes.html'">
             <i class="bi bi-map" aria-hidden="true"></i>
             <span>Routes</span>
         </button>
-        <button class="bottom-nav-item active" aria-label="Weather" aria-current="page">
+        <button type="button" class="bottom-nav-item active" aria-label="Weather" aria-current="page" onclick="window.location.href='/weather.html'">
             <i class="bi bi-cloud-sun" aria-hidden="true"></i>
             <span>Weather</span>
         </button>
-        <button class="bottom-nav-item" onclick="window.location.href='/settings.html'" aria-label="Settings">
-            <i class="bi bi-gear" aria-hidden="true"></i>
-            <span>Settings</span>
+        <button type="button" class="bottom-nav-item" aria-label="Reports" onclick="window.location.href='/reports.html'">
+            <i class="bi bi-bar-chart-line" aria-hidden="true"></i>
+            <span>Reports</span>
+        </button>
+        <button type="button" class="bottom-nav-item" aria-label="More pages"
+                data-bs-toggle="collapse" data-bs-target="#bottom-nav-more"
+                aria-expanded="false" aria-controls="bottom-nav-more">
+            <i class="bi bi-three-dots" aria-hidden="true"></i>
+            <span>More</span>
         </button>
     </nav>
 

--- a/static/weather.html
+++ b/static/weather.html
@@ -161,7 +161,7 @@
 
     <main id="main-content" class="container mt-2" role="main">
         <div class="d-flex align-items-center mb-2">
-            <h2 class="mb-0"><i class="bi bi-cloud-sun me-2" aria-hidden="true"></i>Weather Forecast</h2>
+            <h1 class="fs-4 mb-0"><i class="bi bi-cloud-sun me-2" aria-hidden="true"></i>Weather Forecast</h1>
         </div>
 
         <!-- Transit alert — shown when today is unfavorable -->
@@ -179,6 +179,17 @@
             </div>
         </div>
 
+        <!-- Today at a Glance — shown when the transit alert is hidden (today is favorable) -->
+        <div id="today-glance" class="card mb-3 d-none">
+            <div class="card-body">
+                <div class="d-flex align-items-center gap-2 mb-2">
+                    <i class="bi bi-sun text-success fs-5" aria-hidden="true"></i>
+                    <strong>Today at a Glance</strong>
+                </div>
+                <div id="today-glance-content" class="d-flex flex-wrap gap-3"></div>
+            </div>
+        </div>
+
         <!-- Today's commute windows -->
         <div class="card mb-3">
             <div class="card-header">
@@ -190,7 +201,7 @@
                         <div id="morning-window" class="commute-window-card morning">
                             <div class="d-flex align-items-center gap-2 mb-2">
                                 <i class="bi bi-sunrise text-warning fs-5"></i>
-                                <strong>Morning (7–9 AM)</strong>
+                                <strong>Morning <span id="morning-time-range" class="fw-normal text-muted">(loading…)</span></strong>
                             </div>
                             <div id="morning-content">
                                 <div class="text-muted small">Loading…</div>
@@ -201,7 +212,7 @@
                         <div id="evening-window" class="commute-window-card evening">
                             <div class="d-flex align-items-center gap-2 mb-2">
                                 <i class="bi bi-sunset text-primary fs-5"></i>
-                                <strong>Evening (3–6 PM)</strong>
+                                <strong>Evening <span id="evening-time-range" class="fw-normal text-muted">(loading…)</span></strong>
                             </div>
                             <div id="evening-content">
                                 <div class="text-muted small">Loading…</div>
@@ -218,7 +229,16 @@
         <!-- 7-day forecast -->
         <div class="card mb-3">
             <div class="card-header d-flex justify-content-between align-items-center">
-                <span><i class="bi bi-calendar-week me-2"></i>7-Day Forecast</span>
+                <span>
+                    <i class="bi bi-calendar-week me-2"></i>7-Day Forecast
+                    <i id="comfort-legend-icon" class="bi bi-question-circle text-muted ms-1"
+                       style="cursor: pointer; font-size: 0.85em;"
+                       tabindex="0" role="button"
+                       aria-label="What does the comfort score and pill color mean?"
+                       data-bs-toggle="popover" data-bs-placement="bottom"
+                       data-bs-title="Comfort score"
+                       data-bs-content="Combines temperature, precipitation risk, and wind into a single 0–100 score. 70+ = favorable, 40–69 = neutral, below 40 = unfavorable."></i>
+                </span>
                 <small id="forecast-updated" class="text-muted"></small>
             </div>
             <div class="card-body">

--- a/static/weather.html
+++ b/static/weather.html
@@ -75,9 +75,9 @@
             text-transform: uppercase;
             letter-spacing: 0.02em;
         }
-        .comfort-pill.favorable { background: #d1fae5; color: #065f46; }
-        .comfort-pill.neutral   { background: #fef3c7; color: #92400e; }
-        .comfort-pill.unfavorable { background: #fee2e2; color: #991b1b; }
+        .comfort-pill.favorable { background: color-mix(in srgb, var(--success) 18%, transparent); color: var(--success); }
+        .comfort-pill.neutral   { background: color-mix(in srgb, var(--warning) 18%, transparent); color: var(--warning); }
+        .comfort-pill.unfavorable { background: color-mix(in srgb, var(--danger) 18%, transparent); color: var(--danger); }
 
         .commute-window-card {
             border-radius: 16px;

--- a/tests/test_exploration_service.py
+++ b/tests/test_exploration_service.py
@@ -150,6 +150,56 @@ class TestOrsClient:
         assert result is not None
         assert result.get("_ors_rate_limited") is True
 
+    def test_unroutable_waypoint_returns_sentinel_with_coords(self):
+        """ORS error 2010 returns _ors_unroutable list of (lon, lat) tuples."""
+        from src import ors_client
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.json.return_value = {
+            "error": {
+                "code": 2010,
+                "message": (
+                    "Could not find routable point within a radius of 350.0 meters of "
+                    "specified coordinate 1: -85.1439937 41.8041137."
+                ),
+            }
+        }
+
+        with patch("src.ors_client.requests.post", return_value=mock_response):
+            result = ors_client.get_route([[0, 0], [1, 1]], "cycling-regular", api_key="k")
+
+        assert result is not None
+        assert "_ors_unroutable" in result
+        assert len(result["_ors_unroutable"]) == 1
+        lon, lat = result["_ors_unroutable"][0]
+        assert abs(lon - (-85.1439937)) < 1e-4
+        assert abs(lat - 41.8041137) < 1e-4
+
+    def test_unroutable_multiple_waypoints(self):
+        """Multiple unroutable waypoints in one error message are all extracted."""
+        from src import ors_client
+
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.json.return_value = {
+            "error": {
+                "code": 2010,
+                "message": (
+                    "Could not find routable point within a radius of 350.0 meters of "
+                    "specified coordinate 0: -85.2979086 41.7549539.; "
+                    "Could not find routable point within a radius of 350.0 meters of "
+                    "specified coordinate 1: -85.1439937 41.8041137."
+                ),
+            }
+        }
+
+        with patch("src.ors_client.requests.post", return_value=mock_response):
+            result = ors_client.get_route([[0, 0], [1, 1]], "cycling-regular", api_key="k")
+
+        assert result is not None
+        assert len(result["_ors_unroutable"]) == 2
+
 
 # ── compute_route: no API key ────────────────────────────────────
 
@@ -200,6 +250,42 @@ class TestComputeRoute:
     def test_ors_failure_returns_error(self, service_with_key):
         with patch("src.ors_client.get_route", return_value=None):
             result = service_with_key.compute_route([[0, 0], [1, 1]])
+        assert result["status"] == "error"
+
+    def test_unroutable_interior_waypoint_is_dropped_and_retried(self, service_with_key):
+        """When an interior waypoint is unroutable, it is dropped and ORS is retried."""
+        good_raw = {
+            "features": [{
+                "geometry": {"coordinates": [[-87.65, 41.98], [-87.64, 41.99]]},
+                "properties": {
+                    "summary": {"distance": 5000.0, "duration": 900.0},
+                    "extras": {},
+                },
+            }],
+        }
+        # First call: interior waypoint [-85.14, 41.80] is unroutable.
+        # Second call (after drop): succeeds.
+        side_effects = [
+            {"_ors_unroutable": [(-85.1439937, 41.8041137)]},
+            good_raw,
+        ]
+        with patch("src.ors_client.get_route", side_effect=side_effects) as mock_ors:
+            result = service_with_key.compute_route([
+                [41.98, -87.65],            # start (routable)
+                [41.8041137, -85.1439937],  # interior (off-road)
+                [41.99, -87.64],            # end (routable)
+            ])
+
+        assert result["status"] == "success"
+        assert mock_ors.call_count == 2
+        # Second call must not include the bad interior waypoint.
+        second_coords = mock_ors.call_args_list[1][0][0]
+        assert len(second_coords) == 2  # only start + end
+
+    def test_unroutable_start_cannot_be_dropped(self, service_with_key):
+        """When the start (first) waypoint is unroutable, no retry is possible."""
+        with patch("src.ors_client.get_route", return_value={"_ors_unroutable": [(-87.65, 41.98)]}):
+            result = service_with_key.compute_route([[41.98, -87.65], [41.99, -87.64]])
         assert result["status"] == "error"
 
     def test_memoization_within_ttl(self, service_with_key):

--- a/tests/test_server_process_mgmt.py
+++ b/tests/test_server_process_mgmt.py
@@ -1,0 +1,251 @@
+"""
+Unit tests for launch.py server process-management helpers.
+
+Tests:
+  - _write_pid_file / _read_pid_file / _remove_pid_file
+  - _is_our_server_process (mocked via psutil)
+  - kill_existing_server  — PID-file path, port-scan fallback, stale-file cleanup
+  - server_status         — running, not-running, stale PID file
+  - stop_server           — happy path, nothing running, already-gone PID
+
+These are pure unit tests: no real Flask server is started.
+"""
+
+import json
+import os
+import pytest
+from datetime import datetime
+from unittest.mock import MagicMock, patch, call
+
+
+# ------------------------------------------------------------------ helpers --
+
+def _import_helpers():
+    """Import the process-management functions from launch.py at call time
+    so that psutil (which may not be installed in CI) is only required here.
+    """
+    import importlib.util, sys
+
+    # We import just the symbols we need without executing the Flask app setup.
+    # launch.py guards heavy setup behind ``if __name__ == '__main__'`` so a
+    # plain import is safe (the Flask app is created at module level, but that
+    # is acceptable — it just won't receive requests in this context).
+    import launch  # noqa: F401 — import side-effects are acceptable
+    return launch
+
+
+# ------------------------------------------------------------------ fixtures --
+
+@pytest.fixture()
+def tmp_pid_path(tmp_path, monkeypatch):
+    """Redirect _pid_file_path() to a temp directory for isolation."""
+    pid_file = str(tmp_path / 'ride-optimizer-server.pid')
+
+    import launch
+    monkeypatch.setattr(launch, '_pid_file_path', lambda: pid_file)
+    return pid_file
+
+
+# ============================================================ PID file I/O ==
+
+@pytest.mark.unit
+class TestPidFileIO:
+    def test_write_and_read_round_trip(self, tmp_pid_path):
+        import launch
+        launch._write_pid_file(pid=12345, port=8083)
+
+        data = launch._read_pid_file()
+        assert data['pid'] == 12345
+        assert data['port'] == 8083
+        assert 'started' in data
+        # started should be a parseable ISO timestamp
+        datetime.fromisoformat(data['started'])
+
+    def test_read_missing_file_returns_empty_dict(self, tmp_pid_path):
+        import launch
+        # File does not exist yet
+        assert launch._read_pid_file() == {}
+
+    def test_read_corrupt_file_returns_empty_dict(self, tmp_pid_path):
+        import launch
+        with open(tmp_pid_path, 'w') as fh:
+            fh.write('not valid json{{{')
+        assert launch._read_pid_file() == {}
+
+    def test_remove_pid_file_deletes_file(self, tmp_pid_path):
+        import launch
+        launch._write_pid_file(pid=1, port=8083)
+        assert os.path.exists(tmp_pid_path)
+        launch._remove_pid_file()
+        assert not os.path.exists(tmp_pid_path)
+
+    def test_remove_pid_file_is_idempotent(self, tmp_pid_path):
+        import launch
+        # Should not raise even if the file is already absent
+        launch._remove_pid_file()
+        launch._remove_pid_file()
+
+
+# ========================================= _is_our_server_process (mocked) ==
+
+@pytest.mark.unit
+class TestIsOurServerProcess:
+    def _make_proc(self, cmdline, status='running'):
+        proc = MagicMock()
+        proc.status.return_value = status
+        proc.cmdline.return_value = cmdline
+        return proc
+
+    def test_valid_launch_serve_process(self):
+        import launch
+        cmdline = ['/usr/bin/python', '/home/user/ride-optimizer/launch.py', '--serve', '8083']
+        proc = self._make_proc(cmdline)
+        with patch('psutil.Process', return_value=proc):
+            assert launch._is_our_server_process(99999) is True
+
+    def test_unrelated_process_returns_false(self):
+        import launch
+        proc = self._make_proc(['/usr/bin/python', 'some_other_script.py'])
+        with patch('psutil.Process', return_value=proc):
+            assert launch._is_our_server_process(99999) is False
+
+    def test_zombie_process_returns_false(self):
+        import launch
+        import psutil
+        cmdline = ['python', 'launch.py', '--serve', '8083']
+        proc = self._make_proc(cmdline, status=psutil.STATUS_ZOMBIE)
+        with patch('psutil.Process', return_value=proc):
+            assert launch._is_our_server_process(99999) is False
+
+    def test_no_such_process_returns_false(self):
+        import launch
+        import psutil
+        with patch('psutil.Process', side_effect=psutil.NoSuchProcess(pid=99999)):
+            assert launch._is_our_server_process(99999) is False
+
+
+# =========================================== kill_existing_server (mocked) ==
+
+@pytest.mark.unit
+class TestKillExistingServer:
+    def test_kills_process_from_pid_file(self, tmp_pid_path):
+        import launch
+        import psutil
+
+        launch._write_pid_file(pid=11111, port=8083)
+
+        mock_proc = MagicMock()
+        mock_proc.status.return_value = 'running'
+        mock_proc.cmdline.return_value = ['python', 'launch.py', '--serve', '8083']
+
+        with patch('psutil.Process', return_value=mock_proc):
+            with patch.object(launch, '_find_server_on_port', return_value=None):
+                launch.kill_existing_server(8083)
+
+        mock_proc.terminate.assert_called_once()
+        # PID file should be cleaned up
+        assert not os.path.exists(tmp_pid_path)
+
+    def test_cleans_up_stale_pid_file(self, tmp_pid_path):
+        import launch
+        import psutil
+
+        launch._write_pid_file(pid=22222, port=8083)
+
+        with patch('psutil.Process', side_effect=psutil.NoSuchProcess(pid=22222)):
+            with patch.object(launch, '_find_server_on_port', return_value=None):
+                launch.kill_existing_server(8083)
+
+        assert not os.path.exists(tmp_pid_path)
+
+    def test_port_scan_fallback_when_no_pid_file(self, tmp_pid_path):
+        import launch
+
+        mock_proc = MagicMock()
+        mock_proc.status.return_value = 'running'
+        mock_proc.cmdline.return_value = ['python', 'launch.py', '--serve', '8083']
+
+        with patch('psutil.Process', return_value=mock_proc):
+            with patch.object(launch, '_find_server_on_port', return_value=33333):
+                launch.kill_existing_server(8083)
+
+        mock_proc.terminate.assert_called_once()
+
+    def test_invalid_port_returns_early(self, tmp_pid_path):
+        import launch
+        with patch.object(launch, '_read_pid_file') as mock_read:
+            launch.kill_existing_server(80)  # below 1024 — invalid
+            mock_read.assert_not_called()
+
+
+# ================================================== server_status (mocked) ==
+
+@pytest.mark.unit
+class TestServerStatus:
+    def test_running_server_via_pid_file(self, tmp_pid_path):
+        import launch
+        import psutil
+
+        launch._write_pid_file(pid=44444, port=8083)
+
+        mock_proc = MagicMock()
+        mock_proc.status.return_value = 'running'
+        mock_proc.cmdline.return_value = ['python', 'launch.py', '--serve', '8083']
+        mock_proc.create_time.return_value = datetime.now().timestamp() - 120
+
+        with patch('psutil.Process', return_value=mock_proc):
+            st = launch.server_status()
+
+        assert st['running'] is True
+        assert st['pid'] == 44444
+        assert st['port'] == 8083
+        assert st['uptime_seconds'] is not None
+        assert st['uptime_seconds'] >= 0
+
+    def test_stale_pid_file_reports_not_running(self, tmp_pid_path):
+        import launch
+        import psutil
+
+        launch._write_pid_file(pid=55555, port=8083)
+
+        with patch('psutil.Process', side_effect=psutil.NoSuchProcess(pid=55555)):
+            with patch.object(launch, '_find_server_on_port', return_value=None):
+                st = launch.server_status()
+
+        assert st['running'] is False
+        # Stale file should be removed
+        assert not os.path.exists(tmp_pid_path)
+
+    def test_no_pid_file_not_running(self, tmp_pid_path):
+        import launch
+        with patch.object(launch, '_find_server_on_port', return_value=None):
+            st = launch.server_status()
+        assert st['running'] is False
+        assert st['pid'] is None
+
+
+# ===================================================== stop_server (mocked) ==
+
+@pytest.mark.unit
+class TestStopServer:
+    def test_stops_tracked_server(self, tmp_pid_path):
+        import launch
+
+        launch._write_pid_file(pid=66666, port=8083)
+
+        mock_proc = MagicMock()
+        mock_proc.status.return_value = 'running'
+        mock_proc.cmdline.return_value = ['python', 'launch.py', '--serve', '8083']
+
+        with patch('psutil.Process', return_value=mock_proc):
+            result = launch.stop_server()
+
+        assert result is True
+        mock_proc.terminate.assert_called_once()
+        assert not os.path.exists(tmp_pid_path)
+
+    def test_returns_false_when_no_server(self, tmp_pid_path):
+        import launch
+        with patch.object(launch, '_find_server_on_port', return_value=None):
+            result = launch.stop_server()
+        assert result is False


### PR DESCRIPTION
## Summary

Implements all 20 child issues of Epic #352 (Design Review — Information Density, Discoverability & Card Placement), plus the Fair Weather brand adoption across every page.

**Cross-page foundation:**
- Fair Weather Day/Night color tokens, pill buttons, 16px cards, display typography, logo/favicon, light navbar (main.css + all pages)
- Bottom nav expanded to 5 items (Home, Routes, Weather, Reports, More-drawer with Explore/Settings) — #362
- Help modal degrades to text-only when tutorial GIF/PNG assets are absent — #374

**Dashboard** (#358, #363, #370): equal decision/map column widths, Route Status moved below the map on mobile, "How It Works" relocated out of above-the-fold, static collapse-teaser text on the commute-detail and Route Status panels, commute-load error state, updated What's New copy.

**Weather** (#357, #373): Transit Alert → Today's Commute Windows → 7-Day Forecast DOM order (time-urgency), comfort-score legend with thresholds verified against the actual scoring code, dynamic commute-window time labels (was hardcoded and didn't match the API), "Today at a Glance" positive state, H1 fix.

**Explore** (#360, #361, #367, #375): tile/Squadrats explainer + coverage legend, numbered 3-step workflow with progressive button enablement (Generate disabled/outline until both coverage and start point are set, promotes to the coral CTA), two-column desktop layout (controls left / map right, stats below), unit-neutral distance slider default, Clear Cache confirmation, H1.

**Routes Library** (#364, #365, #372): advanced filters collapsed behind a "More Filters" toggle with a live count badge, list/map column ratio inverted (list now wider), visible "Compare" label, persistent Saved Plans entry point, color-by legend shown pre-plot, results count downgraded from an alert to muted text.

**Route Detail** (#359, #371): raw JSON weather dump replaced with a formatted icon+metric card, "Uses" demoted out of the primary metrics grid (backfilled with Avg Speed), Performance Trends moved up with a history-count fallback and an empty-state placeholder, mobile map height capped, skip-link and H1 fixes.

**Settings + Reports** (#368, #369, #366): Connections split into five collapsible per-integration cards, Outdoor Prefs nested under TrainerRoad, Save/Reset moved above About, fetch→analyze workflow explainer, gear-admin buttons relocated from Reports into Settings and renamed ("Repair Gear Names"), Danger Zone behind a disclosure, empty secondary stats hidden, cards reordered, three distribution charts consolidated into one tabbed card, Personal Records filtered to cycling activity types, bar-chart ARIA fixed.

**#375/#376 polish** (unit-system consistency, stale versions, missing H1s, a11y, destructive-action confirmations) folded into each cluster above rather than done as a separate pass.

One bug caught in review and fixed on top of the agent work: the Reports distance-unit fix initially made the label dynamic ("Kilometers") without converting the underlying value, which is still miles from the backend — now both convert together.

## Relationship to Epic #413 (launch.py Blueprint Refactor)

No launch.py/backend changes were needed for any of the 20 issues — this PR is frontend-only, so it doesn't conflict with #413's blueprint extraction work. One coordination note already posted on #415: the psutil-based process-management fix (#345) that landed on this branch was cherry-picked onto `refactor/launch-py-blueprints` so #413's Phase 2 extraction works from the current implementation instead of the stale Phase-1 stub.

## Heads up: unrelated commits bundled into this branch

While this PR was in progress, some concurrent/background activity committed three unrelated changes onto this branch (not introduced by this work, left as-is rather than rebased out to avoid history rewriting):
- `22b3686` Fix #345 (psutil server process management)
- `c3a8095` Fix Strava OAuth / coverage tile fallback / UTC timestamp display
- `3ddbf6b` Long-ride similarity score caching

Called out here in case you'd rather they ship independently of the design-review epic — happy to split them into their own PR if so.

## Also found — now fixed on this branch

- **CSP was blocking the Dashboard's embedded commute map.** Folium's default template (used for the commute-map iframe) pulls jQuery + Leaflet.awesome-markers + bootstrap-glyphicons from `code.jquery.com`/`cdnjs.cloudflare.com`/`netdna.bootstrapcdn.com` for its `prefix='fa'` icon markers; the blob iframe inherits the parent page's CSP, which didn't allow those hosts (pre-existing on `main`, unrelated to the 20 design-review issues, but caught during this epic's verification pass). Whitelisted the three hosts in `launch.py`'s CSP — verified fixed via Playwright (CSP violations and the `$ is not defined` page error both gone).
- **`DESIGN_PRINCIPLES.md` §3 self-contradiction, corrected.** The v2.2 field note called Route Detail's `col-lg-5`/`col-lg-7` split "the reference implementation" for the map+controls side-by-side rule, directly contradicting the v0.17.0 field note just above it (finding PLACE-DETAIL-2), which already flagged that same split as violating the ratio rule's `col-lg-6` minimum. Added a v2.3 correction: the split is the reference for side-by-side *placement* only, not for the ratio rule, which it doesn't meet — Route Detail's own column ratio remains an uncorrected deviation (not fixed here, wasn't part of the 20 issues).
- **`python launch.py --stop` port-scan fallback gap** — reported as a comment on #413 rather than fixed here, since it's `#345`/`#413` territory: didn't find a live server with no PID file during verification (likely `psutil.net_connections()` needing elevated permissions on macOS).

## Test plan

- [x] All 7 changed pages load with 200 status; console/page errors checked via Playwright (only pre-existing/expected noise: missing tutorial-asset probes on the 5 pages that load help-modal.js, and the pre-existing Folium/CSP iframe issue above)
- [x] `node --check` on every modified JS file
- [x] HTML tag-balance check on every modified page (incl. inline scripts)
- [x] No duplicate element IDs introduced; every ID referenced by JS still present
- [ ] Manual pass on a real mobile device recommended before merge (touch targets, collapse affordances, bottom-nav drawer)

Closes #352, #357, #358, #359, #360, #361, #362, #363, #364, #365, #366, #367, #368, #369, #370, #371, #372, #373, #374, #375, #376

🤖 Generated with [Claude Code](https://claude.com/claude-code)
