### PR TITLE
Fix prod 500: Dockerfile missing templates/ COPY + cron/geocoding fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ COPY launch.py wsgi.py gunicorn.conf.py ./
 COPY app/ ./app/
 COPY src/ ./src/
 COPY static/ ./static/
+COPY templates/ ./templates/
 COPY config/ ./config/
 COPY cron/ ./cron/
 COPY .env.example .

--- a/cron/daily_analysis.py
+++ b/cron/daily_analysis.py
@@ -141,9 +141,18 @@ def main():
                 f"Analysis ended with status '{state}': "
                 f"{snapshot.get('label') or snapshot.get('result')}")
 
+        # The endpoint marks the job 'done' even when run_full_analysis
+        # caught an error internally and returned an error payload (e.g.
+        # Strava auth failure) — surface that as a real failure instead of
+        # logging a bogus "completed successfully" with 0 activities.
+        if result.get('status') == 'error':
+            raise RuntimeError(
+                f"Analysis reported an error: {result.get('message', result)}")
+
+        errors = result.get('errors') or []
         job_record = _record_job(
             storage,
-            'completed' if result.get('success', True) else 'degraded',
+            'degraded' if errors else 'completed',
             start_time, result=result)
 
         status = storage.read('status.json', default={})

--- a/src/route_analyzer.py
+++ b/src/route_analyzer.py
@@ -1267,8 +1267,12 @@ class RouteAnalyzer:
                 tqdm.write("\n✓ Non-interactive mode: auto-approving background geocoding\n")
         
         tqdm.write("\n✓ Starting background geocoding...")
-        if self.interactive:
+        if self.interactive and sys.platform == 'darwin':
             tqdm.write("  A new terminal window will open to show progress.\n")
+        elif self.interactive:
+            progress_file = self.cache_dir / 'geocoding_progress.txt'
+            tqdm.write(f"  Progress terminal windows are only supported on macOS; "
+                       f"track progress in {progress_file}\n")
         else:
             tqdm.write("  Running quietly in the background (non-interactive mode).\n")
 

--- a/tests/test_cron_jobs.py
+++ b/tests/test_cron_jobs.py
@@ -144,6 +144,43 @@ class TestDailyAnalysisJob:
     @patch('cron.daily_analysis.requests.Session')
     @patch('cron.daily_analysis.JSONStorage')
     @patch('cron.daily_analysis.ConfigManager.get_instance')
+    def test_daily_analysis_error_payload_in_done_job(self, mock_config,
+                                                      mock_storage_class,
+                                                      mock_session_class,
+                                                      mock_sleep):
+        """A 'done' job whose result payload is an internal error exits 1.
+
+        run_full_analysis catches errors (e.g. Strava auth failure) and
+        returns {'status': 'error', ...} — the job state still reads 'done',
+        so the script must inspect the payload (found live on pi4, #498).
+        """
+        mock_storage = Mock()
+        mock_storage.read.return_value = {'jobs': []}
+        mock_storage_class.return_value = mock_storage
+
+        session = Mock()
+        session.get.side_effect = [
+            _http_response(json_data={'csrf_token': 'tok'}),
+            _http_response(json_data={
+                'status': 'done',
+                'result': {'status': 'error', 'activities_count': 0,
+                           'message': 'Analysis failed: Unauthorized'},
+            }),
+        ]
+        session.post.return_value = _http_response(
+            json_data={'status': 'started'})
+        mock_session_class.return_value = session
+
+        from cron import daily_analysis
+        result = daily_analysis.main()
+
+        assert result == 1
+        mock_storage.write.assert_called()  # failure recorded in history
+
+    @patch('cron.daily_analysis.time.sleep')
+    @patch('cron.daily_analysis.requests.Session')
+    @patch('cron.daily_analysis.JSONStorage')
+    @patch('cron.daily_analysis.ConfigManager.get_instance')
     def test_daily_analysis_app_unreachable(self, mock_config, mock_storage_class,
                                             mock_session_class, mock_sleep):
         """Connection failure exits 1 and records the failure."""


### PR DESCRIPTION
## Summary
- **Prod-down hotfix**: Dockerfile never copied `templates/` into the image after it was introduced in 2718e03, so every deploy since has 500'd on every page (`TemplateNotFound: index.html`). The container healthcheck only hits `/api/status`, which doesn't render a template, so it stayed "healthy" throughout the outage.
- Cron `daily_analysis.py`: treat an internal error payload inside a "done" job as a real failure instead of logging a false "completed successfully."
- Fix #477: geocoding CLI message lied about terminal availability on non-macOS.

## Test plan
- [x] Confirmed root cause via `podman exec ride-optimizer ls /app/templates` (missing) and container logs (`jinja2.exceptions.TemplateNotFound: index.html`)
- [ ] CI test suite passes
- [ ] After merge, redeploy Pi via GHCR pull and confirm `/` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)