### PR TITLE
Phase 1 of #498: eliminate duplicate host stack, cap analysis workers and BLAS threads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,14 @@ ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     PIP_NO_CACHE_DIR=1 \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
-    APP_PORT=8083
+    APP_PORT=8083 \
+    # numpy/scipy BLAS backends default to one thread per core, which
+    # multiplies memory/CPU pressure inside the 512MB container on the Pi.
+    # Analysis parallelism is governed by ANALYSIS_N_WORKERS instead.
+    OPENBLAS_NUM_THREADS=1 \
+    OMP_NUM_THREADS=1 \
+    MKL_NUM_THREADS=1 \
+    NUMEXPR_NUM_THREADS=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     gcc g++ curl \

--- a/app/services/analysis_service.py
+++ b/app/services/analysis_service.py
@@ -9,6 +9,7 @@ This service orchestrates the main analysis workflow:
 """
 
 import json
+import os
 from src.secure_logger import SecureLogger
 from pathlib import Path
 from typing import List, Dict, Any, Optional, Tuple
@@ -22,6 +23,18 @@ from src.config_manager import ConfigManager
 from app.services.weather_service import WeatherService
 
 logger = SecureLogger(__name__)
+
+
+def _analysis_workers(default: int = 2) -> int:
+    """Worker-process count for route analysis, capped by ANALYSIS_N_WORKERS.
+
+    Memory-constrained deployments (the Pi container) set ANALYSIS_N_WORKERS=1
+    so analysis never forks extra copies of the numpy stack.
+    """
+    try:
+        return max(1, int(os.getenv('ANALYSIS_N_WORKERS', default)))
+    except (TypeError, ValueError):
+        return default
 
 
 class AnalysisService:
@@ -421,6 +434,7 @@ class AnalysisService:
                     h, w = lf.identify_home_work()
                     ra = RouteAnalyzer(activities=preview_acts, home=h, work=w,
                                        config=self.config, force_reanalysis=True,
+                                       n_workers=_analysis_workers(),
                                        enable_geocoding=False)
                     ra.group_similar_routes()
                     logger.info(f"Preview analysis complete on {preview_n} activities")
@@ -480,6 +494,7 @@ class AnalysisService:
                 work=self._work_location,
                 config=self.config,
                 force_reanalysis=force_refresh,
+                n_workers=_analysis_workers(),
                 progress_callback=_route_progress,
                 stop_check=stop_check,
             )

--- a/cron/README.md
+++ b/cron/README.md
@@ -21,15 +21,17 @@ All cron jobs support **push notifications via ntfy.sh** for proactive monitorin
 
 ### 1. Daily Analysis (`daily_analysis.py`)
 - **Schedule**: Daily at 2 AM
-- **Purpose**: Fetch latest activities from Strava and perform full route analysis
-- **Output**: Updates `cache/activities_cache.json`, `cache/route_groups_cache.json`
+- **Purpose**: Trigger a full fetch + analysis in the running app via `POST /api/analyze`, then poll `/api/analyze/status` until done
+- **How**: Thin HTTP client — does **not** import the analysis stack (the app container does the work inside its own memory limit; see issue #498)
+- **Config**: `RIDE_OPTIMIZER_URL` (default `http://127.0.0.1:$APP_PORT`), `ANALYSIS_TIMEOUT` (default 3h), `ANALYSIS_POLL_INTERVAL` (default 30s)
 - **Logs**: `logs/cron_daily_analysis.log`
 - **Notifications**: Sends critical alert on failure
 
 ### 2. Weather Refresh (`weather_refresh.py`)
 - **Schedule**: Every 6 hours
-- **Purpose**: Update weather data for home location
-- **Output**: Updates `cache/weather_cache.json`
+- **Purpose**: Refresh home-location weather via `GET /api/weather` (the app caches it server-side)
+- **How**: Thin HTTP client — does **not** import the service stack (see issue #498)
+- **Config**: `RIDE_OPTIMIZER_URL` (default `http://127.0.0.1:$APP_PORT`)
 - **Logs**: `logs/cron_weather_refresh.log`
 - **Notifications**: None (non-critical job)
 
@@ -220,7 +222,7 @@ crontab cron/crontab.backup.YYYYMMDD_HHMMSS
 
 Each job:
 1. Runs as standalone process
-2. Loads only required services
+2. Talks to the running app over HTTP where possible (`daily_analysis.py`, `weather_refresh.py`) so the heavy lifting happens once, inside the app container's memory budget — the jobs themselves import only stdlib + `requests` + light helpers
 3. Records execution in `job_history.json`
 4. Exits cleanly after completion
 5. No shared state between runs

--- a/cron/daily_analysis.py
+++ b/cron/daily_analysis.py
@@ -1,26 +1,34 @@
 #!/usr/bin/env python3
 """
-Daily Analysis Cron Job
-Replaces APScheduler job for Smart Static architecture.
+Daily Analysis Cron Job — thin HTTP client.
+
+Triggers the running app's /api/analyze endpoint and polls for completion
+instead of importing the analysis stack in-process. The old version loaded
+a second full copy of numpy/sklearn/folium plus the entire activity history
+on the host, outside the container's memory limit — the main cause of the
+Pi's swap spikes (#498).
 
 Run via cron: 0 2 * * * /path/to/cron/daily_analysis.py
 """
 
-import sys
 import logging
-from pathlib import Path
+import os
+import sys
+import time
 from datetime import datetime
+from pathlib import Path
+
+import requests
 
 # Add project root to path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
-from src.config_manager import ConfigManager
 from src.json_storage import JSONStorage
+from src.config_manager import ConfigManager
 from src.logging_config import PIISanitizingFilter
 from src.ntfy_notifier import NtfyNotifier
 from src.secure_logger import SecureLogger
-from app.services.analysis_service import AnalysisService
 
 # Configure logging
 log_dir = project_root / 'logs'
@@ -39,95 +47,123 @@ for _handler in logging.getLogger().handlers:
     _handler.addFilter(PIISanitizingFilter())
 logger = SecureLogger(__name__)
 
+BASE_URL = os.getenv('RIDE_OPTIMIZER_URL',
+                     f"http://127.0.0.1:{os.getenv('APP_PORT', '8083')}")
+POLL_INTERVAL_SECONDS = int(os.getenv('ANALYSIS_POLL_INTERVAL', '30'))
+TIMEOUT_SECONDS = int(os.getenv('ANALYSIS_TIMEOUT', str(3 * 60 * 60)))
+
+
+def _record_job(storage, status, start_time, result=None, error=None):
+    """Append a job record to job_history.json (same format as before)."""
+    job_record = {
+        'job_type': 'daily_analysis',
+        'status': status,
+        'started_at': start_time.isoformat(),
+        'completed_at': datetime.now().isoformat(),
+        'duration_seconds': (datetime.now() - start_time).total_seconds(),
+    }
+    if result is not None:
+        job_record['result'] = {
+            'activities_count': result.get('activities_count', 0),
+            'route_groups_count': result.get('route_groups_count', 0),
+            'long_rides_count': result.get('long_rides_count', 0),
+            'degraded_reason': result.get('degraded_reason'),
+        }
+    if error is not None:
+        job_record['error'] = error
+
+    try:
+        history = storage.read('job_history.json', default={'jobs': []})
+        history['jobs'].append(job_record)
+        history['jobs'] = history['jobs'][-100:]
+        storage.write('job_history.json', history)
+    except Exception as save_error:
+        logger.error(f"Failed to save job history: {save_error}")
+    return job_record
+
 
 def main():
-    """Run daily analysis refresh."""
+    """Trigger analysis over HTTP and wait for it to finish."""
     logger.info("=" * 60)
-    logger.info("Starting daily analysis cron job")
+    logger.info(f"Starting daily analysis cron job (via {BASE_URL})")
     logger.info("=" * 60)
-    
+
     start_time = datetime.now()
     storage = JSONStorage()
-    
-    # Initialize notifier
+
     try:
         config = ConfigManager.get_instance()
         notifier = NtfyNotifier(config.get('notifications.ntfy'))
     except Exception as e:
         logger.warning(f"Failed to initialize notifier: {e}")
         notifier = None
-    
+
     try:
-        # Initialize services
-        analysis_service = AnalysisService()
-        
-        # Run full analysis
-        logger.info("Running full analysis...")
-        result = analysis_service.run_full_analysis(force_refresh=False)
-        
-        # Record job execution
-        job_record = {
-            'job_type': 'daily_analysis',
-            'status': 'completed' if result.get('success') else 'degraded',
-            'started_at': start_time.isoformat(),
-            'completed_at': datetime.now().isoformat(),
-            'duration_seconds': (datetime.now() - start_time).total_seconds(),
-            'result': {
-                'activities_count': result.get('activities_count', 0),
-                'route_groups_count': result.get('route_groups_count', 0),
-                'long_rides_count': result.get('long_rides_count', 0),
-                'degraded_reason': result.get('degraded_reason')
-            }
-        }
-        
-        # Save job history
-        history = storage.read('job_history.json', default={'jobs': []})
-        history['jobs'].append(job_record)
-        
-        # Keep only last 100 job records
-        history['jobs'] = history['jobs'][-100:]
-        storage.write('job_history.json', history)
-        
-        # Update status
+        session = requests.Session()
+
+        # CSRF: fetch a token (sets the session cookie the token is bound to)
+        resp = session.get(f"{BASE_URL}/api/csrf-token", timeout=30)
+        resp.raise_for_status()
+        csrf_token = resp.json()['csrf_token']
+
+        # Trigger the analysis job. fetch_new=True matches the old in-process
+        # behavior (run_full_analysis with skip_strava_fetch=False).
+        resp = session.post(
+            f"{BASE_URL}/api/analyze",
+            json={'fetch_new': True, 'force_refresh': False},
+            headers={'X-CSRFToken': csrf_token},
+            timeout=60,
+        )
+        if resp.status_code == 409:
+            logger.warning("Analysis already running — skipping this cron run")
+            return 0
+        resp.raise_for_status()
+        logger.info("Analysis started, polling for completion...")
+
+        # Poll until the job leaves the 'running' state
+        deadline = time.monotonic() + TIMEOUT_SECONDS
+        while True:
+            if time.monotonic() > deadline:
+                raise TimeoutError(
+                    f"Analysis still running after {TIMEOUT_SECONDS}s")
+            time.sleep(POLL_INTERVAL_SECONDS)
+            status_resp = session.get(f"{BASE_URL}/api/analyze/status",
+                                      timeout=30)
+            status_resp.raise_for_status()
+            snapshot = status_resp.json()
+            state = snapshot.get('status')
+            if state == 'running':
+                continue
+            if state == 'done':
+                result = snapshot.get('result') or {}
+                break
+            raise RuntimeError(
+                f"Analysis ended with status '{state}': "
+                f"{snapshot.get('label') or snapshot.get('result')}")
+
+        job_record = _record_job(
+            storage,
+            'completed' if result.get('success', True) else 'degraded',
+            start_time, result=result)
+
         status = storage.read('status.json', default={})
         status['last_analysis'] = datetime.now().isoformat()
         status['has_data'] = True
         storage.write('status.json', status)
-        
-        logger.info(f"Analysis completed successfully in {job_record['duration_seconds']:.1f}s")
+
+        logger.info(f"Analysis completed successfully in "
+                    f"{job_record['duration_seconds']:.1f}s")
         logger.info(f"Activities: {job_record['result']['activities_count']}")
         logger.info(f"Route groups: {job_record['result']['route_groups_count']}")
-        
         return 0
-        
+
     except Exception as e:
         logger.error(f"Daily analysis failed: {e}", exc_info=True)
-        
-        # Send failure notification
         if notifier:
             notifier.send_cron_failure_alert('daily_analysis', str(e))
-        
-        # Record failure
-        job_record = {
-            'job_type': 'daily_analysis',
-            'status': 'failed',
-            'started_at': start_time.isoformat(),
-            'completed_at': datetime.now().isoformat(),
-            'duration_seconds': (datetime.now() - start_time).total_seconds(),
-            'error': str(e)
-        }
-        
-        try:
-            history = storage.read('job_history.json', default={'jobs': []})
-            history['jobs'].append(job_record)
-            history['jobs'] = history['jobs'][-100:]
-            storage.write('job_history.json', history)
-        except Exception as save_error:
-            logger.error(f"Failed to save job history: {save_error}")
-        
+        _record_job(storage, 'failed', start_time, error=str(e))
         return 1
 
 
 if __name__ == '__main__':
     sys.exit(main())
-

--- a/cron/weather_refresh.py
+++ b/cron/weather_refresh.py
@@ -1,26 +1,31 @@
 #!/usr/bin/env python3
 """
-Weather Refresh Cron Job
-Replaces APScheduler job for Smart Static architecture.
+Weather Refresh Cron Job — thin HTTP client.
+
+Hits the running app's GET /api/weather endpoint (which fetches and caches
+weather for the home location server-side) instead of importing the service
+stack in-process. The old version also wrote its own incompatible schema
+into data/weather_cache.json, clobbering WeatherService's cache format —
+going through the API fixes that too (#498).
 
 Run via cron: 0 */6 * * * /path/to/cron/weather_refresh.py
 """
 
-import sys
 import logging
-from pathlib import Path
+import os
+import sys
 from datetime import datetime
+from pathlib import Path
+
+import requests
 
 # Add project root to path
 project_root = Path(__file__).parent.parent
 sys.path.insert(0, str(project_root))
 
-from src.config_manager import ConfigManager
 from src.json_storage import JSONStorage
 from src.logging_config import PIISanitizingFilter
-from src.ntfy_notifier import NtfyNotifier
 from src.secure_logger import SecureLogger
-from app.services.weather_service import WeatherService
 
 # Configure logging
 log_dir = project_root / 'logs'
@@ -39,104 +44,69 @@ for _handler in logging.getLogger().handlers:
     _handler.addFilter(PIISanitizingFilter())
 logger = SecureLogger(__name__)
 
+BASE_URL = os.getenv('RIDE_OPTIMIZER_URL',
+                     f"http://127.0.0.1:{os.getenv('APP_PORT', '8083')}")
 
-def main():
-    """Refresh weather data for active routes."""
-    logger.info("=" * 60)
-    logger.info("Starting weather refresh cron job")
-    logger.info("=" * 60)
-    
-    start_time = datetime.now()
-    storage = JSONStorage()
-    
-    # Initialize notifier
+
+def _record_job(storage, status, start_time, result=None, error=None):
+    """Append a job record to job_history.json (same format as before)."""
+    job_record = {
+        'job_type': 'weather_refresh',
+        'status': status,
+        'started_at': start_time.isoformat(),
+        'completed_at': datetime.now().isoformat(),
+        'duration_seconds': (datetime.now() - start_time).total_seconds(),
+    }
+    if result is not None:
+        job_record['result'] = result
+    if error is not None:
+        job_record['error'] = error
+
     try:
-        config = ConfigManager.get_instance()
-        notifier = NtfyNotifier(config.get('notifications.ntfy'))
-    except Exception as e:
-        logger.warning(f"Failed to initialize notifier: {e}")
-        notifier = None
-    
-    try:
-        # Initialize services
-        weather_service = WeatherService()
-        
-        # Get home location
-        home_lat = config.get('location.home.latitude')
-        home_lon = config.get('location.home.longitude')
-        
-        if not home_lat or not home_lon:
-            logger.warning("No home location configured, skipping weather refresh")
-            return 0
-        
-        # Fetch current weather
-        logger.info(f"Fetching weather for home location ({home_lat}, {home_lon})")
-        weather_data = weather_service.get_current_weather(home_lat, home_lon, 'Home')
-        
-        # Save to cache
-        cache_data = {
-            'current': weather_data.get('current'),
-            'forecast': weather_data.get('forecast', []),
-            'updated_at': datetime.now().isoformat(),
-            'location': {
-                'name': 'Home',
-                'latitude': home_lat,
-                'longitude': home_lon
-            }
-        }
-        storage.write('weather_cache.json', cache_data)
-        
-        # Record job execution
-        job_record = {
-            'job_type': 'weather_refresh',
-            'status': 'completed',
-            'started_at': start_time.isoformat(),
-            'completed_at': datetime.now().isoformat(),
-            'duration_seconds': (datetime.now() - start_time).total_seconds(),
-            'result': {
-                'location': 'Home',
-                'temperature': weather_data.get('current', {}).get('temperature'),
-                'comfort_score': weather_data.get('current', {}).get('comfort_score')
-            }
-        }
-        
-        # Save job history
         history = storage.read('job_history.json', default={'jobs': []})
         history['jobs'].append(job_record)
         history['jobs'] = history['jobs'][-100:]
         storage.write('job_history.json', history)
-        
-        logger.info(f"Weather refresh completed in {job_record['duration_seconds']:.1f}s")
+    except Exception as save_error:
+        logger.error(f"Failed to save job history: {save_error}")
+    return job_record
+
+
+def main():
+    """Refresh weather for the home location via the app's API."""
+    logger.info("=" * 60)
+    logger.info(f"Starting weather refresh cron job (via {BASE_URL})")
+    logger.info("=" * 60)
+
+    start_time = datetime.now()
+    storage = JSONStorage()
+
+    try:
+        # No lat/lon params: the endpoint defaults to the configured home
+        # location and populates WeatherService's cache server-side.
+        resp = requests.get(f"{BASE_URL}/api/weather", timeout=60)
+
+        if resp.status_code == 400:
+            logger.warning("No home location configured, skipping weather refresh")
+            return 0
+        resp.raise_for_status()
+
+        current = (resp.json() or {}).get('current') or {}
+        job_record = _record_job(storage, 'completed', start_time, result={
+            'location': 'Home',
+            'temperature': current.get('temperature'),
+            'comfort_score': current.get('comfort_score'),
+        })
+
+        logger.info(f"Weather refresh completed in "
+                    f"{job_record['duration_seconds']:.1f}s")
         logger.info(f"Temperature: {job_record['result']['temperature']}°F")
         logger.info(f"Comfort score: {job_record['result']['comfort_score']}/100")
-        
         return 0
-        
+
     except Exception as e:
         logger.error(f"Weather refresh failed: {e}", exc_info=True)
-        
-        # Send failure notification (weather is non-critical, so only log)
-        if notifier:
-            logger.info("Weather refresh failed but not sending notification (non-critical)")
-        
-        # Record failure
-        job_record = {
-            'job_type': 'weather_refresh',
-            'status': 'failed',
-            'started_at': start_time.isoformat(),
-            'completed_at': datetime.now().isoformat(),
-            'duration_seconds': (datetime.now() - start_time).total_seconds(),
-            'error': str(e)
-        }
-        
-        try:
-            history = storage.read('job_history.json', default={'jobs': []})
-            history['jobs'].append(job_record)
-            history['jobs'] = history['jobs'][-100:]
-            storage.write('job_history.json', history)
-        except Exception as save_error:
-            logger.error(f"Failed to save job history: {save_error}")
-        
+        _record_job(storage, 'failed', start_time, error=str(e))
         # Don't fail hard - weather refresh is non-critical
         logger.warning("Weather refresh failed but continuing (non-critical)")
         return 0
@@ -144,4 +114,3 @@ def main():
 
 if __name__ == '__main__':
     sys.exit(main())
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,10 @@ services:
       # container must explicitly opt back into 0.0.0.0. LAN exposure is actually
       # controlled by the "ports:" mapping below, not this value.
       - BIND_HOST=0.0.0.0
+      # Cap analysis worker processes: each ProcessPoolExecutor child forks a
+      # full copy of the numpy stack, which pushed the Pi into swap. 1 = run
+      # analysis sequentially in-process (RouteAnalyzer skips the pool).
+      - ANALYSIS_N_WORKERS=${ANALYSIS_N_WORKERS:-1}
       - NTFY_ENABLED=${NTFY_ENABLED:-false}
       - NTFY_SERVER=${NTFY_SERVER:-https://ntfy.sh}
       - NTFY_TOPIC=${NTFY_TOPIC:-ride-optimizer}

--- a/src/long_ride_analyzer.py
+++ b/src/long_ride_analyzer.py
@@ -552,7 +552,7 @@ class LongRideAnalyzer:
             import os
             cpu_count = os.cpu_count() or 2
             workload_size = len(activities_data)
-            
+
             # Intelligent worker selection based on workload
             if workload_size < 20:
                 # Small workload: 2 workers (minimum parallelism)
@@ -563,10 +563,24 @@ class LongRideAnalyzer:
             else:
                 # Large workload: up to 6 workers (maximum efficiency)
                 optimal_workers = min(6, cpu_count)
-            
+
+            # Memory-constrained deployments (the Pi container) cap this via
+            # ANALYSIS_N_WORKERS so analysis never forks extra numpy stacks.
+            env_cap = os.getenv('ANALYSIS_N_WORKERS')
+            if env_cap:
+                try:
+                    optimal_workers = max(1, min(optimal_workers, int(env_cap)))
+                except ValueError:
+                    pass
+
             max_workers = optimal_workers
             logger.info(f"Using {max_workers} workers for {workload_size} comparisons")
-        
+
+        # A 1-worker pool forks a full extra process for zero parallelism —
+        # fall through to the sequential path instead.
+        if max_workers is not None and max_workers <= 1:
+            use_parallel = False
+
         if use_parallel and len(activities_data) >= 10:
             # Use parallel processing (threshold: 10 items minimum)
             logger.info(f"Using parallel processing to match {len(activities_data)} unnamed rides...")

--- a/src/route_analyzer.py
+++ b/src/route_analyzer.py
@@ -765,7 +765,11 @@ class RouteAnalyzer:
         # Parallelise the inner comparison loop across n_workers processes.
         # The outer (pivot) loop remains sequential because each iteration
         # depends on which routes the previous one removed.
-        self._executor = ProcessPoolExecutor(max_workers=self.n_workers)
+        # With a single worker a pool would only fork one extra copy of the
+        # numpy stack for zero parallelism (a real cost on the Pi), so run
+        # the sequential path instead.
+        self._executor = (ProcessPoolExecutor(max_workers=self.n_workers)
+                          if self.n_workers > 1 else None)
         try:
             if home_to_work:
                 tqdm.write(f"   → Processing {len(home_to_work)} home→work routes "
@@ -785,8 +789,9 @@ class RouteAnalyzer:
                 groups.extend(wth_groups)
                 tqdm.write(f"   ✓ {len(wth_groups)} groups")
         finally:
-            self._executor.shutdown(wait=False, cancel_futures=True)
-            self._executor = None
+            if self._executor is not None:
+                self._executor.shutdown(wait=False, cancel_futures=True)
+                self._executor = None
 
         tqdm.write(f"   Total: {len(groups)} groups")
         logger.info(f"Created {len(groups)} route groups from {len(routes)} routes")

--- a/tests/test_cron_jobs.py
+++ b/tests/test_cron_jobs.py
@@ -42,110 +42,177 @@ def mock_storage():
     return storage
 
 
+def _http_response(status_code=200, json_data=None):
+    """Build a mock requests.Response."""
+    resp = Mock()
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = Exception(f"HTTP {status_code}")
+    else:
+        resp.raise_for_status.return_value = None
+    return resp
+
+
 class TestDailyAnalysisJob:
-    """Tests for daily_analysis.py cron job."""
-    
-    @patch('cron.daily_analysis.AnalysisService')
+    """Tests for daily_analysis.py cron job (thin HTTP client)."""
+
+    @patch('cron.daily_analysis.time.sleep')
+    @patch('cron.daily_analysis.requests.Session')
     @patch('cron.daily_analysis.JSONStorage')
     @patch('cron.daily_analysis.ConfigManager.get_instance')
-    def test_daily_analysis_success(self, mock_config, mock_storage_class, mock_service_class):
-        """Test daily analysis job runs successfully."""
-        # Setup mocks
+    def test_daily_analysis_success(self, mock_config, mock_storage_class,
+                                    mock_session_class, mock_sleep):
+        """Job triggers /api/analyze, polls to done, records history."""
         mock_storage = Mock()
         mock_storage.read.return_value = {'jobs': []}
         mock_storage_class.return_value = mock_storage
-        
-        mock_service = Mock()
-        mock_service.run_full_analysis.return_value = {
-            'success': True,
-            'activities_count': 100,
-            'route_groups_count': 10,
-            'long_rides_count': 5
-        }
-        mock_service_class.return_value = mock_service
-        
-        # Import and run
+
+        session = Mock()
+        session.get.side_effect = [
+            _http_response(json_data={'csrf_token': 'tok'}),
+            _http_response(json_data={'status': 'running'}),
+            _http_response(json_data={
+                'status': 'done',
+                'result': {'success': True, 'activities_count': 100,
+                           'route_groups_count': 10, 'long_rides_count': 5},
+            }),
+        ]
+        session.post.return_value = _http_response(
+            json_data={'status': 'started'})
+        mock_session_class.return_value = session
+
         from cron import daily_analysis
         result = daily_analysis.main()
-        
-        # Verify
+
         assert result == 0
-        mock_service.run_full_analysis.assert_called_once()
+        session.post.assert_called_once()
+        assert '/api/analyze' in session.post.call_args[0][0]
+        # CSRF token forwarded on the POST
+        assert session.post.call_args.kwargs['headers']['X-CSRFToken'] == 'tok'
         mock_storage.write.assert_called()
-    
-    @patch('cron.daily_analysis.AnalysisService')
+
+    @patch('cron.daily_analysis.time.sleep')
+    @patch('cron.daily_analysis.requests.Session')
     @patch('cron.daily_analysis.JSONStorage')
     @patch('cron.daily_analysis.ConfigManager.get_instance')
-    def test_daily_analysis_failure(self, mock_config, mock_storage_class, mock_service_class):
-        """Test daily analysis job handles failures."""
-        # Setup mocks
+    def test_daily_analysis_already_running(self, mock_config, mock_storage_class,
+                                            mock_session_class, mock_sleep):
+        """A 409 from /api/analyze is treated as a graceful skip."""
         mock_storage = Mock()
         mock_storage.read.return_value = {'jobs': []}
         mock_storage_class.return_value = mock_storage
-        
-        mock_service = Mock()
-        mock_service.run_full_analysis.side_effect = Exception('Test error')
-        mock_service_class.return_value = mock_service
-        
-        # Import and run
+
+        session = Mock()
+        session.get.return_value = _http_response(
+            json_data={'csrf_token': 'tok'})
+        session.post.return_value = _http_response(
+            status_code=409, json_data={'status': 'already_running'})
+        mock_session_class.return_value = session
+
+        from cron import daily_analysis
+        assert daily_analysis.main() == 0
+
+    @patch('cron.daily_analysis.time.sleep')
+    @patch('cron.daily_analysis.requests.Session')
+    @patch('cron.daily_analysis.JSONStorage')
+    @patch('cron.daily_analysis.ConfigManager.get_instance')
+    def test_daily_analysis_error_status(self, mock_config, mock_storage_class,
+                                         mock_session_class, mock_sleep):
+        """A job that ends in 'error' state exits 1 and records the failure."""
+        mock_storage = Mock()
+        mock_storage.read.return_value = {'jobs': []}
+        mock_storage_class.return_value = mock_storage
+
+        session = Mock()
+        session.get.side_effect = [
+            _http_response(json_data={'csrf_token': 'tok'}),
+            _http_response(json_data={'status': 'error',
+                                      'label': 'Error: boom'}),
+        ]
+        session.post.return_value = _http_response(
+            json_data={'status': 'started'})
+        mock_session_class.return_value = session
+
         from cron import daily_analysis
         result = daily_analysis.main()
-        
-        # Verify failure recorded
+
         assert result == 1
         mock_storage.write.assert_called()  # Should still record failure
 
-
-class TestWeatherRefreshJob:
-    """Tests for weather_refresh.py cron job."""
-    
-    @patch('cron.weather_refresh.WeatherService')
-    @patch('cron.weather_refresh.JSONStorage')
-    @patch('cron.weather_refresh.ConfigManager.get_instance')
-    def test_weather_refresh_success(self, mock_config, mock_storage_class, mock_service_class):
-        """Test weather refresh job runs successfully."""
-        # Setup mocks
-        mock_config_inst = Mock()
-        mock_config_inst.get.side_effect = lambda key: {
-            'location.home.latitude': 40.7128,
-            'location.home.longitude': -74.0060
-        }.get(key)
-        mock_config.return_value = mock_config_inst
-        
+    @patch('cron.daily_analysis.time.sleep')
+    @patch('cron.daily_analysis.requests.Session')
+    @patch('cron.daily_analysis.JSONStorage')
+    @patch('cron.daily_analysis.ConfigManager.get_instance')
+    def test_daily_analysis_app_unreachable(self, mock_config, mock_storage_class,
+                                            mock_session_class, mock_sleep):
+        """Connection failure exits 1 and records the failure."""
         mock_storage = Mock()
         mock_storage.read.return_value = {'jobs': []}
         mock_storage_class.return_value = mock_storage
-        
-        mock_service = Mock()
-        mock_service.get_current_weather.return_value = {
-            'current': {
-                'temperature': 72,
-                'comfort_score': 85
-            }
-        }
-        mock_service_class.return_value = mock_service
-        
-        # Import and run
-        from cron import weather_refresh
-        result = weather_refresh.main()
-        
-        # Verify
-        assert result == 0
-        mock_service.get_current_weather.assert_called_once()
+
+        session = Mock()
+        session.get.side_effect = Exception('connection refused')
+        mock_session_class.return_value = session
+
+        from cron import daily_analysis
+        result = daily_analysis.main()
+
+        assert result == 1
         mock_storage.write.assert_called()
-    
-    @patch('cron.weather_refresh.ConfigManager.get_instance')
-    def test_weather_refresh_no_location(self, mock_config):
-        """Test weather refresh skips when no location configured."""
-        mock_config_inst = Mock()
-        mock_config_inst.get.return_value = None
-        mock_config.return_value = mock_config_inst
-        
+
+
+class TestWeatherRefreshJob:
+    """Tests for weather_refresh.py cron job (thin HTTP client)."""
+
+    @patch('cron.weather_refresh.requests.get')
+    @patch('cron.weather_refresh.JSONStorage')
+    def test_weather_refresh_success(self, mock_storage_class, mock_get):
+        """Job hits /api/weather and records history."""
+        mock_storage = Mock()
+        mock_storage.read.return_value = {'jobs': []}
+        mock_storage_class.return_value = mock_storage
+
+        mock_get.return_value = _http_response(json_data={
+            'status': 'success',
+            'current': {'temperature': 72, 'comfort_score': 85},
+        })
+
         from cron import weather_refresh
         result = weather_refresh.main()
-        
-        # Should skip gracefully
+
         assert result == 0
+        assert '/api/weather' in mock_get.call_args[0][0]
+        mock_storage.write.assert_called()
+
+    @patch('cron.weather_refresh.requests.get')
+    @patch('cron.weather_refresh.JSONStorage')
+    def test_weather_refresh_no_location(self, mock_storage_class, mock_get):
+        """A 400 (no home location configured) is a graceful skip."""
+        mock_storage = Mock()
+        mock_storage.read.return_value = {'jobs': []}
+        mock_storage_class.return_value = mock_storage
+
+        mock_get.return_value = _http_response(status_code=400)
+
+        from cron import weather_refresh
+        assert weather_refresh.main() == 0
+
+    @patch('cron.weather_refresh.requests.get')
+    @patch('cron.weather_refresh.JSONStorage')
+    def test_weather_refresh_failure_non_critical(self, mock_storage_class, mock_get):
+        """Weather refresh failure is non-critical: exit 0, failure recorded."""
+        mock_storage = Mock()
+        mock_storage.read.return_value = {'jobs': []}
+        mock_storage_class.return_value = mock_storage
+
+        mock_get.side_effect = Exception('connection refused')
+
+        from cron import weather_refresh
+        result = weather_refresh.main()
+
+        assert result == 0
+        mock_storage.write.assert_called()
 
 
 class TestCacheCleanupJob:
@@ -255,27 +322,31 @@ class TestSystemHealthJob:
 class TestCronJobHistory:
     """Tests for job history tracking."""
     
+    @patch('cron.daily_analysis.time.sleep')
+    @patch('cron.daily_analysis.requests.Session')
     @patch('cron.daily_analysis.JSONStorage')
-    @patch('cron.daily_analysis.AnalysisService')
     @patch('cron.daily_analysis.ConfigManager.get_instance')
-    def test_job_history_recorded(self, mock_config, mock_service_class, mock_storage_class):
+    def test_job_history_recorded(self, mock_config, mock_storage_class,
+                                  mock_session_class, mock_sleep):
         """Test job execution is recorded in history."""
         # Setup mock storage
         mock_storage = Mock()
         mock_storage.read.return_value = {'jobs': []}
         mock_storage_class.return_value = mock_storage
-        
-        # Setup mock service
-        mock_service = Mock()
-        mock_service.run_full_analysis.return_value = {
-            'status': 'success',
-            'activities_count': 100
-        }
-        mock_service_class.return_value = mock_service
-        
+
+        session = Mock()
+        session.get.side_effect = [
+            _http_response(json_data={'csrf_token': 'tok'}),
+            _http_response(json_data={'status': 'done',
+                                      'result': {'activities_count': 100}}),
+        ]
+        session.post.return_value = _http_response(
+            json_data={'status': 'started'})
+        mock_session_class.return_value = session
+
         from cron import daily_analysis
         result = daily_analysis.main()
-        
+
         # Verify storage.write was called (job history recorded)
         assert mock_storage.write.called
         # Check that job_history.json was written


### PR DESCRIPTION
Part of #498 (Pi memory pressure / swap).

## What changed

**1. Cron jobs are now thin HTTP clients** (the biggest win)
- `cron/daily_analysis.py`: `POST /api/analyze` (CSRF token fetched from `/api/csrf-token`) + polls `/api/analyze/status` until done. Payload `{"fetch_new": true}` matches the old in-process behavior. 409 = graceful skip; configurable via `RIDE_OPTIMIZER_URL`, `ANALYSIS_TIMEOUT` (3h default), `ANALYSIS_POLL_INTERVAL`.
- `cron/weather_refresh.py`: `GET /api/weather` (defaults to home location, cached server-side).
- Both previously imported `AnalysisService`/`WeatherService` on the host, loading a second full numpy/sklearn/folium stack + entire activity history outside the container's 512MB limit at 2 AM.
- **Bonus bug fix**: the old weather cron wrote an incompatible schema into `data/weather_cache.json`, clobbering `WeatherService`'s `{'locations': ...}` cache format. Going through the API ends that.
- Job-history recording, ntfy failure alerts, and log files are preserved.

**2. `ANALYSIS_N_WORKERS` caps analysis parallelism**
- `docker-compose.yml` defaults it to `1` for the Pi.
- `AnalysisService` passes it to `RouteAnalyzer`; `LongRideAnalyzer`'s "intelligent 2–6" selection respects it as a cap.
- At 1 worker, both analyzers skip `ProcessPoolExecutor` entirely and use their existing sequential paths — no more forking an extra copy of the numpy stack for zero parallelism.

**3. BLAS thread caps in the Dockerfile**
- `OPENBLAS/OMP/MKL/NUMEXPR_NUM_THREADS=1` — BLAS defaults to one thread per core, multiplying pressure inside the container. Overridable at runtime.

## Tests
- `tests/test_cron_jobs.py` rewritten for the HTTP model (success, 409 skip, error status, unreachable app, 400 no-location, non-critical weather failure).
- Full suite: **1153 passed**, 5 pre-existing Windows chmod failures unchanged (known baseline).

## Deploy notes (Pi)
- Cron jobs now require the app container to be running (they already ran on the same host). No crontab changes needed.
- Optional: set `RIDE_OPTIMIZER_URL` in the host env if the app isn't on `127.0.0.1:8083`.
- Remaining Phase 1 ops task (not code): switch SD-card swap to zram.

## Verification plan (post-deploy)
- `podman stats` + `ps aux --sort=-rss` during an analysis run and across the 2 AM window; swap should stay near zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)