### PR TITLE
Add Windows file locking to JSONStorage (#465)

### DIFF
--- a/src/json_storage.py
+++ b/src/json_storage.py
@@ -62,6 +62,33 @@ if sys.platform == 'win32':
                 time.sleep(0.01)
 
 
+    def _win32_replace_retrying(temp_path: Path, filepath: Path) -> None:
+        """
+        ``temp_path.replace(filepath)``, retrying transient PermissionError.
+
+        Even while holding the sidecar lock (which excludes other JSONStorage
+        writers/readers of *this* file), Windows can still momentarily deny
+        ``MoveFileEx`` onto an existing destination if some other handle —
+        Windows Search Indexer, antivirus real-time scanning, an Explorer
+        preview — briefly opened the destination without FILE_SHARE_DELETE.
+        POSIX rename has no such failure mode, which is why this retry only
+        exists on the Windows path. Observed empirically: a tight loop of
+        cross-process update() calls in tests/test_json_storage.py hit this
+        roughly 1 time in 15-20 without a retry, silently dropping a write
+        (the exception was caught and logged by _write_locked, which then
+        returned False).
+        """
+        deadline = time.monotonic() + 2.0
+        while True:
+            try:
+                temp_path.replace(filepath)
+                return
+            except PermissionError:
+                if time.monotonic() >= deadline:
+                    raise
+                time.sleep(0.01)
+
+
 def secure_chmod(path) -> None:
     """
     Best-effort chmod to 0o600 (owner read/write only).
@@ -319,7 +346,10 @@ class JSONStorage:
             os.chmod(temp_path, 0o600)
 
             # Atomic rename (replaces old file)
-            temp_path.replace(filepath)
+            if sys.platform == 'win32':
+                _win32_replace_retrying(temp_path, filepath)
+            else:
+                temp_path.replace(filepath)
 
             logger.debug(f"Successfully wrote {filepath.name}")
             return True

--- a/src/json_storage.py
+++ b/src/json_storage.py
@@ -11,12 +11,15 @@ Provides thread-safe JSON file operations with:
 import json
 import os
 import sys
+import time
 from src.secure_logger import SecureLogger
 import threading
 from contextlib import contextmanager
 
 if sys.platform != 'win32':
     import fcntl
+else:
+    import msvcrt
 from pathlib import Path
 from typing import Any, Callable
 from datetime import datetime
@@ -35,6 +38,28 @@ _THREAD_LOCKS_GUARD = threading.Lock()
 # were being re-read and re-parsed on every API request (#461).
 _READ_CACHE: dict[str, tuple] = {}
 _READ_CACHE_GUARD = threading.Lock()
+
+
+if sys.platform == 'win32':
+    def _msvcrt_lock_blocking(fd: int) -> None:
+        """
+        Lock byte 0 of *fd*, blocking indefinitely until acquired.
+
+        msvcrt.locking's own LK_LOCK mode is *not* an indefinite block like
+        fcntl.flock: per the msvcrt docs it retries only 10 times, roughly a
+        second apart, then raises OSError — under real contention (e.g. a
+        writer that briefly holds the lock across a slow fsync+rename) that
+        cap can be hit, and a caller not expecting a raise there would drop
+        the write it was about to make. Poll with the non-blocking LK_NBLCK
+        mode ourselves instead, so this call has the same "block until
+        acquired" contract as fcntl.flock(LOCK_EX).
+        """
+        while True:
+            try:
+                msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                return
+            except OSError:
+                time.sleep(0.01)
 
 
 def secure_chmod(path) -> None:
@@ -122,13 +147,32 @@ class JSONStorage:
     @contextmanager
     def _locked(self, filepath: Path):
         """
-        Exclusive per-file lock: a threading.Lock within the process plus
-        flock on a sidecar ``<name>.lock`` file across processes (POSIX only;
-        cron jobs and gunicorn workers are separate processes).
+        Exclusive per-file lock: a threading.Lock within the process plus an
+        OS-level lock on a sidecar ``<name>.lock`` file across processes
+        (cron jobs and gunicorn workers are separate processes on the Pi).
 
-        The flock goes on a sidecar file rather than the data file because
+        The OS lock goes on a sidecar file rather than the data file because
         atomic writes replace the data file's inode on rename — a lock held
         on the old inode would not exclude writers that open the new one.
+
+        Cross-process locking mechanism differs by platform:
+        - POSIX (production/Pi): fcntl.flock on the sidecar file.
+        - Windows (local dev): msvcrt.locking on the sidecar file. Windows
+          has no flock-a-whole-file primitive, so this locks a single byte
+          at offset 0 instead — sufficient since the sidecar file's only
+          purpose is to be lockable, not to hold data.
+
+        Note on why this is needed at all despite gunicorn.conf.py defaulting
+        GUNICORN_WORKERS to 1: a single worker already makes the POSIX fcntl
+        path's cross-process guarantee somewhat academic in production (one
+        process, so the threading.Lock above would suffice there too) — but
+        gunicorn itself requires fork() and doesn't run on Windows at all, so
+        this path is exercised only by local Windows dev (`python launch.py`)
+        plus the test suite. There, cross-process safety isn't about worker
+        count but about guarding against e.g. a second `launch.py` accidentally
+        left running, or a test process racing the dev server — hence a real
+        OS-level lock rather than relying solely on the in-process
+        threading.Lock, which cannot exclude a different process.
         """
         with _THREAD_LOCKS_GUARD:
             tlock = _THREAD_LOCKS.setdefault(str(filepath), threading.Lock())
@@ -138,11 +182,24 @@ class JSONStorage:
                 secure_chmod(lock_path)
                 if sys.platform != 'win32':
                     fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+                else:
+                    # msvcrt.locking locks nbytes starting at the current
+                    # file position, and requires those bytes to already
+                    # exist in the file — so make sure there's at least one
+                    # byte to lock before seeking to it.
+                    if os.fstat(lf.fileno()).st_size == 0:
+                        lf.write(' ')
+                        lf.flush()
+                    lf.seek(0)
+                    _msvcrt_lock_blocking(lf.fileno())
                 try:
                     yield
                 finally:
                     if sys.platform != 'win32':
                         fcntl.flock(lf.fileno(), fcntl.LOCK_UN)
+                    else:
+                        lf.seek(0)
+                        msvcrt.locking(lf.fileno(), msvcrt.LK_UNLCK, 1)
 
     def read(self, filename: str, default: Any = None) -> Any:
         """
@@ -166,6 +223,15 @@ class JSONStorage:
             with open(filepath, 'r') as f:
                 if sys.platform != 'win32':
                     fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+                else:
+                    # msvcrt has no shared-lock mode, so this is exclusive —
+                    # slightly more conservative than POSIX LOCK_SH, but reads
+                    # are quick and this only blocks other readers/writers of
+                    # this exact fd's lock byte, not the sidecar lock used by
+                    # write()/update() (see _locked()'s docstring).
+                    if os.fstat(f.fileno()).st_size > 0:
+                        _msvcrt_lock_blocking(f.fileno())
+                        f.seek(0)
                 try:
                     data = json.load(f)
                     logger.debug(f"Successfully read {filename}")
@@ -173,6 +239,9 @@ class JSONStorage:
                 finally:
                     if sys.platform != 'win32':
                         fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+                    elif os.fstat(f.fileno()).st_size > 0:
+                        f.seek(0)
+                        msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
                     
         except json.JSONDecodeError as e:
             logger.error(f"Invalid JSON in {filename}: {e}")

--- a/tests/test_json_storage.py
+++ b/tests/test_json_storage.py
@@ -15,6 +15,22 @@ import shutil
 from src.json_storage import JSONStorage, get_storage
 
 
+def _mp_increment_worker(data_dir: str, n_iterations: int) -> None:
+    """Top-level (picklable) worker for the cross-process update() test.
+
+    Must be module-level so ``multiprocessing`` can pickle it for the
+    ``spawn`` start method Windows uses (a closure/method wouldn't pickle).
+    """
+    storage = JSONStorage(data_dir=data_dir)
+
+    def increment(data):
+        data['count'] += 1
+        return data
+
+    for _ in range(n_iterations):
+        storage.update('mp_shared.json', increment)
+
+
 class TestJSONStorage:
     """Test suite for JSONStorage class."""
     
@@ -286,5 +302,36 @@ class TestJSONStorageConcurrency:
             t.join()
 
         assert storage.read('shared.json') == {'count': n_threads * n_iterations}
+
+    def test_concurrent_updates_across_processes_lose_no_increments(self, temp_dir):
+        """Test update() serializes across OS processes, not just threads.
+
+        This is issue #465: on Windows, the in-process threading.Lock in
+        _locked() can't exclude a *different* process, so cross-process
+        safety depends entirely on the OS-level lock (fcntl on POSIX,
+        msvcrt on Windows) actually being taken on the sidecar file. Uses
+        real subprocesses (not threads) so this would have caught the
+        pre-fix Windows gap, where that OS-level lock was a no-op.
+        """
+        import multiprocessing
+
+        storage = JSONStorage(data_dir=temp_dir)
+        storage.write('mp_shared.json', {'count': 0})
+
+        n_processes, n_iterations = 4, 15
+        procs = [
+            multiprocessing.Process(
+                target=_mp_increment_worker, args=(temp_dir, n_iterations)
+            )
+            for _ in range(n_processes)
+        ]
+        for p in procs:
+            p.start()
+        for p in procs:
+            p.join(timeout=60)
+            assert p.exitcode == 0
+
+        result = JSONStorage(data_dir=temp_dir).read('mp_shared.json')
+        assert result == {'count': n_processes * n_iterations}
 
 


### PR DESCRIPTION
## Summary
- Adds `msvcrt.locking`-based file locking on Windows (gated on `sys.platform == 'win32'`), locking a sidecar `.lock` file rather than the data file itself since atomic rename swaps inodes
- Blocking-poll wrapper (`_msvcrt_lock_blocking`) around `LK_NBLCK`, since `LK_LOCK` only retries ~10s before raising
- Documents the remaining multi-process limitation; confirmed `gunicorn.conf.py` defaults to `GUNICORN_WORKERS=1`, so cross-process races matter mainly for Windows dev, not Pi prod
- Added `_win32_replace_retrying()`: a short poll-retry (2s deadline) around the atomic rename on `PermissionError`, fixing a rare (~1-in-15-20-run) flaky `WinError 5: Access is denied` surfaced by a new cross-process regression test — caused by another handle (AV/indexer) transiently opening the destination file
- Rebased onto current `main` (post Phase 2 of #498) — `read_cached()` delegates through `self.read()` so it automatically inherits the new locking; no conflicts

Closes #465.

## Test plan
- [x] New cross-process regression test with real `multiprocessing.Process` workers: 25/25 clean runs after the retry fix
- [x] Full suite: 1165 passed, 5 pre-existing Windows POSIX-permission-bit failures unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)