### PR TITLE
Phase 2 of #498: cached JSON reads, lazy folium, drop dead heavy deps, polyline simplification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,11 @@ ENV PYTHONUNBUFFERED=1 \
     MKL_NUM_THREADS=1 \
     NUMEXPR_NUM_THREADS=1
 
+# libcairo2/libpango*/libgdk-pixbuf/shared-mime-info/fonts-dejavu-core were
+# only needed by weasyprint (legacy CLI PDF export, removed from
+# requirements.txt in #498 Phase 2).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc g++ curl \
-    libcairo2 libpango-1.0-0 libpangocairo-1.0-0 \
-    libgdk-pixbuf2.0-0 libffi8 shared-mime-info fonts-dejavu-core \
+    gcc g++ curl libffi8 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/app/api/activity_cache.py
+++ b/app/api/activity_cache.py
@@ -1,0 +1,64 @@
+"""
+Shared, mtime-invalidated accessor for the raw Strava activity cache.
+
+stats_bp and data_bp each re-read and re-parsed data/cache/activities.json
+(and rebuilt every Activity object) on every request (#461). This module
+parses and converts once, then serves the same list until the file changes
+on disk.
+
+The returned list is SHARED across callers and threads — treat it as
+read-only. Copy (``list(...)``) before sorting or mutating.
+
+AnalysisService is not a substitute here: it only holds ``_activities``
+in memory after an in-process analysis run, not after loading from cache
+(see AnalysisService._load_from_cache — "we don't cache full activity
+objects").
+"""
+
+import threading
+from pathlib import Path
+from typing import List
+
+from src.secure_logger import SecureLogger
+
+logger = SecureLogger(__name__)
+
+_CACHE_PATH = Path('data/cache/activities.json')
+_guard = threading.Lock()
+_memo = {'stamp': None, 'activities': []}
+
+
+def load_cached_activities() -> List:
+    """Activity objects from data/cache/activities.json, cached by file mtime.
+
+    Returns [] if the cache file is missing or unreadable.
+    """
+    import json
+
+    from src.data_fetcher import Activity
+
+    try:
+        st = _CACHE_PATH.stat()
+    except OSError:
+        with _guard:
+            _memo['stamp'] = None
+            _memo['activities'] = []
+        return []
+    stamp = (st.st_mtime_ns, st.st_size)
+
+    with _guard:
+        if _memo['stamp'] == stamp:
+            return _memo['activities']
+
+    try:
+        with open(_CACHE_PATH, 'r') as f:
+            raw = json.load(f)
+        activities = [Activity.from_dict(a) for a in raw.get('activities', [])]
+    except Exception as e:
+        logger.warning(f"Could not load activities cache: {e}")
+        return []
+
+    with _guard:
+        _memo['stamp'] = stamp
+        _memo['activities'] = activities
+    return activities

--- a/app/api/data_bp.py
+++ b/app/api/data_bp.py
@@ -10,7 +10,6 @@ Routes:
   GET  /api/activities
 """
 
-import json
 import threading
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -272,12 +271,9 @@ def get_cache_info():
     if not cache_path.exists():
         return jsonify({'status': 'no_cache', 'activity_count': 0})
     try:
-        with open(cache_path) as f:
-            cache_data = json.load(f)
-        activities = cache_data.get('activities', cache_data) if isinstance(cache_data, dict) else cache_data
-        if not isinstance(activities, list):
-            return jsonify({'status': 'error', 'message': 'Cache format unrecognized'}), 500
-        dates = sorted(a['start_date'] for a in activities if isinstance(a, dict) and a.get('start_date'))
+        from app.api.activity_cache import load_cached_activities
+        activities = load_cached_activities()
+        dates = sorted(a.start_date for a in activities if a.start_date)
         stat = cache_path.stat()
         return jsonify({
             'status': 'ok',
@@ -305,7 +301,6 @@ def get_activities():
     - limit: max results (default 200)
     - offset: pagination offset (default 0)
     """
-    from src.data_fetcher import Activity as _Activity
     from datetime import timedelta
 
     gear_id = request.args.get('gear_id', '').strip() or None
@@ -318,16 +313,9 @@ def get_activities():
     except (ValueError, TypeError):
         limit, offset = 200, 0
 
-    # Load activities
-    cache_path = Path('data/cache/activities.json')
-    all_activities = []
-    if cache_path.exists():
-        try:
-            with open(cache_path, 'r') as f:
-                raw = json.load(f)
-            all_activities = [_Activity.from_dict(a) for a in raw.get('activities', [])]
-        except Exception as e:
-            logger.warning(f"Could not load activities: {e}")
+    # Load activities (shared cached list — read-only, copy before mutating)
+    from app.api.activity_cache import load_cached_activities
+    all_activities = load_cached_activities()
 
     # Filter by period
     now = datetime.now()
@@ -348,7 +336,8 @@ def get_activities():
         end = now.replace(year=now.year - 1, month=12, day=31, hour=23, minute=59, second=59, microsecond=0)
         activities = [a for a in all_activities if a.start_date and start <= _parse_date(a.start_date) <= end]
     else:
-        activities = all_activities
+        # Copy: the shared cached list must not be sorted in place below
+        activities = list(all_activities)
 
     # Load gear metadata
     analysis_service = current_app.container.analysis_service

--- a/app/api/maps_api.py
+++ b/app/api/maps_api.py
@@ -21,8 +21,13 @@ _storage = JSONStorage()
 
 
 def load_route_groups() -> Dict:
-    """Load route groups from data/route_groups.json (the data actually kept current by AnalysisService)."""
-    data = _storage.read('route_groups.json', default={})
+    """Load route groups from data/route_groups.json (the data actually kept current by AnalysisService).
+
+    Uses the shared parsed-JSON cache — this file is ~12MB and was being
+    re-parsed on every /api/maps/* request (#461). The returned groups are
+    shared; treat them as read-only.
+    """
+    data = _storage.read_cached('route_groups.json', default={}) or {}
     return {'groups': data.get('route_groups', [])}
 
 

--- a/app/api/stats_bp.py
+++ b/app/api/stats_bp.py
@@ -8,10 +8,8 @@ Routes:
   GET  /api/stats/backfill-gear-ids/status
 """
 
-import json
 import threading
 from datetime import datetime, timedelta
-from pathlib import Path
 from typing import Dict
 
 from flask import Blueprint, current_app, jsonify, request
@@ -30,18 +28,13 @@ bp = Blueprint('stats', __name__, url_prefix='/api')
 # ---------------------------------------------------------------------------
 
 def _load_activities_for_stats():
-    """Load raw activities from cache for stats computation."""
-    from src.data_fetcher import Activity as _Activity
-    cache_path = Path('data/cache/activities.json')
-    if not cache_path.exists():
-        return []
-    try:
-        with open(cache_path, 'r') as f:
-            raw = json.load(f)
-        return [_Activity.from_dict(a) for a in raw.get('activities', [])]
-    except Exception as e:
-        logger.warning(f"Could not load activities for stats: {e}")
-        return []
+    """Load raw activities from cache for stats computation.
+
+    Served from the shared mtime-invalidated cache — do not mutate the
+    returned list.
+    """
+    from app.api.activity_cache import load_cached_activities
+    return load_cached_activities()
 
 
 def _meters_to_miles(m):

--- a/app/services/commute_service.py
+++ b/app/services/commute_service.py
@@ -12,13 +12,14 @@ from html import escape
 from typing import List, Dict, Any, Optional, Tuple
 from datetime import datetime, time, date
 
-import folium
+# folium and src.visualizer (which imports folium) are imported lazily in the
+# map-generation methods to avoid startup cost on the Pi — see the same
+# pattern in analysis_service.py.
 
 from src.next_commute_recommender import NextCommuteRecommender, CommuteRecommendation
 from src.route_analyzer import RouteGroup
 from src.location_finder import Location
 from src.config_manager import ConfigManager
-from src.visualizer import RouteVisualizer
 from app.services.trainerroad_service import TrainerRoadService
 from app.services.weather_service import WeatherService
 from app.services.settings_service import SettingsService
@@ -350,7 +351,10 @@ class CommuteService:
         if not routes:
             logger.warning("No routes provided for commute comparison map")
             return None
-        
+
+        import folium  # lazy import to avoid startup cost on Pi
+        from src.visualizer import RouteVisualizer
+
         try:
             route_groups = []
             route_lookup = {}
@@ -525,11 +529,12 @@ class CommuteService:
         """
     
     def _add_commute_weather_overlay(self,
-                                     map_obj: folium.Map,
+                                     map_obj: 'folium.Map',
                                      routes: List[Dict[str, Any]],
                                      home_location: Location,
                                      work_location: Location) -> None:
         """Add toggleable current weather markers for commute locations and route midpoints."""
+        import folium  # lazy import to avoid startup cost on Pi
         weather_layer = folium.FeatureGroup(name='Weather Overlay', show=False)
         
         key_points: List[Tuple[str, Tuple[float, float], str]] = [

--- a/app/services/planner_service.py
+++ b/app/services/planner_service.py
@@ -13,7 +13,8 @@ from html import escape
 from typing import List, Dict, Any, Optional, Tuple
 from datetime import datetime, timedelta
 
-import folium
+# folium is imported lazily in the map-generation methods to avoid startup
+# cost on the Pi — see the same pattern in analysis_service.py.
 
 from src.long_ride_analyzer import LongRideAnalyzer, LongRide, RideRecommendation
 from src.config_manager import ConfigManager
@@ -944,7 +945,9 @@ class PlannerService:
         if not long_rides:
             logger.warning("No long rides provided for map generation")
             return None
-        
+
+        import folium  # lazy import to avoid startup cost on Pi
+
         try:
             # Collect all rides from all days
             all_rides = []
@@ -1131,13 +1134,14 @@ class PlannerService:
         return '#dc3545'
     
     def _add_weather_segmented_route(self,
-                                     feature_group: folium.FeatureGroup,
+                                     feature_group: 'folium.FeatureGroup',
                                      coordinates: List[Tuple[float, float]],
                                      weather_score: float,
                                      popup_html: str,
                                      ride_name: str,
                                      ride_distance: float) -> None:
         """Draw route segments with semantic weather coloring."""
+        import folium  # lazy import to avoid startup cost on Pi
         if len(coordinates) < 2:
             return
         
@@ -1166,10 +1170,11 @@ class PlannerService:
             ).add_to(feature_group)
     
     def _add_weather_forecast_markers(self,
-                                      weather_overlay: folium.FeatureGroup,
+                                      weather_overlay: 'folium.FeatureGroup',
                                       ride_obj: LongRide,
                                       ride: Dict[str, Any]) -> None:
         """Add forecast markers at start, midpoint, and end for long ride routes."""
+        import folium  # lazy import to avoid startup cost on Pi
         points = [
             ('Start', ride_obj.coordinates[0]),
             ('Midpoint', ride_obj.coordinates[len(ride_obj.coordinates) // 2]),

--- a/requirements-dev.lock.txt
+++ b/requirements-dev.lock.txt
@@ -10,24 +10,23 @@ blinker==1.9.0
     # via flask
 branca==0.8.2
     # via folium
-brotli==1.2.0
-    # via fonttools
 certifi==2026.6.17
     # via requests
 cffi==2.1.0
-    # via
-    #   cryptography
-    #   weasyprint
+    # via cryptography
 charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via flask
+colorama==0.4.6
+    # via
+    #   click
+    #   pytest
+    #   tqdm
 coverage==7.15.0
     # via pytest-cov
 cryptography==49.0.0
     # via -r requirements.txt
-cssselect2==0.9.0
-    # via weasyprint
 defusedxml==0.7.1
     # via -r requirements.txt
 deprecated==1.3.1
@@ -39,13 +38,10 @@ flask==3.1.3
     #   -r requirements.txt
     #   flask-cors
     #   flask-limiter
-    #   flask-sqlalchemy
     #   flask-wtf
 flask-cors==6.0.5
     # via -r requirements.txt
 flask-limiter==4.1.1
-    # via -r requirements.txt
-flask-sqlalchemy==3.1.1
     # via -r requirements.txt
 flask-wtf==1.3.0
     # via -r requirements.txt
@@ -55,8 +51,6 @@ flexparser==0.4
     # via pint
 folium==0.20.0
     # via -r requirements.txt
-fonttools==4.63.0
-    # via weasyprint
 garth==0.8.0
     # via -r requirements.txt
 geographiclib==2.1
@@ -147,10 +141,6 @@ packaging==26.2
     #   pytest
 pandas==3.0.3
     # via -r requirements.txt
-pillow==12.3.0
-    # via
-    #   qrcode
-    #   weasyprint
 pint==0.25.3
     # via stravalib
 platformdirs==4.10.0
@@ -179,14 +169,10 @@ pydantic-core==2.46.4
     # via pydantic
 pydantic-settings==2.14.2
     # via garth
-pydyf==0.12.1
-    # via weasyprint
 pygments==2.20.0
     # via
     #   pytest
     #   rich
-pyphen==0.17.2
-    # via weasyprint
 pytest==9.1.1
     # via
     #   -r requirements-dev.txt
@@ -206,8 +192,6 @@ python-dotenv==1.2.2
     #   -r requirements.txt
     #   pydantic-settings
 pyyaml==6.0.3
-    # via -r requirements.txt
-qrcode==8.2
     # via -r requirements.txt
 requests==2.34.2
     # via
@@ -234,20 +218,10 @@ six==1.17.0
     # via python-dateutil
 soupsieve==2.8.4
     # via beautifulsoup4
-sqlalchemy==2.0.51
-    # via
-    #   -r requirements.txt
-    #   flask-sqlalchemy
 stravalib==2.5.0
     # via -r requirements.txt
 threadpoolctl==3.6.0
     # via scikit-learn
-tinycss2==1.5.1
-    # via
-    #   cssselect2
-    #   weasyprint
-tinyhtml5==2.1.0
-    # via weasyprint
 tqdm==4.68.4
     # via -r requirements.txt
 typing-extensions==4.16.0
@@ -265,7 +239,6 @@ typing-extensions==4.16.0
     #   pint
     #   pydantic
     #   pydantic-core
-    #   sqlalchemy
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -275,15 +248,9 @@ tzdata==2026.3
     # via
     #   arrow
     #   icalendar
+    #   pandas
 urllib3==2.7.0
     # via requests
-weasyprint==69.0
-    # via -r requirements.txt
-webencodings==0.5.1
-    # via
-    #   cssselect2
-    #   tinycss2
-    #   tinyhtml5
 werkzeug==3.1.8
     # via
     #   flask
@@ -296,5 +263,3 @@ wtforms==3.2.2
     # via flask-wtf
 xyzservices==2026.3.0
     # via folium
-zopfli==0.4.3
-    # via fonttools

--- a/requirements.lock.txt
+++ b/requirements.lock.txt
@@ -8,22 +8,20 @@ blinker==1.9.0
     # via flask
 branca==0.8.2
     # via folium
-brotli==1.2.0
-    # via fonttools
 certifi==2026.6.17
     # via requests
 cffi==2.1.0
-    # via
-    #   cryptography
-    #   weasyprint
+    # via cryptography
 charset-normalizer==3.4.9
     # via requests
 click==8.4.2
     # via flask
+colorama==0.4.6
+    # via
+    #   click
+    #   tqdm
 cryptography==49.0.0
     # via -r requirements.txt
-cssselect2==0.9.0
-    # via weasyprint
 defusedxml==0.7.1
     # via -r requirements.txt
 deprecated==1.3.1
@@ -35,13 +33,10 @@ flask==3.1.3
     #   -r requirements.txt
     #   flask-cors
     #   flask-limiter
-    #   flask-sqlalchemy
     #   flask-wtf
 flask-cors==6.0.5
     # via -r requirements.txt
 flask-limiter==4.1.1
-    # via -r requirements.txt
-flask-sqlalchemy==3.1.1
     # via -r requirements.txt
 flask-wtf==1.3.0
     # via -r requirements.txt
@@ -51,8 +46,6 @@ flexparser==0.4
     # via pint
 folium==0.20.0
     # via -r requirements.txt
-fonttools==4.63.0
-    # via weasyprint
 garth==0.8.0
     # via -r requirements.txt
 geographiclib==2.1
@@ -140,10 +133,6 @@ packaging==26.2
     #   opentelemetry-instrumentation
 pandas==3.0.3
     # via -r requirements.txt
-pillow==12.3.0
-    # via
-    #   qrcode
-    #   weasyprint
 pint==0.25.3
     # via stravalib
 platformdirs==4.10.0
@@ -168,12 +157,8 @@ pydantic-core==2.46.4
     # via pydantic
 pydantic-settings==2.14.2
     # via garth
-pydyf==0.12.1
-    # via weasyprint
 pygments==2.20.0
     # via rich
-pyphen==0.17.2
-    # via weasyprint
 python-dateutil==2.9.0.post0
     # via
     #   arrow
@@ -184,8 +169,6 @@ python-dotenv==1.2.2
     #   -r requirements.txt
     #   pydantic-settings
 pyyaml==6.0.3
-    # via -r requirements.txt
-qrcode==8.2
     # via -r requirements.txt
 requests==2.34.2
     # via
@@ -210,20 +193,10 @@ similaritymeasures==1.4.0
     # via -r requirements.txt
 six==1.17.0
     # via python-dateutil
-sqlalchemy==2.0.51
-    # via
-    #   -r requirements.txt
-    #   flask-sqlalchemy
 stravalib==2.5.0
     # via -r requirements.txt
 threadpoolctl==3.6.0
     # via scikit-learn
-tinycss2==1.5.1
-    # via
-    #   cssselect2
-    #   weasyprint
-tinyhtml5==2.1.0
-    # via weasyprint
 tqdm==4.68.4
     # via -r requirements.txt
 typing-extensions==4.16.0
@@ -240,7 +213,6 @@ typing-extensions==4.16.0
     #   pint
     #   pydantic
     #   pydantic-core
-    #   sqlalchemy
     #   typing-inspection
 typing-inspection==0.4.2
     # via
@@ -250,15 +222,9 @@ tzdata==2026.3
     # via
     #   arrow
     #   icalendar
+    #   pandas
 urllib3==2.7.0
     # via requests
-weasyprint==69.0
-    # via -r requirements.txt
-webencodings==0.5.1
-    # via
-    #   cssselect2
-    #   tinycss2
-    #   tinyhtml5
 werkzeug==3.1.8
     # via
     #   flask
@@ -271,5 +237,3 @@ wtforms==3.2.2
     # via flask-wtf
 xyzservices==2026.3.0
     # via folium
-zopfli==0.4.3
-    # via fonttools

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,17 +13,18 @@ scipy>=1.9.0
 similaritymeasures>=0.5.0
 cryptography>=41.0.0
 tqdm>=4.65.0
-qrcode[pil]>=7.4.2
-weasyprint>=60.0
 defusedxml>=0.7.1
 gunicorn>=21.2.0
 flask>=3.0.0
 flask-cors>=4.0.0
-flask-sqlalchemy>=3.1.1
 flask-wtf>=1.2.0
 flask-limiter>=3.5.0
-sqlalchemy>=2.0.16
 icalendar>=5.0.0
 marshmallow>=3.20.0
 garth>=0.4.0
 psutil>=5.9.0
+
+# Legacy-CLI-only extras (report_generator.py PDF/QR export via deprecated
+# main.py; degrades gracefully when absent — #467, #498). Install manually if
+# you need the CLI PDF reports:
+#   pip install "qrcode[pil]>=7.4.2" "weasyprint>=60.0"

--- a/src/json_storage.py
+++ b/src/json_storage.py
@@ -28,6 +28,14 @@ logger = SecureLogger(__name__)
 _THREAD_LOCKS: dict[str, threading.Lock] = {}
 _THREAD_LOCKS_GUARD = threading.Lock()
 
+# Parsed-JSON read cache keyed by resolved file path, invalidated by file
+# (mtime_ns, size). Module-level for the same reason as _THREAD_LOCKS: all
+# JSONStorage instances over the same file share one cached parse. This
+# exists for the large hot files (route_groups.json is ~12MB on disk) that
+# were being re-read and re-parsed on every API request (#461).
+_READ_CACHE: dict[str, tuple] = {}
+_READ_CACHE_GUARD = threading.Lock()
+
 
 def secure_chmod(path) -> None:
     """
@@ -172,7 +180,43 @@ class JSONStorage:
         except Exception as e:
             logger.error(f"Error reading {filename}: {e}", exc_info=True)
             return default
-    
+
+    def read_cached(self, filename: str, default: Any = None) -> Any:
+        """
+        Read JSON with an in-process cache invalidated by file (mtime, size).
+
+        Repeated calls return the same parsed object until the file changes
+        on disk (writes through JSONStorage rename the file, which bumps the
+        mtime and invalidates naturally). Use for large, frequently-read,
+        rarely-written files where a per-request re-parse is the bottleneck.
+
+        The returned object is SHARED across callers and threads — treat it
+        as read-only. Copy before sorting or mutating.
+        """
+        filepath = self._validate_filename(filename)
+        key = str(filepath)
+
+        try:
+            st = filepath.stat()
+        except OSError:
+            # Missing file: drop any stale entry so a later recreate re-reads
+            with _READ_CACHE_GUARD:
+                _READ_CACHE.pop(key, None)
+            return default
+        stamp = (st.st_mtime_ns, st.st_size)
+
+        with _READ_CACHE_GUARD:
+            hit = _READ_CACHE.get(key)
+            if hit is not None and hit[0] == stamp:
+                return hit[1]
+
+        data = self.read(filename, default=default)
+        # Don't cache failures/defaults — let the next call retry the read
+        if data is not default:
+            with _READ_CACHE_GUARD:
+                _READ_CACHE[key] = (stamp, data)
+        return data
+
     def write(self, filename: str, data: Any) -> bool:
         """
         Write JSON file atomically with proper permissions and path validation.

--- a/src/report_generator.py
+++ b/src/report_generator.py
@@ -19,8 +19,10 @@ from typing import Dict, Any
 # defusedxml is only needed for parsing untrusted XML input
 from xml.etree import ElementTree as ET
 
-# qrcode is a hard dependency (requirements.txt); this import-fallback only
-# guards against it being missing from the environment, not a feature flag.
+# qrcode and weasyprint are optional extras (removed from requirements.txt in
+# #498 Phase 2 — this legacy-CLI-only module was the sole consumer). QR/PDF
+# export degrades gracefully when they're absent; install manually if needed:
+#   pip install "qrcode[pil]>=7.4.2" "weasyprint>=60.0"
 try:
     import qrcode
     QRCODE_AVAILABLE = True

--- a/src/visualizer.py
+++ b/src/visualizer.py
@@ -8,7 +8,8 @@ Licensed under the MIT License - see LICENSE file for details.
 """
 
 from .secure_logger import SecureLogger
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Tuple
+import math
 
 import folium
 from folium import plugins
@@ -19,6 +20,68 @@ from .route_namer import RouteNamer
 from .units import UnitConverter
 
 logger = SecureLogger(__name__)
+
+
+def simplify_coordinates(coords: List[Tuple[float, float]],
+                          tolerance_deg: float = 0.00005) -> List[Tuple[float, float]]:
+    """
+    Simplify a route's coordinate list with the (iterative) Douglas-Peucker algorithm.
+
+    Full-resolution GPS tracks can have a point every few meters, and Folium embeds
+    every coordinate directly into the generated map's SVG/JS, so large routes bloat
+    map HTML size and render cost with no visible benefit at typical zoom levels.
+
+    Implemented directly (no shapely dependency) since shapely is only an optional,
+    try/except-gated dependency elsewhere in this codebase (coverage_tracker.py), not
+    a guaranteed one.
+
+    Args:
+        coords: List of (lat, lon) tuples
+        tolerance_deg: Maximum perpendicular distance (in degrees) a point may deviate
+            from the simplified line before it's kept as significant. The default
+            (~0.00005 deg) is roughly 5m at mid-latitudes.
+
+    Returns:
+        Simplified list of (lat, lon) tuples. Always keeps both endpoints.
+    """
+    n = len(coords)
+    if n < 3:
+        return list(coords)
+
+    def _perp_distance(point, start, end) -> float:
+        x, y = point
+        x1, y1 = start
+        x2, y2 = end
+        if (x1, y1) == (x2, y2):
+            return math.hypot(x - x1, y - y1)
+        num = abs((y2 - y1) * x - (x2 - x1) * y + x2 * y1 - y2 * x1)
+        den = math.hypot(y2 - y1, x2 - x1)
+        return num / den
+
+    keep = [False] * n
+    keep[0] = keep[-1] = True
+
+    # Iterative (stack-based) rather than recursive to avoid Python recursion-depth
+    # issues on very long, low-curvature routes.
+    stack = [(0, n - 1)]
+    while stack:
+        start_idx, end_idx = stack.pop()
+        if end_idx - start_idx < 2:
+            continue
+        start, end = coords[start_idx], coords[end_idx]
+        max_dist = -1.0
+        max_idx = start_idx
+        for i in range(start_idx + 1, end_idx):
+            dist = _perp_distance(coords[i], start, end)
+            if dist > max_dist:
+                max_dist = dist
+                max_idx = i
+        if max_dist > tolerance_deg:
+            keep[max_idx] = True
+            stack.append((start_idx, max_idx))
+            stack.append((max_idx, end_idx))
+
+    return [c for c, k in zip(coords, keep) if k]
 
 
 class RouteVisualizer:
@@ -157,10 +220,15 @@ class RouteVisualizer:
         
         # Build className with all applicable classes
         class_names = f"route-line route-{route_group.id} {direction_class} {plus_class}".strip()
-        
+
+        # Simplify before embedding into the map — full-resolution GPS tracks bloat the
+        # generated HTML/SVG with points too close together to matter at map zoom levels.
+        simplify_tolerance = self.config.get('visualization.route_simplify_tolerance_deg', 0.00005)
+        render_coords = simplify_coordinates(coords, simplify_tolerance)
+
         # Add polyline with custom class and data attributes for JavaScript interaction
         folium.PolyLine(
-            coords,
+            render_coords,
             color=color,
             weight=weight,
             opacity=opacity,
@@ -293,13 +361,15 @@ class RouteVisualizer:
         if self.map is None:
             raise ValueError("Map not initialized. Call create_base_map() first.")
         
-        # Collect all coordinates from all routes
+        # Collect all coordinates from all routes (simplified — a heatmap doesn't need
+        # full-resolution GPS density, and this is summed across every route in every
+        # group, which can be a lot of points).
         heat_data = []
-        
+        simplify_tolerance = self.config.get('visualization.route_simplify_tolerance_deg', 0.00005)
+
         for group in self.route_groups:
             for route in group.routes:
-                # Add all coordinates
-                for coord in route.coordinates:
+                for coord in simplify_coordinates(route.coordinates, simplify_tolerance):
                     heat_data.append([coord[0], coord[1]])
         
         if heat_data:
@@ -489,10 +559,12 @@ class RouteVisualizer:
         
         if optimal_route.representative_route and optimal_route.representative_route.coordinates:
             coords = optimal_route.representative_route.coordinates
-            
+            simplify_tolerance = self.config.get('visualization.route_simplify_tolerance_deg', 0.00005)
+            render_coords = simplify_coordinates(coords, simplify_tolerance)
+
             # Add route polyline
             folium.PolyLine(
-                coords,
+                render_coords,
                 color=optimal_color,
                 weight=optimal_weight,
                 opacity=0.8,

--- a/src/weather_fetcher.py
+++ b/src/weather_fetcher.py
@@ -24,19 +24,23 @@ class WeatherFetcher:
     """Fetches weather data from Open-Meteo API (free, no API key needed)."""
     
     def __init__(self, cache_radius_km: float = 2.0, cache_duration_hours: float = 1.5,
-                 cache_file: Optional[str] = None):
+                 cache_file: Optional[str] = None, max_cache_entries: int = 500):
         """
         Initialize weather fetcher.
-        
+
         Args:
             cache_radius_km: Radius in km to consider locations as "same" for caching (default 2.0)
             cache_duration_hours: How long to cache weather data in hours (default 1.5 = 90 minutes)
             cache_file: Path to cache file (default: cache/weather_cache.json)
+            max_cache_entries: Hard cap on cache size. Once exceeded, the oldest entries are
+                evicted regardless of TTL, bounding both memory use and the cost of the linear
+                scan _find_cached_weather does on every lookup (default 500).
         """
         self.base_url = "https://api.open-meteo.com/v1/forecast"
         self.session = requests.Session()
         self.cache_radius_km = cache_radius_km
         self.cache_duration_hours = cache_duration_hours
+        self.max_cache_entries = max_cache_entries
         
         # Set up cache file path
         if cache_file is None:
@@ -103,7 +107,25 @@ class WeatherFetcher:
             
         except Exception as e:
             logger.error(f"Error saving cache file: {e}")
-        
+
+    def _evict_oldest_if_needed(self) -> None:
+        """
+        Bound cache size regardless of TTL.
+
+        _find_cached_weather already prunes expired entries lazily as it scans, but a
+        session that queries many distinct locations within a single cache_duration_hours
+        window can still grow the cache without limit. Evict the oldest entries by
+        timestamp once max_cache_entries is exceeded.
+        """
+        overflow = len(self.cache) - self.max_cache_entries
+        if overflow <= 0:
+            return
+        oldest_keys = sorted(self.cache.keys(), key=lambda k: self.cache[k]['timestamp'])[:overflow]
+        for key in oldest_keys:
+            del self.cache[key]
+        logger.debug(f"Evicted {overflow} oldest weather cache entries "
+                     f"(cache size capped at {self.max_cache_entries})")
+
     def _find_cached_weather(self, lat: float, lon: float) -> Optional[Dict]:
         """
         Find cached weather data for a nearby location (if not expired).
@@ -205,6 +227,7 @@ class WeatherFetcher:
                 'data': conditions,
                 'timestamp': datetime.now()
             }
+            self._evict_oldest_if_needed()
 
             if save_cache:
                 self._save_cache()


### PR DESCRIPTION
Part of #498 (Pi memory pressure). Two commits — my Phase 2 work plus a co-resident agent commit (46db85f) that landed on this branch covering the #466 bundle.

## Commit 00d56f7 (this session)

**1. Shared parsed-JSON caches (#461)**
- `JSONStorage.read_cached()`: module-level parse cache keyed by resolved path, invalidated by `(mtime_ns, size)`. Writes through JSONStorage rename the file, so invalidation is automatic.
- `maps_api` now uses it for `route_groups.json` (~12MB, previously re-parsed on **every** `/api/maps/*` request).
- New `app/api/activity_cache.py`: mtime-memoized `Activity` list shared by `stats_bp` (`/api/stats`) and `data_bp` (`/api/activities`, `/api/cache-info`), each of which previously re-read and re-converted `data/cache/activities.json` per request.
- Cached objects documented as shared/read-only; the one in-place `.sort()` consumer now copies first.

**2. Lazy folium (completing the existing pattern)**
- `commute_service` and `planner_service` no longer import folium (or `src.visualizer`, which pulls it transitively) at module level — only inside the map-generation methods. Verified `folium` absent from `sys.modules` after importing both services.

**3. Dead heavy deps removed**
- `weasyprint`, `qrcode[pil]`, `flask-sqlalchemy`, `sqlalchemy` dropped from `requirements.txt`; both uv lock files regenerated; pango/cairo/gdk-pixbuf apt packages removed from the Dockerfile (existed only for weasyprint). Sole consumer is legacy-CLI-only `report_generator.py` (#467), which already degrades gracefully — manual install instructions left in comments. Shrinks the image and every process's baseline.

## Commit 46db85f (co-resident agent, verified compatible — no file overlap)
- `visualizer.py`: dependency-free Douglas-Peucker simplification applied to route polylines and heatmap points before Folium embedding (#466).
- `weather_fetcher.py`: bounded weather cache (`max_cache_entries=500`) with eviction (#466).
- Confirms #464/#476 were already resolved by `09d272c`.

## Tests
Full suite: **1153 passed**, 11 skipped, same 5 pre-existing Windows chmod/permission failures as baseline (both commits ran the suite independently).

## Notes
- Local `ISSUE_PRIORITIES.md` has an uncommitted auto-generated refresh with degraded data ("Next Release: unknown") — intentionally excluded from this PR.
- Deploy: standard GHCR pull + `podman-compose up -d` on pi4; no config/crontab changes needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)