### PR TITLE
Relocate report_generator.py to legacy/ package (#467)

### DIFF
--- a/legacy/__init__.py
+++ b/legacy/__init__.py
@@ -1,0 +1,7 @@
+"""
+Legacy CLI-only code, not reachable from the Flask web app (app/, static/).
+
+Only used by the deprecated main.py CLI tool for personal-use data
+analysis/reporting. See main.py's module docstring for the full
+deprecation notice.
+"""

--- a/legacy/report_generator.py
+++ b/legacy/report_generator.py
@@ -7,7 +7,7 @@ Copyright (c) 2024-2026 e2kd7n
 Licensed under the MIT License - see LICENSE file for details.
 """
 
-from .secure_logger import SecureLogger
+from src.secure_logger import SecureLogger
 import base64
 import csv
 import json
@@ -42,8 +42,8 @@ except (ImportError, OSError) as e:
     logger.warning(f"WeasyPrint not available: {e}. PDF export will be disabled.")
     HTML = None
 
-from .route_analyzer import Route
-from .units import UnitConverter
+from src.route_analyzer import Route
+from src.units import UnitConverter
 
 logger = SecureLogger(__name__)
 
@@ -361,7 +361,7 @@ class ReportGenerator:
         current_weather = None
         home = self.results.get('home')
         if home:
-            from .weather_fetcher import WeatherFetcher
+            from src.weather_fetcher import WeatherFetcher
             weather_fetcher = WeatherFetcher()
             current_weather = weather_fetcher.get_current_conditions(home.lat, home.lon)
         

--- a/main.py
+++ b/main.py
@@ -64,7 +64,7 @@ from src.location_finder import LocationFinder
 from src.route_analyzer import RouteAnalyzer
 from src.optimizer import RouteOptimizer
 from src.visualizer import RouteVisualizer
-from src.report_generator import ReportGenerator
+from legacy.report_generator import ReportGenerator
 from src.long_ride_analyzer import LongRideAnalyzer
 
 # Configure logging - suppress timestamps for cleaner output during analysis

--- a/src/route_analyzer.py
+++ b/src/route_analyzer.py
@@ -1502,8 +1502,11 @@ end tell
                         stderr=subprocess.DEVNULL,
                         check=False
                     )
-                except Exception:
-                    pass  # Ignore errors in background thread
+                except Exception as e:
+                    # Not critical — geocoding_progress.txt is already being written
+                    # unconditionally by _geocode_routes_background, so the user can
+                    # still monitor progress by hand even if the terminal never opens.
+                    logger.debug(f"Could not open geocoding monitor terminal: {e}")
             
             # Start in a daemon thread so it doesn't block exit
             terminal_thread = threading.Thread(target=start_terminal, daemon=True)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -13,7 +13,7 @@ from src.data_fetcher import Activity, StravaDataFetcher
 from src.location_finder import LocationFinder
 from src.route_analyzer import RouteAnalyzer
 from src.optimizer import RouteOptimizer
-from src.report_generator import ReportGenerator
+from legacy.report_generator import ReportGenerator
 
 
 @pytest.mark.integration
@@ -211,7 +211,7 @@ units:
         assert len(cached_activities) == len(sample_activities)
         assert all(isinstance(a, Activity) for a in cached_activities)
     
-    @patch('src.report_generator.ReportGenerator._render_template')
+    @patch('legacy.report_generator.ReportGenerator._render_template')
     def test_report_generation(self, mock_render, sample_activities,
                               mock_config, temp_dir):
         """Test report generation."""
@@ -308,7 +308,7 @@ units:
             assert len(ranked_routes) > 0
         
         # Step 4: Generate report (mocked)
-        with patch('src.report_generator.ReportGenerator._render_template') as mock_render:
+        with patch('legacy.report_generator.ReportGenerator._render_template') as mock_render:
             mock_render.return_value = "<html><body>Report</body></html>"
             
             analysis_results = {

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 from xml.etree import ElementTree as ET
 
-from src.report_generator import ReportGenerator
+from legacy.report_generator import ReportGenerator
 
 
 def _make_config(unit_system='metric'):


### PR DESCRIPTION
## Summary
- Moves src/report_generator.py to legacy/report_generator.py with a new legacy/__init__.py documenting the boundary
- Updates all importers: main.py, tests/test_report_generator.py, tests/test_integration.py
- Rebased onto current main, resolving the expected requirements.txt conflict in favor of main's already-landed optional-install approach for weasyprint/qrcode
- Includes one small unrelated commit found uncommitted in the worktree: replaces a bare except-pass with logger.debug in route_analyzer.py's macOS-only geocoding-terminal spawner, kept separate from the relocation commit

Closes #467.

## Test plan
test_report_generator.py + test_integration.py: 28/28 pass post-rebase.