### PR TITLE
Full-history Strava backfill (#486) + local-day stats bucketing (#496)

### DIFF
--- a/ISSUE_PRIORITIES.md
+++ b/ISSUE_PRIORITIES.md
@@ -1,6 +1,6 @@
 # Issue Prioritization
 
-**Last Updated:** 2026-07-15 21:30:57 UTC / 2026-07-15 16:30:57 CDT
+**Last Updated:** 2026-07-16 23:38:10 UTC / 2026-07-16 23:38:10 GMT
 
 This file reflects the current state of GitHub issues organized by release milestone and priority within each release.
 
@@ -9,51 +9,8 @@ This file reflects the current state of GitHub issues organized by release miles
 ## 📍 Release Context
 
 - **Current Release:** none (deployed, milestone fully closed)
-- **Next Release:** v0.18.0 (in development)
+- **Next Release:** unknown (in development)
 - **Future Releases:** 
-
----
-
-## 🎯 v0.18.0 (Next Release - IN DEVELOPMENT)
-
-**Priority within this release determines work order. Complete P0/P1 issues before moving to future releases.**
-
-### 🔴 P0 - CRITICAL
-**No P0 issues** ✅
-
-### 🔴 P1 - HIGH
-- #493 - Explore: plotted road routes can claim zero of their highlighted new tiles — never verified against the actual route
-- #489 - Explore: replace implicit round-trip with explicit route shape (Loop / Out-and-back / Point-to-point)
-- #484 - TrainerRoad TSS extraction matches the first number in any description — 'IF 0.85' or '3x10 min' becomes TSS
-- #483 - Surface breakdown weights every ORS segment equally instead of by its coordinate span — paved/unpaved percentages are wrong
-- #477 - route_analyzer.py::_open_geocoding_terminal is macOS-only, silently no-ops on Windows/Linux
-
-### 🟡 P2 - MEDIUM
-- #492 - Epic: Explore Route Generator — Shape/Duration/Area Targeting, Trim Coverage-Browser Scope
-- #491 - Explore: let rider draw/select a target area instead of only start-point + radius
-- #490 - Explore: add duration-based route target alongside distance
-- #488 - Explore: fold full-map coverage browsing into route-generation feedback; drop standalone browse mode
-- #487 - Explore: audit and prune optimizeFor strategy sprawl (tiles/distance/efficiency/infill/frontier)
-- #481 - /api/exploration/roads: unbounded bbox can OOM the Pi via osmnx, and road_network.graphml cache ignores requested bounds (wrong results after panning)
-- #465 - json_storage.py has no file locking on Windows (only atomic rename)
-- #463 - route_analyzer.py/long_ride_analyzer.py duplicate similarity logic instead of shared route_comparison.py
-- #461 - Duplicate uncached JSON cache reads + full service re-init after routine actions
-- #460 - Two divergent create_app() factories + dead scheduler/config infra
-- #459 - Lost-update races in read-modify-write JSON flows (plan storage, TrainerRoad cache)
-- #451 - Exploration route generator: extend overlap penalty to tiles claimed within the in-progress tour
-
-### 🟢 P3 - LOW
-- #484 - TrainerRoad TSS extraction matches the first number in any description — 'IF 0.85' or '3x10 min' becomes TSS
-- #483 - Surface breakdown weights every ORS segment equally instead of by its coordinate span — paved/unpaved percentages are wrong
-- #482 - /api/exploration/route: waypoints not validated (500s on malformed input, no count cap → ORS quota burn) and route memo cache grows unbounded
-- #477 - route_analyzer.py::_open_geocoding_terminal is macOS-only, silently no-ops on Windows/Linux
-- #467 - Legacy report_generator.py/main.py — decide relocation vs keeping in src/
-- #453 - Exploration route generator: wind-aware outbound/return orientation (headwind out, tailwind back)
-- #452 - Exploration route generator: detect and label unavoidable out-and-back routes
-- #430 - Coverage tracker should include Garmin activities, not just Strava
-
-### 📋 P4 - FUTURE
-**No P4 issues** ✅
 
 ---
 
@@ -68,32 +25,23 @@ None
 - #486 - Activity fetch caps at 500 most-recent activities — no pagination backfill for full Strava history
 
 ### 🟡 P2 - MEDIUM
-- #495 - before_date in /api/fetch and /api/analyze is an exclusive bound — selecting an end date excludes that whole day
-- #494 - Date-only fetch params (after_date/before_date) treated as UTC midnight instead of local, shifting Strava query windows
-- #474 - app/schemas.py validation schemas (RoutesQuerySchema, MapQuerySchema) defined but never wired up
-- #473 - maps_api.py::load_route_groups() reads a cache path that looks stale — verify /api/maps/* isn't silently empty
-- #464 - get_prevailing_wind_direction ignores lat/lon, always returns Chicago-specific data
-- #462 - Duplicate backup scripts (backup-env.sh vs backup_env.sh) — consolidate
+None
 
 ### 🟢 P3 - LOW
 - #496 - Reports stats bucket activities by UTC calendar day, not local day — late-night rides can land in the wrong day/month
-- #476 - Ad-hoc time.sleep(2) rate-limit workaround embedded in data_bp.py progress callback
-- #466 - Performance backlog: weather cache growth/rewrites, map simplification, redundant geodesic scans
 
 ### 📋 P4 - FUTURE
 None
 
 ### ⚠️ Unprioritized (No P-label)
-None
+- #498 - Pi memory pressure: app swaps heavily — eliminate duplicate host stack, cap parallelism, stop re-parsing large JSON
 
 ---
 
 ## 📝 Workspace TODOs & Tasks
 Code comments and inline tasks found in the workspace that may need attention.
 
-Found **1** code comments requiring attention:
-
-- `static/js/dashboard.js` - 6:// NOTE: Initialization is handled by inline script in index.html
+**No TODO/FIXME comments found in code** ✅
 
 ## 📖 Priority System (Release-Aware)
 

--- a/app/api/data_bp.py
+++ b/app/api/data_bp.py
@@ -6,6 +6,9 @@ Routes:
   POST /api/analyze/stop
   POST /api/fetch
   GET  /api/fetch/status
+  POST /api/fetch/backfill-history
+  GET  /api/fetch/backfill-history/status
+  POST /api/fetch/backfill-history/stop
   GET  /api/cache-info
   GET  /api/activities
 """
@@ -266,6 +269,92 @@ def get_fetch_status():
     return jsonify(current_app.container.jobs.fetch.snapshot())
 
 
+@bp.route('/fetch/backfill-history', methods=['POST'])
+@limiter.limit("2 per minute")
+def trigger_history_backfill():
+    """
+    Page backward through the account's full Strava history (issue #486).
+
+    A normal fetch only ever returns the most recent `max_activities`
+    activities. This walks backward with `before=` until it reaches the
+    start of history or catches up to what's already cached. Explicit,
+    user-triggered action — not run as part of the normal fetch/analyze flow.
+    """
+    jobs = current_app.container.jobs
+    if not jobs.history_backfill.try_start({
+        'status': 'running',
+        'new_total': 0,
+        'pages': 0,
+        'label': 'Starting full history backfill…',
+        'started_at': datetime.now().isoformat(),
+    }):
+        return jsonify({'status': 'already_running'}), 409
+
+    container = current_app.container
+    container.initialise()
+
+    analysis_service = container.analysis_service
+    if analysis_service is None:
+        jobs.history_backfill.reset({'status': 'idle'})
+        return jsonify({'status': 'error', 'message': 'Analysis is currently unavailable'}), 503
+
+    jobs.history_backfill_stop.clear()
+
+    def _progress(new_total, pages, oldest_seen):
+        label = f'Paging back through history… {new_total:,} new activities found ({pages} pages)'
+        if oldest_seen:
+            label += f', now at {oldest_seen.date()}'
+        jobs.history_backfill.update(new_total=new_total, pages=pages, label=label)
+
+    def _run():
+        try:
+            result = analysis_service.data_fetcher.backfill_full_history(
+                progress_callback=_progress,
+                stop_check=jobs.history_backfill_stop.is_set,
+            )
+            new_total = result['new_total']
+            if new_total > 0:
+                jobs.history_backfill.update(
+                    label=f'Backfill done — {new_total:,} new activities. Running incremental analysis…',
+                    new_total=new_total,
+                    pages=result['pages'],
+                )
+                analysis_service.run_full_analysis(force_refresh=False, skip_strava_fetch=True)
+                container.reset_initialisation()
+                jobs.history_backfill.update(
+                    status='done',
+                    label=f'Done — {new_total:,} new activities backfilled (analysis updated)',
+                )
+            else:
+                jobs.history_backfill.update(
+                    status='done',
+                    label='Done — cache already had full history, nothing new found',
+                )
+        except Exception as e:
+            logger.error(f"Background history backfill failed: {e}", exc_info=True)
+            jobs.history_backfill.update(status='error', label=f'Error: {e}')
+        finally:
+            jobs.history_backfill_stop.clear()
+
+    threading.Thread(target=_run, daemon=True).start()
+    return jsonify({'status': 'started'})
+
+
+@bp.route('/fetch/backfill-history/status')
+def get_history_backfill_status():
+    return jsonify(current_app.container.jobs.history_backfill.snapshot())
+
+
+@bp.route('/fetch/backfill-history/stop', methods=['POST'])
+def stop_history_backfill():
+    jobs = current_app.container.jobs
+    if jobs.history_backfill.get('status') != 'running':
+        return jsonify({'status': 'not_running'}), 400
+    jobs.history_backfill_stop.set()
+    jobs.history_backfill.update(label='Stopping…')
+    return jsonify({'status': 'stopping'})
+
+
 @bp.route('/cache-info')
 def get_cache_info():
     cache_path = Path('data/cache/activities.json')
@@ -333,20 +422,20 @@ def get_activities():
     now = datetime.now()
     if period == 'this_week':
         start = (now - timedelta(days=now.weekday())).replace(hour=0, minute=0, second=0, microsecond=0)
-        activities = [a for a in all_activities if a.start_date and _parse_date(a.start_date) >= start]
+        activities = [a for a in all_activities if a.start_date and _activity_local_start(a) >= start]
     elif period == 'this_month':
         start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-        activities = [a for a in all_activities if a.start_date and _parse_date(a.start_date) >= start]
+        activities = [a for a in all_activities if a.start_date and _activity_local_start(a) >= start]
     elif period == 'this_year':
         start = now.replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
-        activities = [a for a in all_activities if a.start_date and _parse_date(a.start_date) >= start]
+        activities = [a for a in all_activities if a.start_date and _activity_local_start(a) >= start]
     elif period == 'last_30d':
         start = now - timedelta(days=30)
-        activities = [a for a in all_activities if a.start_date and _parse_date(a.start_date) >= start]
+        activities = [a for a in all_activities if a.start_date and _activity_local_start(a) >= start]
     elif period == 'last_year':
         start = now.replace(year=now.year - 1, month=1, day=1, hour=0, minute=0, second=0, microsecond=0)
         end = now.replace(year=now.year - 1, month=12, day=31, hour=23, minute=59, second=59, microsecond=0)
-        activities = [a for a in all_activities if a.start_date and start <= _parse_date(a.start_date) <= end]
+        activities = [a for a in all_activities if a.start_date and start <= _activity_local_start(a) <= end]
     else:
         activities = all_activities
 
@@ -415,5 +504,27 @@ def _parse_date(s: str) -> datetime:
     """Parse an ISO date string, stripping timezone for naive comparison."""
     try:
         return datetime.fromisoformat(s.replace('Z', '+00:00')).replace(tzinfo=None)
+    except (ValueError, AttributeError):
+        return datetime.min
+
+
+def _activity_local_start(a) -> datetime:
+    """
+    Return an activity's start as a naive datetime in the *ride's own*
+    local time, so period filters bucket by the calendar day/month/year the
+    ride actually started in rather than the server's timezone or UTC
+    (issue #496). See app/api/stats_bp.py for the fuller rationale — this
+    mirrors that helper for the /activities list endpoint.
+    """
+    local = getattr(a, 'start_date_local', None)
+    if local:
+        try:
+            return datetime.fromisoformat(local.replace('Z', '+00:00')).replace(tzinfo=None)
+        except (ValueError, AttributeError):
+            pass
+    if not a.start_date:
+        return datetime.min
+    try:
+        return datetime.fromisoformat(a.start_date.replace('Z', '+00:00')).astimezone().replace(tzinfo=None)
     except (ValueError, AttributeError):
         return datetime.min

--- a/app/api/stats_bp.py
+++ b/app/api/stats_bp.py
@@ -60,19 +60,37 @@ def _seconds_to_hours(s):
     return s / 3600.0
 
 
-def _parse_activity_start_local(start_date):
+def _activity_local_start(a):
     """
-    Parse a Strava activity's start_date (UTC, e.g. "...Z") into a naive
-    datetime in the server's local time.
+    Return an activity's start as a naive datetime in the *ride's own*
+    local time — i.e. the calendar day/month/year it actually started in,
+    regardless of where this server happens to run (issue #496).
 
-    A bare `.replace(tzinfo=None)` on the parsed UTC value keeps the UTC
-    wall-clock numbers, so a ride that starts late at night locally but
-    crosses into the next UTC day gets bucketed/compared against
-    `datetime.now()` (local) as if it happened a day later than it did
-    (issue #496). Converting via `.astimezone()` first shifts the
-    wall-clock to local time before the tzinfo is dropped.
+    Strava's `start_date_local` carries the wall-clock time at the ride's
+    start location, encoded with a spurious UTC/`Z` marker; we take its
+    date/time components at face value rather than converting through any
+    timezone (converting would re-introduce the server-timezone bug this
+    field exists to avoid). Garmin-sourced activities already store local
+    wall-clock time in both `start_date` and `start_date_local`.
+
+    Falls back to `start_date` (true UTC) converted via the *server's*
+    local timezone for activities cached before `start_date_local` existed
+    — an approximation, not a fix, for that older data.
     """
-    return datetime.fromisoformat(start_date.replace('Z', '+00:00')).astimezone().replace(tzinfo=None)
+    local = getattr(a, 'start_date_local', None)
+    if local:
+        return datetime.fromisoformat(local.replace('Z', '+00:00')).replace(tzinfo=None)
+    return datetime.fromisoformat(a.start_date.replace('Z', '+00:00')).astimezone().replace(tzinfo=None)
+
+
+def _activity_local_date_str(a):
+    """Return an activity's local calendar date as 'YYYY-MM-DD', or None."""
+    if not a.start_date and not getattr(a, 'start_date_local', None):
+        return None
+    try:
+        return _activity_local_start(a).strftime('%Y-%m-%d')
+    except (ValueError, AttributeError):
+        return None
 
 
 def _filter_activities_by_period(activities, period):
@@ -97,7 +115,7 @@ def _filter_activities_by_period(activities, period):
             if not a.start_date:
                 continue
             try:
-                d = _parse_activity_start_local(a.start_date)
+                d = _activity_local_start(a)
                 if start <= d <= end:
                     result.append(a)
             except (ValueError, AttributeError):
@@ -112,7 +130,7 @@ def _filter_activities_by_period(activities, period):
         if not a.start_date:
             continue
         try:
-            d = _parse_activity_start_local(a.start_date)
+            d = _activity_local_start(a)
             if d >= start:
                 result.append(a)
         except (ValueError, AttributeError):
@@ -194,7 +212,7 @@ def _compute_records(activities):
     def _fmt(a):
         return {
             'id': a.id, 'name': a.name,
-            'date': (a.start_date or '')[:10],
+            'date': _activity_local_date_str(a) or '',
             'distance_mi': round(_meters_to_miles(a.distance), 1),
             'speed_mph': round(_ms_to_mph(a.average_speed), 1),
             'elevation_ft': round(_meters_to_feet(a.total_elevation_gain)),
@@ -256,7 +274,7 @@ def get_stats():
         if not a.start_date:
             continue
         try:
-            d = _parse_activity_start_local(a.start_date)
+            d = _activity_local_start(a)
             label = d.strftime('%G-W%V')
             week_buckets.setdefault(label, []).append(a)
         except (ValueError, AttributeError):
@@ -270,7 +288,7 @@ def get_stats():
         if not a.start_date:
             continue
         try:
-            d = _parse_activity_start_local(a.start_date)
+            d = _activity_local_start(a)
             label = d.strftime('%Y-%m')
             month_buckets.setdefault(label, []).append(a)
         except (ValueError, AttributeError):
@@ -323,10 +341,11 @@ def get_calendar_stats():
     month_prefix = f'{year:04d}-{month:02d}'
 
     for a in all_activities:
-        if not a.start_date or not a.start_date.startswith(month_prefix):
+        local_date = _activity_local_date_str(a)
+        if not local_date or not local_date.startswith(month_prefix):
             continue
         try:
-            day = int(a.start_date[8:10])
+            day = int(local_date[8:10])
             day_buckets[day].append(a)
         except (ValueError, IndexError, KeyError):
             continue
@@ -345,9 +364,9 @@ def get_calendar_stats():
 
     month_activities = [a for acts in day_buckets.values() for a in acts]
 
-    dates = sorted(a.start_date for a in all_activities if a.start_date)
-    cache_earliest = dates[0][:10] if dates else None
-    cache_latest = dates[-1][:10] if dates else None
+    dates = sorted(d for d in (_activity_local_date_str(a) for a in all_activities) if d)
+    cache_earliest = dates[0] if dates else None
+    cache_latest = dates[-1] if dates else None
 
     return jsonify({
         'status': 'success',
@@ -393,7 +412,7 @@ def get_gear_stats():
     for gear_id, acts in gear_buckets.items():
         meta = gear_meta.get(gear_id, {'id': gear_id, 'name': gear_id, 'type': 'unknown'})
         s = _compute_summary(acts)
-        last_used = max((a.start_date or '' for a in acts), default='')[:10]
+        last_used = max((_activity_local_date_str(a) or '' for a in acts), default='')
         gear_list.append({**meta, **s, 'last_used': last_used})
 
     gear_list.sort(key=lambda g: (0 if g.get('type') == 'bike' else 1, -g.get('total_distance_mi', 0)))

--- a/app/jobs/job_state.py
+++ b/app/jobs/job_state.py
@@ -65,5 +65,8 @@ class JobRegistry:
         self.fetch.reset({'status': 'idle', 'fetched': 0, 'label': '', 'started_at': None})
         self.backfill: JobState = JobState()
         self.backfill.reset({'status': 'idle'})
+        self.history_backfill: JobState = JobState()
+        self.history_backfill.reset({'status': 'idle'})
         # threading.Event replaces the bare bool _analysis_stop_requested
         self.analysis_stop: threading.Event = threading.Event()
+        self.history_backfill_stop: threading.Event = threading.Event()

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -23,6 +23,7 @@ location:
 data_fetching:
   cache_duration_days: 365  # Extended to 1 year - historical data doesn't change
   max_activities: 500
+  backfill_page_size: 200  # page size for the explicit full-history backfill (issue #486)
 
 long_rides:
 

--- a/src/data_fetcher.py
+++ b/src/data_fetcher.py
@@ -31,7 +31,8 @@ class Activity:
     name: str
     type: str
     sport_type: Optional[str] = None  # More specific type (e.g., 'GravelRide', 'Ride')
-    start_date: Optional[str] = None  # ISO format
+    start_date: Optional[str] = None  # ISO format, UTC
+    start_date_local: Optional[str] = None  # ISO format, wall-clock time at the ride's start location
     distance: float = 0.0  # meters
     moving_time: int = 0  # seconds
     elapsed_time: int = 0  # seconds
@@ -101,6 +102,7 @@ class Activity:
             type=str(activity.type) if activity.type else "Unknown",
             sport_type=str(getattr(activity.sport_type, 'root', activity.sport_type)) if hasattr(activity, 'sport_type') and activity.sport_type else None,
             start_date=activity.start_date.isoformat() if activity.start_date else None,
+            start_date_local=activity.start_date_local.isoformat() if getattr(activity, 'start_date_local', None) else None,
             distance=float(activity.distance) if activity.distance else 0.0,
             moving_time=to_seconds(activity.moving_time),
             elapsed_time=to_seconds(activity.elapsed_time),
@@ -150,6 +152,7 @@ class Activity:
             type=sport_type,
             sport_type=sport_type,
             start_date=ga.get('startTimeLocal'),
+            start_date_local=ga.get('startTimeLocal'),
             distance=ga.get('distance', 0.0),
             moving_time=int(ga.get('movingDuration') or ga.get('duration') or 0),
             elapsed_time=int(ga.get('duration', 0)),
@@ -746,4 +749,81 @@ class StravaDataFetcher:
 
         logger.info(f"Backfill complete: {updated} updated, {fetched} fetched from Strava")
         return {'updated': updated, 'skipped': len(by_id) - updated, 'total_cached': len(by_id)}
+
+    def backfill_full_history(self, page_size: Optional[int] = None,
+                               progress_callback=None, stop_check=None) -> Dict[str, Any]:
+        """
+        Page backward through the account's full Strava history using
+        before=, merging each page into the cache.
+
+        A normal fetch_activities() call always returns the *n most recent*
+        activities (Strava's list endpoint is newest-first), so an account
+        with more lifetime activities than `max_activities` has activities
+        that are never reachable through that path — see issue #486. This
+        walks backward in time, re-querying with `before` set to the oldest
+        start_date seen so far, until either Strava returns an empty page
+        (start of history reached) or a full page comes back with nothing
+        new to merge (caught up to activities already in the cache).
+
+        This is deliberately a separate, explicit action from the normal
+        fetch flow — for a large account it's dozens of paginated calls and
+        is slow, so it should be user-triggered, not run on every refresh.
+
+        Returns:
+            Dict with 'new_total' (activities added) and 'pages' (API calls made).
+        """
+        if page_size is None:
+            page_size = self.config.get('data_fetching.backfill_page_size', 200)
+
+        oldest_seen: Optional[datetime] = None
+        total_new = 0
+        total_pages = 0
+
+        print("\n" + "="*70)
+        print("📦 FULL HISTORY BACKFILL")
+        print("="*70)
+
+        while True:
+            if stop_check and stop_check():
+                logger.info(f"Backfill stopped by request after {total_pages} pages")
+                break
+
+            try:
+                batch = list(self.client.get_activities(limit=page_size, before=oldest_seen))
+            except Exception as e:
+                logger.error(f"Backfill failed after {total_pages} pages: {e}")
+                raise
+
+            if not batch:
+                logger.info(f"Backfill reached the start of activity history after {total_pages} pages")
+                break
+
+            page_activities = [Activity.from_strava_activity(a) for a in batch]
+            stats = self.cache_activities(page_activities, merge=True)
+            total_pages += 1
+            total_new += stats['new']
+
+            page_dates = [
+                datetime.fromisoformat(a.start_date.replace('Z', '+00:00'))
+                for a in page_activities if a.start_date
+            ]
+            page_oldest = min(page_dates) if page_dates else None
+
+            if progress_callback:
+                progress_callback(total_new, total_pages, page_oldest)
+
+            if page_oldest is None or (oldest_seen is not None and page_oldest >= oldest_seen):
+                logger.warning("Backfill page had no older activity to page past — stopping")
+                break
+            oldest_seen = page_oldest
+
+            if stats['new'] == 0:
+                logger.info(f"Backfill caught up to cached activities after {total_pages} pages")
+                break
+
+            # Throttle to stay well under Strava's rate limits
+            time.sleep(2)
+
+        logger.info(f"Backfill complete: {total_new} new activities across {total_pages} pages")
+        return {'new_total': total_new, 'pages': total_pages}
 

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -55,6 +55,7 @@
             setupFetchModeControls();
             document.getElementById('run-analysis-btn').addEventListener('click', runAnalysis);
             document.getElementById('fetch-btn').addEventListener('click', startFetch);
+            document.getElementById('backfill-history-btn').addEventListener('click', startHistoryBackfill);
 
             // Restore progress UI if analysis or fetch is already running (e.g. after page reload)
             (async () => {
@@ -86,6 +87,21 @@
                         progressEl.style.display = '';
                         statusEl.textContent = job.label || 'Fetch in progress…';
                         pollFetchStatus();
+                    }
+                } catch (_) {}
+            })();
+            (async () => {
+                try {
+                    const job = await window.apiClient.fetch('/fetch/backfill-history/status');
+                    if (job.status === 'running') {
+                        const btn = document.getElementById('backfill-history-btn');
+                        const progressEl = document.getElementById('backfill-history-progress');
+                        const statusEl = document.getElementById('backfill-history-status');
+                        btn.disabled = true;
+                        btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span> Backfilling…';
+                        progressEl.classList.remove('d-none');
+                        statusEl.textContent = job.label || 'Backfill in progress…';
+                        pollHistoryBackfillStatus();
                     }
                 } catch (_) {}
             })();
@@ -1337,6 +1353,75 @@
             const btn = document.getElementById('repair-gear-btn');
             btn.disabled = false;
             btn.innerHTML = '<i class="bi bi-patch-check" aria-hidden="true"></i> Repair Gear Names';
+        }
+
+        // ── Full history backfill (#486) ─────────────────────────
+
+        let _historyBackfillStop = null;
+
+        async function startHistoryBackfill() {
+            const btn = document.getElementById('backfill-history-btn');
+            const progressEl = document.getElementById('backfill-history-progress');
+            btn.disabled = true;
+            btn.innerHTML = '<span class="spinner-border spinner-border-sm me-1" role="status" aria-hidden="true"></span> Backfilling…';
+            progressEl.classList.remove('d-none');
+
+            try {
+                const resp = await window.apiClient.fetch('/fetch/backfill-history', {
+                    method: 'POST',
+                    body: JSON.stringify({}),
+                });
+                if (resp.status === 'started' || resp.status === 'already_running') {
+                    pollHistoryBackfillStatus();
+                } else {
+                    if (typeof showToast === 'function') showToast(resp.message || 'Failed to start backfill', 'error');
+                    resetHistoryBackfillBtn();
+                }
+            } catch (e) {
+                if (typeof showToast === 'function') showToast(`Backfill failed: ${e.message}`, 'error');
+                resetHistoryBackfillBtn();
+            }
+        }
+
+        function pollHistoryBackfillStatus() {
+            const statusEl = document.getElementById('backfill-history-status');
+
+            _historyBackfillStop = window.pollJob({
+                intervalMs: 2000,
+                fetchStatus: () => window.apiClient.fetch('/fetch/backfill-history/status'),
+                onGiveUp: (reason) => {
+                    resetHistoryBackfillBtn();
+                    if (typeof showToast === 'function') {
+                        showToast(reason === 'timeout' ? 'Backfill is taking unusually long' : 'Lost connection while checking backfill status', 'warning');
+                    }
+                },
+                onStatus: (resp) => {
+                    if (resp.status === 'running') {
+                        statusEl.textContent = resp.label || 'Backfilling…';
+                        return 'running';
+                    } else if (resp.status === 'done') {
+                        if (typeof showToast === 'function') showToast(resp.label || 'Backfill complete', 'success');
+                        resetHistoryBackfillBtn();
+                        loadCacheInfo();
+                        return 'done';
+                    } else if (resp.status === 'error') {
+                        if (typeof showToast === 'function') showToast(resp.label || 'Backfill error', 'error');
+                        resetHistoryBackfillBtn();
+                        return 'error';
+                    }
+                    return 'running';
+                },
+            });
+        }
+
+        function resetHistoryBackfillBtn() {
+            const btn = document.getElementById('backfill-history-btn');
+            const progressEl = document.getElementById('backfill-history-progress');
+            const statusEl = document.getElementById('backfill-history-status');
+            btn.disabled = false;
+            btn.innerHTML = '<i class="bi bi-clock-history" aria-hidden="true"></i> Backfill Full History';
+            progressEl.classList.add('d-none');
+            statusEl.textContent = '';
         }
 
         // ── Home & Work Location (#472) ─────────────────────────

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -341,6 +341,26 @@
                                                  role="progressbar"></div>
                                         </div>
                                     </div>
+
+                                    <div class="mt-3">
+                                        <p class="small fw-semibold text-body-secondary mb-1">Full history backfill</p>
+                                        <p class="workflow-explainer mb-2">
+                                            A normal fetch only ever pulls your most recent activities. If your
+                                            lifetime Strava activity count is larger than what shows up here, run
+                                            this once to page backward through your full history. It's slow — one
+                                            paginated call per ~200 activities — so only run it when you need it.
+                                        </p>
+                                        <button type="button" class="btn btn-outline-secondary btn-sm" id="backfill-history-btn">
+                                            <i class="bi bi-clock-history" aria-hidden="true"></i> Backfill Full History
+                                        </button>
+                                        <div id="backfill-history-progress" class="mt-2 d-none">
+                                            <div class="d-flex align-items-center gap-2">
+                                                <span class="spinner-border spinner-border-sm text-secondary flex-shrink-0"
+                                                      id="backfill-history-spinner" role="status" aria-hidden="true"></span>
+                                                <span id="backfill-history-status" class="small text-body"></span>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
 
                                 <hr class="my-3">

--- a/tests/test_data_fetcher.py
+++ b/tests/test_data_fetcher.py
@@ -462,6 +462,7 @@ class TestFetchActivities:
         m.type = "Ride"
         m.sport_type = None
         m.start_date = datetime(2026, 5, 1, 8, 0, tzinfo=timezone.utc)
+        m.start_date_local = None
         m.distance = distance
         m.moving_time = 1200
         m.elapsed_time = 1300
@@ -925,4 +926,110 @@ class TestGearMethods:
         calls = []
         fetcher.backfill_gear_ids(progress_callback=lambda fetched, updated: calls.append((fetched, updated)))
         assert len(calls) >= 1
+
+
+class TestBackfillFullHistory:
+    """Test backfill_full_history() — issue #486 pagination-backward fix."""
+
+    @pytest.fixture
+    def fetcher(self, tmp_path):
+        client = Mock()
+        config = Mock()
+        config.get.side_effect = lambda key, default=None: {
+            'data_fetching.cache_duration_days': 7,
+            'data_fetching.max_activities': 500,
+            'data_fetching.backfill_page_size': 200,
+        }.get(key, default)
+        f = StravaDataFetcher(client, config, use_test_cache=False)
+        f.cache_path = tmp_path / "activities.json"
+        return f
+
+    def _make_strava_activity(self, activity_id, day):
+        m = Mock()
+        m.id = activity_id
+        m.name = f"Ride {activity_id}"
+        m.type = "Ride"
+        m.sport_type = None
+        m.start_date = datetime(2026, 1, day, 8, 0, tzinfo=timezone.utc)
+        m.start_date_local = None
+        m.distance = 5000.0
+        m.moving_time = 1200
+        m.elapsed_time = 1300
+        m.total_elevation_gain = 50.0
+        m.average_speed = 4.17
+        m.max_speed = 8.0
+        m.start_latlng = None
+        m.end_latlng = None
+        m.map = None
+        return m
+
+    @patch('src.data_fetcher.time.sleep')
+    def test_stops_on_empty_page(self, mock_sleep, fetcher):
+        # Two pages of activities, then Strava returns nothing further back.
+        page1 = [self._make_strava_activity(i, day=20 - i) for i in range(5)]
+        page2 = [self._make_strava_activity(i, day=10 - i) for i in range(5, 10)]
+        fetcher.client.get_activities.side_effect = [page1, page2, []]
+
+        result = fetcher.backfill_full_history()
+
+        assert result['new_total'] == 10
+        assert result['pages'] == 2
+        assert fetcher.client.get_activities.call_count == 3
+        cached = fetcher.load_cached_activities()
+        assert len(cached) == 10
+
+    @patch('src.data_fetcher.time.sleep')
+    def test_stops_when_page_fully_cached(self, mock_sleep, fetcher):
+        # Pre-seed the cache with an activity that the second page will re-fetch.
+        page1 = [self._make_strava_activity(1, day=20)]
+        page2 = [self._make_strava_activity(2, day=10)]  # already cached below
+        fetcher.client.get_activities.side_effect = [page1, page2]
+
+        from src.data_fetcher import Activity
+        seeded = Activity(id=2, name="Cached", type="Ride", distance=5000.0,
+                           moving_time=1200, elapsed_time=1300, total_elevation_gain=50.0,
+                           average_speed=4.0, max_speed=8.0,
+                           start_date=datetime(2026, 1, 10, 8, 0, tzinfo=timezone.utc).isoformat())
+        fetcher.cache_activities([seeded], merge=False)
+
+        result = fetcher.backfill_full_history()
+
+        # Page 1 (new activity id=1) merges; page 2 re-fetches the already-cached
+        # id=2 with nothing new, so the loop stops after 2 pages without a 3rd call.
+        assert result['pages'] == 2
+        assert fetcher.client.get_activities.call_count == 2
+        cached_ids = {a.id for a in fetcher.load_cached_activities()}
+        assert cached_ids == {1, 2}
+
+    @patch('src.data_fetcher.time.sleep')
+    def test_merges_across_pages_no_duplicates(self, mock_sleep, fetcher):
+        page1 = [self._make_strava_activity(1, day=20)]
+        page2 = [self._make_strava_activity(2, day=10)]
+        fetcher.client.get_activities.side_effect = [page1, page2, []]
+
+        fetcher.backfill_full_history()
+
+        cached = fetcher.load_cached_activities()
+        assert sorted(a.id for a in cached) == [1, 2]
+
+    @patch('src.data_fetcher.time.sleep')
+    def test_respects_stop_check(self, mock_sleep, fetcher):
+        result = fetcher.backfill_full_history(stop_check=lambda: True)
+
+        assert result == {'new_total': 0, 'pages': 0}
+        fetcher.client.get_activities.assert_not_called()
+
+    @patch('src.data_fetcher.time.sleep')
+    def test_api_error_propagates(self, mock_sleep, fetcher):
+        fetcher.client.get_activities.side_effect = RuntimeError("API down")
+        with pytest.raises(RuntimeError, match="API down"):
+            fetcher.backfill_full_history()
+
+    @patch('src.data_fetcher.time.sleep')
+    def test_progress_callback_invoked(self, mock_sleep, fetcher):
+        page1 = [self._make_strava_activity(1, day=20)]
+        fetcher.client.get_activities.side_effect = [page1, []]
+        calls = []
+        fetcher.backfill_full_history(progress_callback=lambda new_total, pages, oldest: calls.append((new_total, pages)))
+        assert calls == [(1, 1)]
 

--- a/tests/test_stats_bp_local_time.py
+++ b/tests/test_stats_bp_local_time.py
@@ -1,58 +1,110 @@
 """Tests for local-time date bucketing in app/api/stats_bp.py (issue #496).
 
-Bucketing/period-filtering previously converted a UTC start_date to naive
-by stripping tzinfo without shifting the wall-clock, so a ride that starts
-late at night locally but crosses into the next UTC day was bucketed as if
-it happened a day (or, at boundaries, a month/year) later than it did.
+Bucketing/period-filtering must peg an activity to the calendar day it
+started on *in the timezone where the ride began*, not the server's
+timezone and not UTC. Strava's `start_date_local` carries the ride's local
+wall-clock time (mislabeled with a trailing `Z`), so the fix takes its
+date/time components at face value instead of converting through any
+timezone.
 """
 
 from datetime import datetime, timedelta
 
 import pytest
 
-from app.api.stats_bp import _filter_activities_by_period, _parse_activity_start_local
+from app.api.stats_bp import (
+    _activity_local_date_str,
+    _activity_local_start,
+    _filter_activities_by_period,
+)
 
 
 class _FakeActivity:
-    def __init__(self, start_date):
+    def __init__(self, start_date=None, start_date_local=None):
         self.start_date = start_date
+        self.start_date_local = start_date_local
 
 
 @pytest.mark.unit
-class TestParseActivityStartLocal:
-    def test_utc_wallclock_shifts_without_fix_would_differ(self):
-        utc_dt = datetime.fromisoformat('2026-07-01T04:00:00+00:00')
-        local_dt = utc_dt.astimezone().replace(tzinfo=None)
-        naive_strip_dt = utc_dt.replace(tzinfo=None)
-        # The two approaches only agree when local UTC offset is 0 — assert
-        # the fixed helper actually applies the local offset.
-        offset = datetime.now().astimezone().utcoffset()
-        assert local_dt == naive_strip_dt + offset
+class TestActivityLocalStart:
+    def test_uses_start_date_local_wall_clock_verbatim(self):
+        # A ride that started at 11pm in a timezone far ahead of UTC: the
+        # UTC start_date has already rolled to the next day, but
+        # start_date_local still shows the ride's own calendar day.
+        activity = _FakeActivity(
+            start_date='2026-07-02T09:00:00Z',
+            start_date_local='2026-07-01T23:00:00Z',
+        )
+        result = _activity_local_start(activity)
+        assert result == datetime(2026, 7, 1, 23, 0, 0)
 
-    def test_parse_activity_start_local_applies_local_offset(self):
-        start_date = '2026-07-01T04:00:00Z'
-        result = _parse_activity_start_local(start_date)
+    def test_crosses_month_boundary_correctly(self):
+        activity = _FakeActivity(
+            start_date='2026-08-01T05:30:00Z',
+            start_date_local='2026-07-31T22:30:00Z',
+        )
+        assert _activity_local_start(activity).strftime('%Y-%m') == '2026-07'
+
+    def test_crosses_year_boundary_correctly(self):
+        activity = _FakeActivity(
+            start_date='2027-01-01T06:00:00Z',
+            start_date_local='2026-12-31T22:00:00Z',
+        )
+        assert _activity_local_start(activity).year == 2026
+
+    def test_falls_back_to_server_tz_conversion_without_start_date_local(self):
+        # Legacy cached activities predating this field: best-effort
+        # fallback via the server's own timezone, not a bare tzinfo strip.
+        activity = _FakeActivity(start_date='2026-07-01T04:00:00Z')
+        result = _activity_local_start(activity)
         expected = datetime.fromisoformat('2026-07-01T04:00:00+00:00').astimezone().replace(tzinfo=None)
         assert result == expected
 
 
 @pytest.mark.unit
+class TestActivityLocalDateStr:
+    def test_formats_local_calendar_date(self):
+        activity = _FakeActivity(
+            start_date='2026-07-02T09:00:00Z',
+            start_date_local='2026-07-01T23:00:00Z',
+        )
+        assert _activity_local_date_str(activity) == '2026-07-01'
+
+    def test_returns_none_without_any_date(self):
+        assert _activity_local_date_str(_FakeActivity()) is None
+
+
+@pytest.mark.unit
 class TestFilterActivitiesByPeriod:
-    def test_this_week_uses_local_calendar_day_boundary(self):
+    def test_this_week_uses_ride_local_calendar_day_boundary(self):
         now_local = datetime.now()
         start_of_week_local = (now_local - timedelta(days=now_local.weekday())).replace(
             hour=0, minute=0, second=0, microsecond=0)
 
-        # An activity whose UTC start_date, if naively stripped of tzinfo,
-        # would fall just *before* the local start-of-week boundary, but
-        # whose true local time falls just *after* it.
-        local_offset = datetime.now().astimezone().utcoffset()
+        # An activity whose ride-local start time falls just after the
+        # start-of-week boundary, encoded (as Strava does) with a
+        # misleading UTC 'Z' marker rather than a real offset.
         true_local_time = start_of_week_local + timedelta(minutes=5)
-        utc_equivalent = true_local_time - local_offset
-        activity = _FakeActivity(utc_equivalent.strftime('%Y-%m-%dT%H:%M:%SZ'))
+        activity = _FakeActivity(
+            start_date=true_local_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            start_date_local=true_local_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+        )
 
         result = _filter_activities_by_period([activity], 'this_week')
 
-        if local_offset.total_seconds() == 0:
-            pytest.skip("Server is running in UTC; boundary-shift case can't be exercised")
         assert activity in result
+
+    def test_ride_local_time_just_before_boundary_is_excluded(self):
+        now_local = datetime.now()
+        start_of_week_local = (now_local - timedelta(days=now_local.weekday())).replace(
+            hour=0, minute=0, second=0, microsecond=0)
+
+        true_local_time = start_of_week_local - timedelta(minutes=5)
+        activity = _FakeActivity(
+            start_date=true_local_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+            start_date_local=true_local_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+        )
+
+        result = _filter_activities_by_period([activity], 'this_week')
+
+        assert activity not in result


### PR DESCRIPTION
## Summary
- Adds `StravaDataFetcher.backfill_full_history()` to page backward through Strava's full activity history via `before=`, closing the gap where accounts with more lifetime activities than `max_activities` could never reach their older activities through a normal fetch (#486). Wired up as an explicit, user-triggered action: `POST /api/fetch/backfill-history` (+ status/stop endpoints) and a "Backfill Full History" button in Settings.
- Adds `start_date_local` to the `Activity` dataclass, carrying Strava's actual local wall-clock start time.
- Fixes Reports stats bucketing to use that local time directly instead of approximating via the server's timezone, so a ride's date is correct regardless of where the server happens to be hosted (#496).

## Test plan
- [x] `pytest tests/test_data_fetcher.py tests/test_job_state.py tests/test_stats_bp_local_time.py -q` — all pass
- [x] Full suite: 1164 passed, 11 skipped; 5 pre-existing failures are Windows filesystem permission-bit checks unrelated to this change (verified present on `main` too)
- [ ] Manual: run the backfill button against a real account with >500 lifetime activities and confirm cache count converges toward Strava's total

🤖 Generated with [Claude Code](https://claude.com/claude-code)