### PR TITLE
Unify route-similarity math on route_comparison.py (#463)

### DIFF
--- a/src/long_ride_analyzer.py
+++ b/src/long_ride_analyzer.py
@@ -6,7 +6,6 @@ Analyzes non-commute cycling activities for recreational ride recommendations.
 
 import json
 from .secure_logger import SecureLogger
-import math
 from pathlib import Path
 from typing import List, Tuple, Dict, Any, Optional
 from dataclasses import dataclass
@@ -17,12 +16,13 @@ from functools import partial
 import numpy as np
 from geopy.distance import geodesic
 import polyline
-from similaritymeasures import frechet_dist
-from scipy.spatial.distance import directed_hausdorff
 
 from .data_fetcher import Activity
 from .route_namer import RouteNamer
-from .route_comparison import coords_to_km, extent_point
+from .route_comparison import (
+    coords_to_km, passes_prefilter, combined_distance_km,
+    LONG_RIDE_THRESHOLDS,
+)
 from .weather_fetcher import WeatherFetcher
 from .json_storage import secure_chmod
 
@@ -215,10 +215,6 @@ class LongRideAnalyzer:
     def _coords_to_km(coords: np.ndarray) -> np.ndarray:
         return coords_to_km(coords)
 
-    @staticmethod
-    def _extent_point(coords_km: np.ndarray) -> np.ndarray:
-        return extent_point(coords_km)
-
     def consolidate_similar_named_groups(self, name_groups: Dict[str, List[Activity]],
                                         similarity_threshold: float = 2.0,
                                         on_progress=None) -> Dict[str, List[Activity]]:
@@ -287,7 +283,13 @@ class LongRideAnalyzer:
                     if cache_key in self._similarity_cache:
                         combined_distance = self._similarity_cache[cache_key]
                     else:
-                        # Pre-filter: skip if average distances differ by more than 25%
+                        # Pre-filter: skip if average recorded distances differ by more
+                        # than 25%. Uses Strava's recorded activity.distance rather than
+                        # coordinate-derived path length -- summary polylines are
+                        # simplified (Douglas-Peucker), so path length from decoded
+                        # points can undercount the real distance. Cheaper and more
+                        # accurate than the length-ratio check inside passes_prefilter,
+                        # so it stays as a first-pass filter ahead of it.
                         dists1 = [a.distance for a in name_groups[name1] if a.distance]
                         dists2 = [a.distance for a in name_groups[name2] if a.distance]
                         if dists1 and dists2:
@@ -301,31 +303,15 @@ class LongRideAnalyzer:
                         coords1_km = group_representatives[name1]
                         coords2_km = group_representatives[name2]
 
-                        # Pre-filter: centroid distance — loops going different places have
-                        # centroids far apart even when they share a start/end point
-                        centroid_dist = float(np.linalg.norm(
-                            coords1_km.mean(axis=0) - coords2_km.mean(axis=0)
-                        ))
-                        if centroid_dist > 5.0:
+                        # Shared geometric pre-filter (centroid + extent-point distance;
+                        # length-ratio and bbox-overlap checks are no-ops here since
+                        # LONG_RIDE_THRESHOLDS already applied the distance-based ratio
+                        # check above and bbox_overlap_min is 0).
+                        if not passes_prefilter(coords1_km, coords2_km, LONG_RIDE_THRESHOLDS):
                             self._similarity_cache[cache_key] = float('inf')
                             continue
 
-                        # Pre-filter: extent point distance — the farthest-from-start point
-                        # of each route must be close; routes apexing in different directions
-                        # will fail even if their centroids are coincidentally similar
-                        extent_dist = float(np.linalg.norm(
-                            self._extent_point(coords1_km) - self._extent_point(coords2_km)
-                        ))
-                        if extent_dist > 10.0:
-                            self._similarity_cache[cache_key] = float('inf')
-                            continue
-
-                        frechet_distance = frechet_dist(coords1_km, coords2_km)
-                        hausdorff_dist = max(
-                            directed_hausdorff(coords1_km, coords2_km)[0],
-                            directed_hausdorff(coords2_km, coords1_km)[0]
-                        )
-                        combined_distance = (frechet_distance + hausdorff_dist) / 2
+                        combined_distance = combined_distance_km(coords1_km, coords2_km)
                         self._similarity_cache[cache_key] = combined_distance
 
                     # If routes are similar, merge them
@@ -452,39 +438,20 @@ class LongRideAnalyzer:
 
         try:
             raw_coords = np.array(polyline.decode(activity_polyline))
-            # Scale to km using the same approach as _coords_to_km
-            mean_lat = float(np.mean(raw_coords[:, 0]))
-            lat_km = 111.32
-            lon_km = 111.32 * math.cos(math.radians(mean_lat))
-            route_coords = raw_coords.copy().astype(float)
-            route_coords[:, 0] *= lat_km
-            route_coords[:, 1] *= lon_km
+            route_coords = coords_to_km(raw_coords)
 
             best_match = None
             best_distance = float('inf')
 
             for group_name, rep_coords_km in group_representatives.items():
                 try:
-                    # Centroid pre-filter
-                    centroid_dist = float(np.linalg.norm(
-                        route_coords.mean(axis=0) - rep_coords_km.mean(axis=0)
-                    ))
-                    if centroid_dist > 5.0:
+                    # Shared geometric pre-filter (length-ratio, centroid, extent-point;
+                    # bbox-overlap is a no-op since LONG_RIDE_THRESHOLDS.bbox_overlap_min
+                    # is 0), same thresholds used by consolidate_similar_named_groups.
+                    if not passes_prefilter(route_coords, rep_coords_km, LONG_RIDE_THRESHOLDS):
                         continue
 
-                    # Extent point pre-filter
-                    extent_dist = float(np.linalg.norm(
-                        LongRideAnalyzer._extent_point(route_coords) - LongRideAnalyzer._extent_point(rep_coords_km)
-                    ))
-                    if extent_dist > 10.0:
-                        continue
-
-                    frechet_distance = frechet_dist(route_coords, rep_coords_km)
-                    hausdorff_dist = max(
-                        directed_hausdorff(route_coords, rep_coords_km)[0],
-                        directed_hausdorff(rep_coords_km, route_coords)[0]
-                    )
-                    combined_distance = (frechet_distance + hausdorff_dist) / 2
+                    combined_distance = combined_distance_km(route_coords, rep_coords_km)
 
                     if combined_distance < best_distance:
                         best_distance = combined_distance

--- a/src/route_analyzer.py
+++ b/src/route_analyzer.py
@@ -29,6 +29,10 @@ from .data_fetcher import Activity
 from .location_finder import Location
 from .route_namer import RouteNamer, check_rate_limit_file
 from .json_storage import secure_chmod
+from .route_comparison import (
+    passes_prefilter_deg, frechet_similarity_deg,
+    hausdorff_percentile_similarity_deg, commute_similarity_score,
+)
 
 logger = SecureLogger(__name__)
 
@@ -56,7 +60,7 @@ def _similarity_worker(args):
     Returns list of (original_idx, cache_key, similarity_score).
     """
     import numpy as np
-    from scipy.spatial.distance import cdist
+    from .route_comparison import commute_similarity_score
 
     pivot_coords, candidates, frechet_available, hausdorff_percentile = args
     pivot = np.array(pivot_coords)
@@ -64,25 +68,11 @@ def _similarity_worker(args):
 
     for (original_idx, cache_key, candidate_coords) in candidates:
         candidate = np.array(candidate_coords)
-
-        def hausdorff_sim(c1, c2):
-            d12 = cdist(c1, c2).min(axis=1)
-            d21 = cdist(c2, c1).min(axis=1)
-            pct = max(np.percentile(d12, hausdorff_percentile),
-                      np.percentile(d21, hausdorff_percentile))
-            return 1 / (1 + pct * 111000 / 200)
-
-        try:
-            if frechet_available:
-                import similaritymeasures as sm
-                frechet_sim = 1 / (1 + sm.frechet_dist(pivot, candidate) * 111000 / 300)
-                h_sim = hausdorff_sim(pivot, candidate)
-                score = frechet_sim * 0.7 if h_sim < 0.50 else frechet_sim
-            else:
-                score = hausdorff_sim(pivot, candidate)
-        except Exception:
-            score = hausdorff_sim(pivot, candidate)
-
+        score = commute_similarity_score(
+            pivot, candidate,
+            percentile=hausdorff_percentile,
+            frechet_available=frechet_available,
+        )
         results.append((original_idx, cache_key, score))
 
     return results
@@ -423,41 +413,20 @@ class RouteAnalyzer:
                                  length_ratio_max: float = 2.0,
                                  centroid_max_deg: float = 0.02,
                                  bbox_overlap_min: float = 0.3) -> bool:
-        """Fast geometric pre-filter — returns False if routes are obviously dissimilar."""
-        if (route1.bbox is None or route2.bbox is None
-                or route1.path_length_deg is None or route2.path_length_deg is None):
-            return True  # no geometry available, can't reject
+        """Fast geometric pre-filter — returns False if routes are obviously dissimilar.
 
-        # 1) Path length ratio — reject if one route is far longer than the other
-        shorter = min(route1.path_length_deg, route2.path_length_deg)
-        longer = max(route1.path_length_deg, route2.path_length_deg)
-        if shorter > 0 and longer / shorter > length_ratio_max:
-            return False
-
-        # 2) Centroid distance — reject if centroids are far apart
-        c1, c2 = route1.centroid, route2.centroid
-        cdist_deg = ((c1[0] - c2[0]) ** 2 + (c1[1] - c2[1]) ** 2) ** 0.5
-        if cdist_deg > centroid_max_deg:
-            return False
-
-        # 3) Bounding box overlap ratio — reject if boxes barely intersect
-        min_lat1, min_lon1, max_lat1, max_lon1 = route1.bbox
-        min_lat2, min_lon2, max_lat2, max_lon2 = route2.bbox
-
-        inter_lat = max(0, min(max_lat1, max_lat2) - max(min_lat1, min_lat2))
-        inter_lon = max(0, min(max_lon1, max_lon2) - max(min_lon1, min_lon2))
-        intersection = inter_lat * inter_lon
-
-        if intersection == 0:
-            return False
-
-        area1 = (max_lat1 - min_lat1) * (max_lon1 - min_lon1)
-        area2 = (max_lat2 - min_lat2) * (max_lon2 - min_lon2)
-        smaller_area = min(area1, area2)
-        if smaller_area > 0 and intersection / smaller_area < bbox_overlap_min:
-            return False
-
-        return True
+        Delegates to the shared route_comparison.passes_prefilter_deg, using
+        Route's precomputed bbox/centroid/path_length_deg (see
+        Route.compute_geometry) rather than recomputing geometry from full
+        coordinate arrays on every candidate pair.
+        """
+        return passes_prefilter_deg(
+            route1.bbox, route1.centroid, route1.path_length_deg,
+            route2.bbox, route2.centroid, route2.path_length_deg,
+            length_ratio_max=length_ratio_max,
+            centroid_max_deg=centroid_max_deg,
+            bbox_overlap_min=bbox_overlap_min,
+        )
     def extract_routes(self, direction: str = 'both') -> List[Route]:
         """
         Extract routes between home and work.
@@ -615,66 +584,33 @@ class RouteAnalyzer:
         Returns:
             Similarity score (0-1)
         """
-        from scipy.spatial.distance import cdist
-        
         # Get percentile from config (default 95.0 = ignore worst 5% of deviations)
         percentile = self.config.get('route_analysis.outlier_tolerance_percentile', 95.0)
-        
-        # Distance from each point in coords1 to nearest point in coords2
-        distances_1_to_2 = cdist(coords1, coords2).min(axis=1)
-        
-        # Distance from each point in coords2 to nearest point in coords1
-        distances_2_to_1 = cdist(coords2, coords1).min(axis=1)
-        
-        # Use percentile instead of max to tolerate outliers
-        percentile_dist_1 = np.percentile(distances_1_to_2, percentile)
-        percentile_dist_2 = np.percentile(distances_2_to_1, percentile)
-        
-        # Take the larger of the two percentile distances
-        percentile_dist = max(percentile_dist_1, percentile_dist_2)
-        
-        # Convert degrees to meters (approximate)
-        # At Chicago's latitude (~42°), 1 degree ≈ 111km latitude, ~82km longitude
-        # Using 111km as conservative estimate
-        normalized_dist = percentile_dist * 111000
-        
-        # Convert to similarity score (0-1)
-        # Routes are considered similar if percentile deviation is within 200m
-        distance_threshold = 200  # meters
-        similarity = 1 / (1 + normalized_dist / distance_threshold)
-        
-        return similarity
-    
+
+        # Delegates to the shared route_comparison implementation (also used by
+        # _similarity_worker, the ProcessPoolExecutor path) so both the sequential
+        # and parallel grouping paths stay on identical math.
+        return hausdorff_percentile_similarity_deg(coords1, coords2, percentile=percentile)
+
     def _calculate_frechet_similarity(self, coords1: np.ndarray, coords2: np.ndarray) -> float:
         """
         Calculate similarity using Fréchet distance.
-        
+
         Fréchet distance considers the order of points, like walking a dog on a leash.
         It's better at detecting routes that follow the same path vs routes that are
         spatially close but follow different paths.
-        
+
         Args:
             coords1: First route coordinates
             coords2: Second route coordinates
-            
+
         Returns:
             Similarity score (0-1)
         """
         try:
-            # Calculate Fréchet distance
-            # Note: similaritymeasures expects (n, 2) arrays
-            frechet_dist = similaritymeasures.frechet_dist(coords1, coords2)
-            
-            # Convert degrees to meters
-            normalized_dist = frechet_dist * 111000
-            
-            # Convert to similarity score
-            # Fréchet distance is typically larger than Hausdorff, so use larger threshold
-            distance_threshold = 300  # meters - allow more variation for path-based comparison
-            similarity = 1 / (1 + normalized_dist / distance_threshold)
-            
-            return similarity
-            
+            # Delegates to the shared route_comparison implementation (also used by
+            # _similarity_worker, the ProcessPoolExecutor path).
+            return frechet_similarity_deg(coords1, coords2)
         except Exception as e:
             logger.warning(f"Fréchet distance calculation failed: {e}, falling back to Hausdorff")
             return self._calculate_hausdorff_similarity(coords1, coords2)
@@ -1147,111 +1083,6 @@ class RouteAnalyzer:
             f"{expensive_comparisons} expensive)"
         )
 
-        return groups
-
-    @staticmethod
-    def _group_routes_by_similarity_static(routes: List[Route], direction: str,
-                                          similarity_threshold: float,
-                                          similarity_cache: Dict[str, float]) -> List[RouteGroup]:
-        """
-        Static method for parallel route grouping.
-        
-        This is a static method so it can be pickled for multiprocessing.
-        
-        Args:
-            routes: List of routes to group
-            direction: Route direction
-            similarity_threshold: Similarity threshold for grouping
-            similarity_cache: Cached similarity calculations
-            
-        Returns:
-            List of RouteGroup objects
-        """
-        if not routes:
-            return []
-        
-        groups = []
-        ungrouped = routes.copy()
-        group_id = 0
-        
-        # Helper function to calculate similarity (simplified for static context)
-        def calc_similarity(route1: Route, route2: Route) -> float:
-            # Check cache first
-            cache_key = f"{route1.activity_id}_{route2.activity_id}"
-            if cache_key in similarity_cache:
-                return similarity_cache[cache_key]
-            
-            # Calculate similarity using the same thresholds/logic as the instance path
-            coords1 = np.array(route1.coordinates)
-            coords2 = np.array(route2.coordinates)
-            
-            def calc_hausdorff_similarity() -> float:
-                from scipy.spatial.distance import cdist
-                distances_1_to_2 = cdist(coords1, coords2).min(axis=1)
-                distances_2_to_1 = cdist(coords2, coords1).min(axis=1)
-                percentile_dist_1 = np.percentile(distances_1_to_2, 95.0)
-                percentile_dist_2 = np.percentile(distances_2_to_1, 95.0)
-                percentile_dist = max(percentile_dist_1, percentile_dist_2)
-                normalized_dist = percentile_dist * 111000
-                distance_threshold = 200
-                return 1 / (1 + normalized_dist / distance_threshold)
-            
-            if FRECHET_AVAILABLE:
-                try:
-                    frechet_dist = similaritymeasures.frechet_dist(coords1, coords2)
-                    normalized_dist = frechet_dist * 111000
-                    frechet_similarity = 1 / (1 + normalized_dist / 300)
-                    hausdorff_similarity = calc_hausdorff_similarity()
-                    if hausdorff_similarity < 0.50:
-                        return frechet_similarity * 0.7
-                    return frechet_similarity
-                except (ValueError, IndexError, TypeError) as e:
-                    logger.debug(f"Fréchet distance calculation failed, falling back to Hausdorff: {e}")
-            
-            return calc_hausdorff_similarity()
-        
-        while ungrouped:
-            # Start new group with first ungrouped route
-            current = ungrouped.pop(0)
-            group = [current]
-            
-            # Find similar routes
-            to_remove = []
-            for i, route in enumerate(ungrouped):
-                if not RouteAnalyzer._passes_geometric_filter(current, route):
-                    continue
-                similarity = calc_similarity(current, route)
-                if similarity >= similarity_threshold:
-                    group.append(route)
-                    to_remove.append(i)
-            
-            # Remove grouped routes
-            for i in reversed(to_remove):
-                ungrouped.pop(i)
-            
-            # Select representative route (median by duration)
-            sorted_routes = sorted(group, key=lambda r: r.duration)
-            representative = sorted_routes[len(sorted_routes) // 2]
-            
-            # Create route group
-            route_id = f"{direction}_{group_id}"
-            route_name = f"Route {group_id}"
-            
-            route_group = RouteGroup(
-                id=route_id,
-                direction=direction,
-                routes=group,
-                representative_route=representative,
-                frequency=len(group),
-                name=route_name
-            )
-            
-            groups.append(route_group)
-            group_id += 1
-        
-        # Sort by frequency
-        groups.sort(key=lambda g: g.frequency, reverse=True)
-        
         return groups
 
     def _select_representative_route(self, routes: List[Route]) -> Route:

--- a/src/route_comparison.py
+++ b/src/route_comparison.py
@@ -156,3 +156,123 @@ def similarity_score(coords1: np.ndarray,
     dist_km = combined_distance_km(coords1, coords2)
     dist_m = dist_km * 1000
     return 1.0 / (1.0 + dist_m / scale_m)
+
+
+# ---------------------------------------------------------------------------
+# Degree-space variants used by the commute route grouper (RouteAnalyzer).
+#
+# RouteAnalyzer compares routes that are all within a few km of each other
+# (a single commute corridor), so it works directly in raw lat/lon degrees
+# with a flat 111km/degree conversion rather than round-tripping through
+# coords_to_km's latitude-corrected km scaling used by the long-ride/loop
+# comparisons above. It also pre-filters using bbox/centroid/path-length
+# values cached once per Route (see Route.compute_geometry) instead of
+# recomputing them from full coordinate arrays on every candidate pair --
+# that caching matters for the O(n^2) inner loop over hundreds of commute
+# activities, so it is kept as a distinct entry point rather than forced
+# through passes_prefilter/combined_distance_km above.
+# ---------------------------------------------------------------------------
+
+def passes_prefilter_deg(bbox1, centroid1, path_length_deg1,
+                         bbox2, centroid2, path_length_deg2,
+                         length_ratio_max: float = 2.0,
+                         centroid_max_deg: float = 0.02,
+                         bbox_overlap_min: float = 0.3) -> bool:
+    """
+    Fast geometric pre-filter over precomputed degree-space route geometry.
+    Returns False if routes are obviously dissimilar. Any missing geometry
+    (None) skips the filter entirely -- callers can't reject what they can't
+    measure.
+    """
+    if (bbox1 is None or bbox2 is None
+            or path_length_deg1 is None or path_length_deg2 is None):
+        return True
+
+    # 1) Path length ratio — reject if one route is far longer than the other
+    shorter = min(path_length_deg1, path_length_deg2)
+    longer = max(path_length_deg1, path_length_deg2)
+    if shorter > 0 and longer / shorter > length_ratio_max:
+        return False
+
+    # 2) Centroid distance — reject if centroids are far apart
+    cdist_deg = ((centroid1[0] - centroid2[0]) ** 2 + (centroid1[1] - centroid2[1]) ** 2) ** 0.5
+    if cdist_deg > centroid_max_deg:
+        return False
+
+    # 3) Bounding box overlap ratio — reject if boxes barely intersect
+    min_lat1, min_lon1, max_lat1, max_lon1 = bbox1
+    min_lat2, min_lon2, max_lat2, max_lon2 = bbox2
+
+    inter_lat = max(0, min(max_lat1, max_lat2) - max(min_lat1, min_lat2))
+    inter_lon = max(0, min(max_lon1, max_lon2) - max(min_lon1, min_lon2))
+    intersection = inter_lat * inter_lon
+
+    if intersection == 0:
+        return False
+
+    area1 = (max_lat1 - min_lat1) * (max_lon1 - min_lon1)
+    area2 = (max_lat2 - min_lat2) * (max_lon2 - min_lon2)
+    smaller_area = min(area1, area2)
+    if smaller_area > 0 and intersection / smaller_area < bbox_overlap_min:
+        return False
+
+    return True
+
+
+def frechet_similarity_deg(coords1: np.ndarray, coords2: np.ndarray,
+                           distance_threshold_m: float = 300.0) -> float:
+    """
+    Fréchet-distance similarity for raw lat/lon-degree coordinates, using a
+    flat 111km/degree conversion (adequate over the few-km span of a single
+    commute corridor). Raises if similaritymeasures isn't installed --
+    callers fall back to hausdorff_percentile_similarity_deg.
+    """
+    if not FRECHET_AVAILABLE:
+        raise RuntimeError("similaritymeasures is not available")
+    dist_deg = frechet_dist(coords1, coords2)
+    normalized_dist_m = dist_deg * 111000
+    return 1 / (1 + normalized_dist_m / distance_threshold_m)
+
+
+def hausdorff_percentile_similarity_deg(coords1: np.ndarray, coords2: np.ndarray,
+                                        percentile: float = 95.0,
+                                        distance_threshold_m: float = 200.0) -> float:
+    """
+    Percentile-based (outlier-tolerant) Hausdorff similarity for raw
+    lat/lon-degree coordinates. Using the Nth percentile of nearest-neighbor
+    deviations instead of the max tolerates GPS glitches/brief detours while
+    still catching real route differences.
+    """
+    distances_1_to_2 = cdist(coords1, coords2).min(axis=1)
+    distances_2_to_1 = cdist(coords2, coords1).min(axis=1)
+    percentile_dist = max(
+        np.percentile(distances_1_to_2, percentile),
+        np.percentile(distances_2_to_1, percentile),
+    )
+    normalized_dist_m = percentile_dist * 111000
+    return 1 / (1 + normalized_dist_m / distance_threshold_m)
+
+
+def commute_similarity_score(coords1: np.ndarray, coords2: np.ndarray,
+                             percentile: float = 95.0,
+                             frechet_available: bool = FRECHET_AVAILABLE,
+                             disagreement_penalty: float = 0.7,
+                             disagreement_floor: float = 0.50) -> float:
+    """
+    Combined Fréchet+Hausdorff similarity score for commute route grouping.
+
+    Fréchet is the primary metric (order-sensitive, robust to GPS sampling
+    differences); percentile Hausdorff is a secondary spatial-disagreement
+    check -- if Hausdorff indicates the routes are spatially far apart even
+    though Fréchet looks close, the Fréchet score is penalized.
+    """
+    if frechet_available:
+        try:
+            frechet_sim = frechet_similarity_deg(coords1, coords2)
+            hausdorff_sim = hausdorff_percentile_similarity_deg(coords1, coords2, percentile)
+            if hausdorff_sim < disagreement_floor:
+                return frechet_sim * disagreement_penalty
+            return frechet_sim
+        except Exception:
+            pass
+    return hausdorff_percentile_similarity_deg(coords1, coords2, percentile)

--- a/tests/test_route_analyzer.py
+++ b/tests/test_route_analyzer.py
@@ -1001,51 +1001,6 @@ class TestMergeNewRoutes:
         assert len(result) >= 1
 
 
-# ---------------------------------------------------------------------------
-# _group_routes_by_similarity_static tests
-# ---------------------------------------------------------------------------
-
-class TestGroupRoutesBySimilarityStatic:
-    def test_empty_returns_empty(self):
-        result = RouteAnalyzer._group_routes_by_similarity_static(
-            [], "home_to_work", 0.70, {}
-        )
-        assert result == []
-
-    def test_single_route_creates_one_group(self):
-        route = _make_route(1)
-        result = RouteAnalyzer._group_routes_by_similarity_static(
-            [route], "home_to_work", 0.70, {}
-        )
-        assert len(result) == 1
-        assert result[0].frequency == 1
-
-    def test_identical_routes_grouped(self):
-        routes = [_make_route(i) for i in range(1, 4)]
-        result = RouteAnalyzer._group_routes_by_similarity_static(
-            routes, "home_to_work", 0.70, {}
-        )
-        assert len(result) == 1
-        assert result[0].frequency == 3
-
-    def test_distinct_routes_separate_groups(self):
-        r1 = _make_route(1, coords=[(41.88 + i * 0.001, -87.63) for i in range(6)])
-        r2 = _make_route(2, coords=[(42.88 + i * 0.001, -88.63) for i in range(6)])
-        result = RouteAnalyzer._group_routes_by_similarity_static(
-            [r1, r2], "home_to_work", 0.70, {}
-        )
-        assert len(result) == 2
-
-    def test_cache_key_used_for_similarity(self):
-        r1 = _make_route(1)
-        r2 = _make_route(2)
-        # Pre-populate cache with a high similarity score
-        cache = {"1_2": 0.99, "2_1": 0.99}
-        result = RouteAnalyzer._group_routes_by_similarity_static(
-            [r1, r2], "home_to_work", 0.70, cache
-        )
-        assert len(result) == 1  # Both merged due to cached high similarity
-
 
 # ---------------------------------------------------------------------------
 # calculate_route_metrics zero-duration edge case

--- a/tests/test_route_comparison.py
+++ b/tests/test_route_comparison.py
@@ -1,0 +1,131 @@
+"""
+Tests for src/route_comparison.py — the shared route-similarity math used by
+both RouteAnalyzer (commute grouping) and LongRideAnalyzer (recreational ride
+grouping). See issue #463: this module exists so the two analyzers don't
+reimplement Fréchet/Hausdorff comparison independently.
+"""
+import numpy as np
+import pytest
+
+from src.route_comparison import (
+    ComparisonThresholds,
+    COMMUTE_THRESHOLDS,
+    LONG_RIDE_THRESHOLDS,
+    coords_to_km,
+    extent_point,
+    centroid,
+    path_length_km,
+    bbox_overlap_ratio,
+    passes_prefilter,
+    combined_distance_km,
+    similarity_score,
+    passes_prefilter_deg,
+    frechet_similarity_deg,
+    hausdorff_percentile_similarity_deg,
+    commute_similarity_score,
+)
+
+
+def _line(offset_lat=0.0, offset_lon=0.0, n=6):
+    return np.array([
+        [41.8800 + offset_lat + i * 0.001, -87.6300 + offset_lon]
+        for i in range(n)
+    ])
+
+
+class TestKmScaledHelpers:
+    def test_coords_to_km_identity_on_empty(self):
+        assert len(coords_to_km(np.empty((0, 2)))) == 0
+
+    def test_combined_distance_km_zero_for_identical_routes(self):
+        coords_km = coords_to_km(_line())
+        assert combined_distance_km(coords_km, coords_km) == pytest.approx(0.0, abs=1e-6)
+
+    def test_combined_distance_km_grows_with_offset(self):
+        c1 = coords_to_km(_line())
+        c2 = coords_to_km(_line(offset_lat=0.5))  # ~55km away
+        assert combined_distance_km(c1, c2) > 10
+
+    def test_similarity_score_high_for_identical(self):
+        coords = _line()
+        assert similarity_score(coords, coords) > 0.99
+
+    def test_similarity_score_low_for_distant(self):
+        assert similarity_score(_line(), _line(offset_lat=1.0)) < 0.1
+
+    def test_passes_prefilter_rejects_distant_centroids(self):
+        c1 = coords_to_km(_line())
+        c2 = coords_to_km(_line(offset_lat=1.0))
+        assert passes_prefilter(c1, c2, COMMUTE_THRESHOLDS) is False
+
+    def test_passes_prefilter_accepts_nearby_routes(self):
+        c1 = coords_to_km(_line())
+        c2 = coords_to_km(_line(offset_lon=0.0005))
+        assert passes_prefilter(c1, c2, LONG_RIDE_THRESHOLDS) is True
+
+    def test_bbox_overlap_ratio_full_overlap_is_one(self):
+        # A pure north-south line has zero-width bbox in one axis, so use a
+        # route with variation on both axes to get a non-degenerate box.
+        square = np.array([[41.88, -87.63], [41.89, -87.63], [41.89, -87.62], [41.88, -87.62]])
+        c1 = coords_to_km(square)
+        assert bbox_overlap_ratio(c1, c1) == pytest.approx(1.0)
+
+    def test_path_length_km_zero_for_single_point(self):
+        assert path_length_km(np.array([[41.88, -87.63]])) == 0.0
+
+
+class TestDegreeScaledHelpers:
+    """Covers the RouteAnalyzer (commute grouper) variants: raw lat/lon degrees,
+    flat 111km/degree conversion, and precomputed-geometry prefiltering."""
+
+    def test_frechet_similarity_deg_high_for_identical(self):
+        coords = _line()
+        assert frechet_similarity_deg(coords, coords) > 0.9
+
+    def test_frechet_similarity_deg_low_for_distant(self):
+        assert frechet_similarity_deg(_line(), _line(offset_lat=1.0)) < 0.5
+
+    def test_hausdorff_percentile_similarity_deg_high_for_identical(self):
+        coords = _line()
+        assert hausdorff_percentile_similarity_deg(coords, coords) > 0.9
+
+    def test_hausdorff_percentile_similarity_deg_bounded(self):
+        sim = hausdorff_percentile_similarity_deg(_line(), _line(offset_lat=0.5))
+        assert 0.0 <= sim <= 1.0
+
+    def test_commute_similarity_score_matches_frechet_when_agreeing(self):
+        coords = _line()
+        assert commute_similarity_score(coords, coords) > 0.99
+
+    def test_commute_similarity_score_falls_back_without_frechet(self):
+        coords = _line()
+        score_with = commute_similarity_score(coords, coords, frechet_available=True)
+        score_without = commute_similarity_score(coords, coords, frechet_available=False)
+        # Both should agree closely for identical routes even via different paths
+        assert score_with == pytest.approx(score_without, abs=0.05)
+
+    def test_passes_prefilter_deg_none_geometry_passes(self):
+        assert passes_prefilter_deg(None, None, None, None, None, None) is True
+
+    def test_passes_prefilter_deg_rejects_distant_centroid(self):
+        bbox1 = (41.87, -87.64, 41.89, -87.62)
+        bbox2 = (43.87, -89.64, 43.89, -89.62)
+        assert passes_prefilter_deg(
+            bbox1, (41.88, -87.63), 0.01,
+            bbox2, (43.88, -89.63), 0.01,
+        ) is False
+
+    def test_passes_prefilter_deg_rejects_length_ratio(self):
+        bbox = (41.87, -87.64, 41.89, -87.62)
+        assert passes_prefilter_deg(
+            bbox, (41.88, -87.63), 0.001,
+            bbox, (41.88, -87.63), 1.0,
+            length_ratio_max=2.0,
+        ) is False
+
+
+class TestComparisonThresholds:
+    def test_commute_and_long_ride_thresholds_are_distinct_instances(self):
+        assert isinstance(COMMUTE_THRESHOLDS, ComparisonThresholds)
+        assert isinstance(LONG_RIDE_THRESHOLDS, ComparisonThresholds)
+        assert COMMUTE_THRESHOLDS is not LONG_RIDE_THRESHOLDS


### PR DESCRIPTION
## Summary
- route_analyzer.py's _passes_geometric_filter, _calculate_hausdorff_similarity, _calculate_frechet_similarity, and the _similarity_worker multiprocessing path now delegate to shared route_comparison.py functions instead of duplicating the math locally. Verified all thresholds/constants match the old inline code exactly.
- Deleted the dead _group_routes_by_similarity_static (~105 lines) and its 5 dedicated tests.
- long_ride_analyzer.py now calls shared passes_prefilter/combined_distance_km against LONG_RIDE_THRESHOLDS.

Closes #463.

## Behavioral note for reviewer
Unifying long_ride_analyzer.py onto the shared prefilter added a new coordinate-based path-length-ratio check (>1.25x rejects) at two call sites that did not have it before. This is a real filter addition, not just deduplication, though the threshold matches an existing activity-distance-based ratio check elsewhere, so impact is likely small. Worth a sanity check on long-ride grouping output before merging.

## Test plan
Full suite: 1167 passed, 5 pre-existing Windows chmod failures, 11 skipped. Targeted route-similarity tests: 111 passed.