### PR TITLE
Granular service refresh instead of full container re-init (#461)

### DIFF
--- a/app/api/data_bp.py
+++ b/app/api/data_bp.py
@@ -143,7 +143,10 @@ def trigger_analysis():
             else:
                 jobs.analysis.update(status='done', phase='done', result=result,
                                      label=f"Done — {result.get('activities_count', 0):,} activities")
-            container.reset_initialisation()
+            # analysis_service itself already reflects the fresh results (same
+            # instance, mutated in place by run_full_analysis) — only the
+            # services that derive their state from it need rebuilding (#461).
+            container.refresh_services('commute', 'planner')
         except Exception as e:
             logger.error(f"Background analysis failed: {e}", exc_info=True)
             jobs.analysis.update(status='error', phase='error',
@@ -243,7 +246,11 @@ def trigger_fetch():
                     force_refresh=False,
                     skip_strava_fetch=True,
                 )
-                container.reset_initialisation()
+                # Only CommuteService/PlannerService derive their state from
+                # analysis_service's route groups / long rides — no need to
+                # tear down WeatherService/TrainerRoadService/RouteLibraryService
+                # or reconstruct AnalysisService itself (#461).
+                container.refresh_services('commute', 'planner')
                 jobs.fetch.update(
                     status='done',
                     label=f'Done — {total:,} activities, {new_count:,} new (analysis updated)',
@@ -319,7 +326,10 @@ def trigger_history_backfill():
                     pages=result['pages'],
                 )
                 analysis_service.run_full_analysis(force_refresh=False, skip_strava_fetch=True)
-                container.reset_initialisation()
+                # Same reasoning as trigger_fetch above — only Commute/Planner
+                # derive state from analysis_service's route groups / long
+                # rides (#461).
+                container.refresh_services('commute', 'planner')
                 jobs.history_backfill.update(
                     status='done',
                     label=f'Done — {new_total:,} new activities backfilled (analysis updated)',

--- a/app/api/integrations_bp.py
+++ b/app/api/integrations_bp.py
@@ -231,7 +231,11 @@ def location_save():
     # concurrent edit leaving config.yaml briefly invalid) shouldn't be reported as a lost save.
     try:
         ConfigManager.get_instance().reload()
-        current_app.container.reset_initialisation()
+        # Only CommuteService reads home/work location at init time (via
+        # _load_commute_data() pulling fresh config) — no need to rebuild
+        # WeatherService/TrainerRoadService/RouteLibraryService/AnalysisService/
+        # PlannerService too (#461).
+        current_app.container.refresh_services('commute')
     except Exception as exc:
         logger.error("Location saved but config reload failed: %s", exc, exc_info=True)
         return jsonify({'success': True, 'warning': 'Saved, but the app may need a restart to pick up the change.'})

--- a/app/api/strava_bp.py
+++ b/app/api/strava_bp.py
@@ -125,7 +125,10 @@ def strava_callback():
         })
         logger.info("Strava OAuth complete — credentials saved")
 
-        current_app.container.reset_initialisation()
+        # New credentials only change what Strava-backed services can fetch —
+        # WeatherService/TrainerRoadService/RouteLibraryService don't depend
+        # on Strava auth, so a full container reset is unnecessary (#461).
+        current_app.container.refresh_services('analysis', 'commute', 'planner')
 
         setup_redirect = session.pop('setup_redirect', False)
         if setup_redirect:
@@ -147,7 +150,9 @@ def strava_disconnect():
         creds_path = current_app.container.credentials_path
         if creds_path.exists():
             creds_path.unlink()
-        current_app.container.reset_initialisation()
+        # See connect handler above — only Strava-backed services need to be
+        # rebuilt after a credentials change (#461).
+        current_app.container.refresh_services('analysis', 'commute', 'planner')
         logger.info("Strava credentials removed — integration disconnected")
         return jsonify({'success': True})
     except Exception as exc:

--- a/app/container.py
+++ b/app/container.py
@@ -111,8 +111,46 @@ class ServiceContainer:
         logger.info("Services initialized successfully")
 
     def reset_initialisation(self) -> None:
-        """Allow re-initialisation after an analysis/fetch job completes."""
+        """Force a full re-initialisation of every service on the next initialise() call.
+
+        Prefer refresh_services() below when only specific services are
+        affected by an action — this nukes and rebuilds all six services,
+        which is heavier than necessary for e.g. a location change that only
+        affects CommuteService (issue #461).
+        """
         self._initialised = False
+
+    def refresh_services(self, *names: str) -> None:
+        """Re-run init for only the named services, in place, without touching
+        the other (unaffected) services or forcing a full container rebuild.
+
+        Valid names: 'weather', 'trainerroad', 'route_library', 'analysis',
+        'commute', 'planner'. Unknown names are logged and skipped.
+
+        If the container hasn't completed its first initialise() yet, this is
+        a no-op — the next request's initialise() call will build every
+        service fresh anyway, so there's nothing useful to refresh early.
+        """
+        if not self._initialised:
+            return
+
+        dispatch = {
+            'weather': self._init_weather,
+            'trainerroad': self._init_trainerroad,
+            'route_library': self._init_route_library,
+            'analysis': self._init_analysis,
+            'commute': self._init_commute,
+            'planner': self._init_planner,
+        }
+        for name in names:
+            init_fn = dispatch.get(name)
+            if init_fn is None:
+                logger.warning("refresh_services: unknown service name %r", name)
+                continue
+            try:
+                init_fn()
+            except Exception as exc:
+                logger.error("refresh_services: failed to refresh '%s': %s", name, exc, exc_info=True)
 
     # ------------------------------------------------------------------
     # Private per-service init helpers

--- a/tests/test_container_refresh.py
+++ b/tests/test_container_refresh.py
@@ -1,0 +1,70 @@
+"""Tests for ServiceContainer.refresh_services (issue #461).
+
+reset_initialisation() forces a full re-init of every service on the next
+initialise() call. refresh_services() should instead rebuild only the named
+services in place, leaving the others untouched, and should be a no-op
+before the container has completed its first initialise().
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.container import ServiceContainer
+
+
+@pytest.mark.unit
+class TestRefreshServices:
+    def test_noop_before_first_initialise(self):
+        container = ServiceContainer()
+        # Never called container.initialise() — _initialised is False.
+        container._init_weather = MagicMock()
+        container.refresh_services('weather')
+        container._init_weather.assert_not_called()
+
+    def test_only_named_services_are_rebuilt(self):
+        container = ServiceContainer()
+        container._initialised = True
+        container._init_weather = MagicMock(name='init_weather')
+        container._init_trainerroad = MagicMock(name='init_trainerroad')
+        container._init_route_library = MagicMock(name='init_route_library')
+        container._init_analysis = MagicMock(name='init_analysis')
+        container._init_commute = MagicMock(name='init_commute')
+        container._init_planner = MagicMock(name='init_planner')
+
+        container.refresh_services('commute', 'planner')
+
+        container._init_commute.assert_called_once()
+        container._init_planner.assert_called_once()
+        container._init_weather.assert_not_called()
+        container._init_trainerroad.assert_not_called()
+        container._init_route_library.assert_not_called()
+        container._init_analysis.assert_not_called()
+
+    def test_unknown_service_name_is_skipped_not_raised(self):
+        container = ServiceContainer()
+        container._initialised = True
+        container._init_commute = MagicMock()
+
+        container.refresh_services('not_a_real_service', 'commute')
+
+        container._init_commute.assert_called_once()
+
+    def test_exception_in_one_service_does_not_block_others(self):
+        container = ServiceContainer()
+        container._initialised = True
+        container._init_commute = MagicMock(side_effect=RuntimeError("boom"))
+        container._init_planner = MagicMock()
+
+        container.refresh_services('commute', 'planner')
+
+        container._init_planner.assert_called_once()
+
+    def test_does_not_flip_initialised_flag(self):
+        container = ServiceContainer()
+        container._initialised = True
+        container._init_commute = MagicMock()
+
+        container.refresh_services('commute')
+
+        assert container._initialised is True


### PR DESCRIPTION
## Summary
This is the remaining half of #461 not already covered by main's Phase 2 (#498) work — the duplicate-uncached-JSON-reads half of #461 and all of #473 were already resolved by `JSONStorage.read_cached()` / `app/api/activity_cache.py`, landed in commit c2da980.

What was still unaddressed: `ServiceContainer.reset_initialisation()` forced a full re-init of all six services (Weather, TrainerRoad, RouteLibrary, Analysis, Commute, Planner) after every Strava connect/disconnect, location save, and analysis/fetch completion.

- Adds `ServiceContainer.refresh_services(*names)` — rebuilds only the named services in place, no-op before first `initialise()`
- Updates call sites to use it instead of `reset_initialisation()`:
  - `strava_bp.py` (connect/disconnect → refresh analysis, commute, planner)
  - `integrations_bp.py` (location save → refresh commute)
  - `data_bp.py` (analysis complete, fetch complete, and the newer `history-backfill` endpoint → refresh commute, planner)

Closes #461. Supersedes the original `worktree-agent-ac93bd1a6d86370cd` branch, whose caching-accessor content is now redundant with main.

## Test plan
- [x] `test_container_refresh.py`: 5/5 pass
- [x] Targeted run (strava/integration/data_bp/container/fetch/analysis): 332/332 pass
- [x] Full suite: 1169 passed, 5 pre-existing Windows chmod failures, 11 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)