### PR TITLE
Explore: explicit route shape control + tile-claim drop safeguard (#489, #493)

### DIFF
--- a/static/js/exploration-worker.js
+++ b/static/js/exploration-worker.js
@@ -5,12 +5,16 @@
  * Generates one route per compass quadrant (NE/SE/SW/NW) that has reachable
  * unvisited tiles, streaming each as it finishes rather than waiting for all.
  *
- * Input message: {start, end?, distanceKm, mode, routeType, coverageData, coverageDataSecondary?, optimizeFor}
+ * Input message: {start, end?, distanceKm, mode, routeType, shape, coverageData, coverageDataSecondary?, optimizeFor}
  *   - start: {lat, lon}
  *   - end: {lat, lon} | null (null = round-trip back to start)
  *   - distanceKm: target route distance
  *   - mode: 'tiles' | 'roads'
  *   - routeType: 'round_trip' | 'point_to_point'
+ *   - shape: 'loop' | 'out_and_back' | 'point_to_point' (#489) — for a
+ *       round trip, whether outbound/return should be biased toward
+ *       different corridors (loop) or deliberately retrace the same one
+ *       (out_and_back). Ignored when routeType is 'point_to_point'.
  *   - coverageData: {visited: {"x,y": {...}}, total_in_bounds, bounds, zoom}
  *   - coverageDataSecondary: same shape as coverageData, at a different zoom | null
  *       When present ("Both" grid mode), routes are optimized against both
@@ -89,8 +93,12 @@ function countVisitedNeighbours(t, visitedSet) {
     ].filter(k => visitedSet.has(k)).length;
 }
 
-function optimize({ start, end, distanceKm, mode, routeType, coverageData, coverageDataSecondary, optimizeFor, corridorConstraint }) {
+function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData, coverageDataSecondary, optimizeFor, corridorConstraint }) {
     const isRoundTrip = routeType === 'round_trip' || !end;
+    // Default to 'loop' for round trips when the caller doesn't specify —
+    // matches the pre-#489 behaviour of drawing from whichever quadrant the
+    // road network happens to support.
+    const effectiveShape = !isRoundTrip ? 'point_to_point' : (shape === 'out_and_back' ? 'out_and_back' : 'loop');
     const reachRadius = distanceKm / (isRoundTrip ? 4 : 3);
 
     reportProgress('Scanning tile grid…');
@@ -127,8 +135,18 @@ function optimize({ start, end, distanceKm, mode, routeType, coverageData, cover
     QUADRANTS.forEach((dir, i) => {
         reportProgress(`Optimizing ${dir} route (${i + 1}/${QUADRANTS.length})…`);
 
+        // #489: 'loop' pulls zones from this quadrant AND its clockwise
+        // neighbour so outbound/return legs are biased toward different
+        // corridors instead of both living in one compass slice.
+        // 'out_and_back' deliberately keeps a single quadrant and takes only
+        // its single best zone, accepting the retrace rather than fighting
+        // the road network for a loop that may not exist there.
+        const scanDirs = effectiveShape === 'loop' ? [dir, nextQuadrant(dir)] : [dir];
+        const zoneCap = effectiveShape === 'out_and_back' ? 1 : perGridCap;
+
         const gridCandidates = grids.map(g => {
-            const dirZones = floodFillZones(g.buckets[dir]).map(z => ({
+            const bucketTiles = scanDirs.flatMap(d => g.buckets[d]);
+            const dirZones = floodFillZones(bucketTiles).map(z => ({
                 ...z,
                 distanceFromStart: haversineKm(start.lat, start.lon, z.centroid.lat, z.centroid.lon),
             }));
@@ -136,7 +154,7 @@ function optimize({ start, end, distanceKm, mode, routeType, coverageData, cover
             const penalised = applyOverlapPenalty(scored, start, g.visitedSet, g.zoom);
             return {
                 zoom: g.zoom,
-                candidates: penalised.slice(0, perGridCap),
+                candidates: penalised.slice(0, zoneCap),
             };
         });
 
@@ -173,6 +191,7 @@ function optimize({ start, end, distanceKm, mode, routeType, coverageData, cover
             type: 'route',
             route: {
                 direction: dir,
+                shape: effectiveShape,
                 waypoints: ordered,
                 newTilesByZoom,
                 stats: {
@@ -276,6 +295,13 @@ function quadrantFor(bearing) {
     if (bearing < 180) return 'SE';
     if (bearing < 270) return 'SW';
     return 'NW';
+}
+
+/** Clockwise-adjacent quadrant, used to pull a loop's return leg from a
+ *  different corridor than its outbound leg (#489). */
+function nextQuadrant(dir) {
+    const i = QUADRANTS.indexOf(dir);
+    return QUADRANTS[(i + 1) % QUADRANTS.length];
 }
 
 // ── Tile utilities ──────────────────────────────────────────────

--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -528,6 +528,7 @@ function _paletteFor(dirOrIndex) {
 }
 
 const DIRECTION_LABELS = { NE: 'Northeast', SE: 'Southeast', SW: 'Southwest', NW: 'Northwest' };
+const SHAPE_LABELS = { loop: 'Loop', out_and_back: 'Out-and-back', point_to_point: 'Point-to-point' };
 
 // Per-direction Phase-1 polyline references, keyed by direction ('NE', etc.)
 const _phase1Polylines = {};
@@ -707,7 +708,8 @@ async function generateRoute() {
         statusEl.textContent = 'Worker error: ' + err.message;
     };
 
-    const routeType = document.getElementById('route-type-select').value;
+    const shape = document.getElementById('route-type-select').value; // 'loop' | 'out_and_back' | 'point_to_point'
+    const routeType = shape === 'point_to_point' ? 'point_to_point' : 'round_trip';
     const endPos = (routeType === 'point_to_point' && endMarker) ? endMarker.getLatLng() : null;
 
     explorationWorker.postMessage({
@@ -716,6 +718,7 @@ async function generateRoute() {
         distanceKm,
         mode: 'tiles',
         routeType,
+        shape,
         coverageData,
         coverageDataSecondary: mode === 'both' ? coverageDataSecondary : null,
         optimizeFor,
@@ -827,6 +830,7 @@ async function generateWorkoutCombo() {
         distanceKm,
         mode: 'tiles',
         routeType: 'round_trip',
+        shape: 'loop',
         coverageData,
         coverageDataSecondary: mode === 'both' ? coverageDataSecondary : null,
         optimizeFor,
@@ -865,11 +869,20 @@ function renderRoute(route, index) {
         weight: 3,
         dashArray: '8, 8',
         opacity: 0.8,
-    }).bindPopup(`${DIRECTION_LABELS[route.direction]} — ${distanceLabel}, ${newTilesLabel(route.stats)}`);
+    }).bindPopup(`${routeDirLabel(route)} — ${distanceLabel}, ${newTilesLabel(route.stats)}`);
     line.on('click', (e) => { L.DomEvent.stopPropagation(e); highlightRoute(route.direction); });
     routeLayer.addLayer(line);
     addArrows(coords, palette.light);
     _phase1Polylines[route.direction] = line;
+}
+
+/** Direction label with an explicit shape tag (#489) so riders can see which
+ *  shape a route actually got — loop and out-and-back both look like a
+ *  "round trip" otherwise, with no way to tell them apart in the UI. */
+function routeDirLabel(route) {
+    const shapeTag = route.shape && SHAPE_LABELS[route.shape] && route.shape !== 'point_to_point'
+        ? ` (${SHAPE_LABELS[route.shape]})` : '';
+    return `${DIRECTION_LABELS[route.direction]}${shapeTag}`;
 }
 
 function newTilesLabel(stats) {
@@ -892,7 +905,7 @@ function addRouteListItem(route, index, targetDistanceKm, extraLabel = '') {
     badge.innerHTML = `
         <div class="d-flex align-items-center gap-2 w-100">
             <span class="swatch"></span>
-            <span class="route-label">${DIRECTION_LABELS[dir]} · ${distanceLabel} · ${newTilesLabel(route.stats)}${extraLabel ? ' ' + extraLabel : ''}</span>
+            <span class="route-label">${routeDirLabel(route)} · ${distanceLabel} · ${newTilesLabel(route.stats)}${extraLabel ? ' ' + extraLabel : ''}</span>
             <button class="btn btn-xs btn-outline-primary ms-auto plot-road-btn" data-direction="${dir}"
                     aria-label="Plot road route for ${DIRECTION_LABELS[dir]}">
                 <i class="bi bi-map" aria-hidden="true"></i> Plot road route
@@ -935,12 +948,20 @@ function displace(lat, lon, distKm, bearingDeg) {
  *
  * Strategy when too short: insert a displacement point pushed out along the
  * route's main bearing so the road router must travel farther out-and-back.
- * Strategy when too long: drop the lowest-priority waypoint.
+ * Strategy when too long: drop a padding waypoint first if one exists,
+ * falling back to the furthest tile-claiming waypoint only when no padding
+ * is left to sacrifice (#493 Phase B) — a purely distance-driven drop can
+ * otherwise discard the exact corner waypoint a route claimed a tile
+ * through while unrelated padding sits untouched.
  */
 async function refineRoute(baseWaypoints, targetKm, surfacePref, candidateList, dirBearing, roadFilters = {}) {
     const TOLERANCE = 0.15;
     const MAX_ITERATIONS = 6;
     let waypoints = baseWaypoints.map(w => [...w]); // deep copy
+    // Parallel to waypoints.slice(1, -1) (the inner/droppable waypoints):
+    // true = tile-claiming corner from bestCornerPoint/candidates, false =
+    // padding inserted purely to hit the distance target.
+    let loadBearing = waypoints.slice(1, -1).map(() => true);
     let result = null;
     let candidates = candidateList.slice();
 
@@ -970,8 +991,18 @@ async function refineRoute(baseWaypoints, targetKm, surfacePref, candidateList, 
         if (Math.abs(ratio - 1) <= TOLERANCE) break; // within 15% — done
 
         if (ratio > 1 + TOLERANCE && waypoints.length > 3) {
-            // Too long: drop the furthest (last inner) waypoint.
-            waypoints = [waypoints[0], ...waypoints.slice(1, -2), waypoints[waypoints.length - 1]];
+            // Too long: drop a padding waypoint if one exists; only fall
+            // back to the furthest load-bearing (tile-claiming) waypoint
+            // once padding is exhausted.
+            let dropIdx = loadBearing.indexOf(false);
+            if (dropIdx === -1) dropIdx = loadBearing.length - 1; // furthest inner waypoint
+            waypoints = [
+                waypoints[0],
+                ...waypoints.slice(1, 1 + dropIdx),
+                ...waypoints.slice(2 + dropIdx, -1),
+                waypoints[waypoints.length - 1],
+            ];
+            loadBearing = [...loadBearing.slice(0, dropIdx), ...loadBearing.slice(dropIdx + 1)];
         } else if (ratio < 1 - TOLERANCE) {
             // Too short: try adding next candidate zone first, then fall back
             // to pushing a displacement waypoint out along the route bearing.
@@ -984,6 +1015,7 @@ async function refineRoute(baseWaypoints, targetKm, surfacePref, candidateList, 
                     [wp.lat, wp.lon],
                     waypoints[waypoints.length - 1],
                 ];
+                loadBearing.push(true); // new candidate corner claims a tile
             } else {
                 // No more candidates — insert a padding point pushed out by
                 // half the deficit distance along the main quadrant bearing.
@@ -996,6 +1028,7 @@ async function refineRoute(baseWaypoints, targetKm, surfacePref, candidateList, 
                     padPt,
                     ...waypoints.slice(1),
                 ];
+                loadBearing.unshift(false); // pure padding, not tile-claiming
             }
         } else {
             break;
@@ -1170,7 +1203,7 @@ async function plotRoadRoute(direction, route, targetDistanceKm, color, badgeEl)
         const tilesSuffix = verified
             ? ` · ${unionMap.size} new tile${unionMap.size === 1 ? '' : 's'}${unionMap.size === 0 ? ' reached' : ''}`
             : '';
-        labelEl.textContent = `${DIRECTION_LABELS[direction]} · ${parts.join(' / ')}${tilesSuffix}`;
+        labelEl.textContent = `${routeDirLabel(route)} · ${parts.join(' / ')}${tilesSuffix}`;
     }
 
     infoEl.innerHTML =

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -90,9 +90,10 @@
                         </span>
                         <div class="control-step">
                             <div class="mb-2">
-                                <label class="form-label small mb-0" for="route-type-select">Route type</label>
-                                <select class="form-select form-select-sm" id="route-type-select" aria-label="Route type — round trip or point to point">
-                                    <option value="round_trip" selected>Round trip</option>
+                                <label class="form-label small mb-0" for="route-type-select">Route shape</label>
+                                <select class="form-select form-select-sm" id="route-type-select" aria-label="Route shape — loop, out-and-back, or point to point">
+                                    <option value="loop" selected>Loop (different roads out and back)</option>
+                                    <option value="out_and_back">Out-and-back (same road both ways)</option>
                                     <option value="point_to_point">Point to point</option>
                                 </select>
                             </div>


### PR DESCRIPTION
## Summary
- **#489** — Adds an explicit Loop / Out-and-back / Point-to-point shape selector to the Explore route generator. `loop` biases zone selection toward a quadrant and its clockwise neighbor (different outbound/return corridors); `out_and_back` restricts to a single quadrant's best zone and accepts the retrace. Routes now surface their actual shape in the UI (badges/popups) instead of leaving riders to infer it.
- **#493 Phase B** — `refineRoute` now tags waypoints as tile-claiming (load-bearing) vs. distance-padding, and prefers dropping padding when trimming for distance, so a route no longer risks silently discarding the exact corner it was claiming a tile through. Phase A (reconciliation against the real routed coordinates via `verifyTileClaims`) and Phase C (regression test) were already on `main`.

## Test plan
- [x] `node --check` on both modified JS files
- [x] `pytest tests/test_exploration_service.py` (28 passed, unaffected by this change)
- [x] Isolated Node harness against the real `optimize()` function with synthetic coverage data: confirmed `loop` routes span 2 adjacent quadrants and `out_and_back` routes stay within 1
- [x] Isolated Node harness against the real `refineRoute()` function with a scripted fake router: confirmed a padding waypoint is dropped before either load-bearing (tile-claiming) corner
- [x] Loaded `/explore.html` via Playwright against the local dev server to confirm the new select renders with the three shape options
- [ ] Manual verification against real ride history/coverage data not done — this dev environment has no cached Strava activities (empty coverage grid, `bounds: None`), so live route generation end-to-end wasn't exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)