### PR TITLE
Fair Weather completion: Night mode toggle, Bootstrap RGB retarget, Route Detail ratio

### DIFF
--- a/static/compare.html
+++ b/static/compare.html
@@ -2,6 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    (function () {
+        try {
+            var t = localStorage.getItem('fairWeatherTheme');
+            if (t !== 'day' && t !== 'night') {
+                t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'night' : 'day';
+            }
+            document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {}
+    })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Compare Routes - Ride Optimizer</title>
     <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -38,6 +38,11 @@
 
     /* Bootstrap utility hooks (drives .bg-primary tints, focus rings, etc.) */
     --bs-primary-rgb: 11, 111, 166;
+    /* Info is retired — cobalt carries it (brand book) */
+    --bs-info-rgb: 11, 111, 166;
+    --bs-success-rgb: 62, 142, 99;
+    --bs-warning-rgb: 201, 138, 29;
+    --bs-danger-rgb: 196, 72, 58;
 
     /* Spacing scale (#280) */
     --space-1: 4px;
@@ -100,6 +105,10 @@ html[data-theme="night"] {
     --danger: #E2695C;
     --accent-rgb: 79, 179, 232;
     --bs-primary-rgb: 79, 179, 232;
+    --bs-info-rgb: 79, 179, 232;
+    --bs-success-rgb: 87, 179, 132;
+    --bs-warning-rgb: 224, 166, 62;
+    --bs-danger-rgb: 226, 105, 92;
 }
 
 body {

--- a/static/explore.html
+++ b/static/explore.html
@@ -2,6 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    (function () {
+        try {
+            var t = localStorage.getItem('fairWeatherTheme');
+            if (t !== 'day' && t !== 'night') {
+                t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'night' : 'day';
+            }
+            document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {}
+    })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Explore - Ride Optimizer</title>
     <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">

--- a/static/index.html
+++ b/static/index.html
@@ -2,6 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    (function () {
+        try {
+            var t = localStorage.getItem('fairWeatherTheme');
+            if (t !== 'day' && t !== 'night') {
+                t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'night' : 'day';
+            }
+            document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {}
+    })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Ride Optimizer</title>
     

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -548,6 +548,31 @@ window.unfavoriteRouteWithUndo = function(routeId) {
     }
 };
 
+// Fair Weather Day/Night theme
+/**
+ * Get the currently active Fair Weather theme.
+ * The `data-theme` attribute is set as early as possible (inline in <head>,
+ * before this script loads) to avoid a flash of the wrong theme.
+ * @returns {string} 'day' or 'night'
+ */
+window.getFairWeatherTheme = function() {
+    return document.documentElement.getAttribute('data-theme') === 'night' ? 'night' : 'day';
+};
+
+/**
+ * Set and persist the Fair Weather theme.
+ * @param {string} theme - 'day' or 'night'
+ */
+window.setFairWeatherTheme = function(theme) {
+    const resolved = theme === 'night' ? 'night' : 'day';
+    document.documentElement.setAttribute('data-theme', resolved);
+    try {
+        localStorage.setItem('fairWeatherTheme', resolved);
+    } catch (_) {
+        // localStorage unavailable (private browsing, etc.) — theme still applies for this load
+    }
+};
+
 // Unit conversion utilities
 /**
  * Get user's preferred unit system from settings

--- a/static/reports.html
+++ b/static/reports.html
@@ -2,6 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    (function () {
+        try {
+            var t = localStorage.getItem('fairWeatherTheme');
+            if (t !== 'day' && t !== 'night') {
+                t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'night' : 'day';
+            }
+            document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {}
+    })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Reports - Ride Optimizer</title>
     <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">

--- a/static/route-detail.html
+++ b/static/route-detail.html
@@ -2,6 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    (function () {
+        try {
+            var t = localStorage.getItem('fairWeatherTheme');
+            if (t !== 'day' && t !== 'night') {
+                t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'night' : 'day';
+            }
+            document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {}
+    })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Route Details - Ride Optimizer</title>
     <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">
@@ -623,7 +634,7 @@
                         </div>
 
                         <div class="row g-3">
-                            <div class="col-lg-5">
+                            <div class="col-lg-7">
                                 <div class="card">
                                     <div class="card-body">
                                         <div class="row g-2 mb-3">
@@ -683,7 +694,7 @@
                                 ${routeHistoryMarkup}
                                 ${longRideUsesMarkup}
                             </div>
-                            <div class="col-lg-7">
+                            <div class="col-lg-5">
                                 <div style="position: sticky; top: var(--space-3);">
                                     <div class="card">
                                         <div class="card-body p-0">

--- a/static/routes.html
+++ b/static/routes.html
@@ -2,6 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    (function () {
+        try {
+            var t = localStorage.getItem('fairWeatherTheme');
+            if (t !== 'day' && t !== 'night') {
+                t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'night' : 'day';
+            }
+            document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {}
+    })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Routes - Ride Optimizer</title>
     <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">

--- a/static/settings.html
+++ b/static/settings.html
@@ -2,6 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    (function () {
+        try {
+            var t = localStorage.getItem('fairWeatherTheme');
+            if (t !== 'day' && t !== 'night') {
+                t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'night' : 'day';
+            }
+            document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {}
+    })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Settings - Ride Optimizer</title>
 
@@ -178,6 +189,17 @@
                                     </select>
                                     <div id="default-view-help" class="form-text">
                                         <i class="bi bi-info-circle"></i> Page to show when you open the app
+                                    </div>
+                                </div>
+
+                                <div class="mb-3">
+                                    <label for="theme-preference" class="form-label fw-bold">Appearance</label>
+                                    <select class="form-select" id="theme-preference" aria-describedby="theme-preference-help">
+                                        <option value="day">Day</option>
+                                        <option value="night">Night</option>
+                                    </select>
+                                    <div id="theme-preference-help" class="form-text">
+                                        <i class="bi bi-info-circle"></i> Switches the app between Fair Weather's Day and Night color modes
                                     </div>
                                 </div>
 
@@ -829,6 +851,7 @@
 
             // Load saved preferences
             loadUserPreferences();
+            initThemeControl();
 
             // Setup event listeners
             setupEventListeners();
@@ -936,6 +959,17 @@
             });
             bodyEl.addEventListener('hidden.bs.collapse', () => {
                 if (label) label.textContent = 'Show Danger Zone';
+            });
+        }
+
+        // Appearance select mirrors the current data-theme (set on every page load via the
+        // inline head script) and applies changes immediately — it's not gated on auto-save.
+        function initThemeControl() {
+            const select = document.getElementById('theme-preference');
+            if (!select || !window.getFairWeatherTheme) return;
+            select.value = window.getFairWeatherTheme();
+            select.addEventListener('change', function() {
+                window.setFairWeatherTheme(this.value);
             });
         }
 
@@ -1109,6 +1143,11 @@
                 _outdoorMinTempF = 40;
                 setOutdoorTempSliderUnit(false);
                 document.getElementById('outdoor-allow-rain').checked = false;
+
+                localStorage.removeItem('fairWeatherTheme');
+                const systemTheme = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'night' : 'day';
+                window.setFairWeatherTheme(systemTheme);
+                document.getElementById('theme-preference').value = systemTheme;
 
                 clearUnsavedChanges();
 

--- a/static/setup.html
+++ b/static/setup.html
@@ -2,6 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    (function () {
+        try {
+            var t = localStorage.getItem('fairWeatherTheme');
+            if (t !== 'day' && t !== 'night') {
+                t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'night' : 'day';
+            }
+            document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {}
+    })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Setup — Ride Optimizer</title>
     <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">

--- a/static/weather.html
+++ b/static/weather.html
@@ -2,6 +2,17 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <script>
+    (function () {
+        try {
+            var t = localStorage.getItem('fairWeatherTheme');
+            if (t !== 'day' && t !== 'night') {
+                t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'night' : 'day';
+            }
+            document.documentElement.setAttribute('data-theme', t);
+        } catch (e) {}
+    })();
+    </script>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Weather Forecast - Ride Optimizer</title>
     <link rel="icon" type="image/svg+xml" href="/img/favicon.svg">


### PR DESCRIPTION
## Summary
- Closes #446 — adds a Day/Night Appearance select to Settings, backed by a `data-theme` init snippet in every page's `<head>` (reads `localStorage`, falls back to `prefers-color-scheme: dark` on first load), plus `window.getFairWeatherTheme`/`setFairWeatherTheme` helpers in `common.js`.
- Closes #447 — overrides `--bs-success-rgb`/`--bs-warning-rgb`/`--bs-danger-rgb` and retires `--bs-info-rgb` to the accent color, in both Day and Night token blocks, so Bootstrap's `.text-*`/`.bg-*`/`.badge-*`/`.alert-*` utilities render brand colors instead of stock Bootstrap.
- Closes #448 — swaps Route Detail's stats/history and map columns to `col-lg-7`/`col-lg-5` so primary decision data gets majority desktop width.
- Closes #449 (epic).

## New finding (not fixed here, filed separately)
Testing Night mode live (now that it's reachable) surfaced token drift the epic anticipated: several `.fw-semibold` value elements on Route Detail (distance/duration/elevation/weather stats) render Bootstrap's default `#212529` text color instead of `--ink`, so they're low-contrast on the Night background. Screenshot-verified. Recommend a follow-up issue per #446's own "re-sweep for token drift" note.

## Test plan
- [x] `pytest -q -m "not slow and not e2e"` — 42 failures/8 errors, all reproduced identically with these changes stashed out (pre-existing on `main`, unrelated — see `launch.config` AttributeError from in-flight Epic #413 DoD work on another branch)
- [x] Playwright: fresh context with `prefers-color-scheme: dark`, no stored preference → defaults to Night
- [x] Playwright: Settings Appearance select toggles theme live, persists across reload
- [x] Playwright: mocked Route Detail render confirms `col-lg-7`/`col-lg-5` order and `.text-success` computed color matches brand tokens in both Day and Night

🤖 Generated with [Claude Code](https://claude.com/claude-code)