### PR TITLE
Fix #477: geocoding CLI message lies about terminal on non-macOS

### DIFF
--- a/src/route_analyzer.py
+++ b/src/route_analyzer.py
@@ -1267,8 +1267,12 @@ class RouteAnalyzer:
                 tqdm.write("\n✓ Non-interactive mode: auto-approving background geocoding\n")
         
         tqdm.write("\n✓ Starting background geocoding...")
-        if self.interactive:
+        if self.interactive and sys.platform == 'darwin':
             tqdm.write("  A new terminal window will open to show progress.\n")
+        elif self.interactive:
+            progress_file = self.cache_dir / 'geocoding_progress.txt'
+            tqdm.write(f"  Progress terminal windows are only supported on macOS; "
+                       f"track progress in {progress_file}\n")
         else:
             tqdm.write("  Running quietly in the background (non-interactive mode).\n")
 


### PR DESCRIPTION
## Summary
- Closes #459 separately (already fixed in 3d34c16; closed via `gh issue close` with an explanation — `JSONStorage.update()`, plan save/delete, and TrainerRoad cache all already use the atomic compound-update path, verified by `tests/test_json_storage.py::TestJSONStorageConcurrency`). No code change needed for it, so it's not part of this PR's diff.
- Fixes #477: `_open_geocoding_terminal` already skipped cleanly on non-macOS (fixed in 09d272c during the engineering audit), but `_start_background_geocoding`'s user-facing CLI message still unconditionally claimed "A new terminal window will open" regardless of platform. On Windows/Linux that promise was never kept — the only trace was a debug-level log line nobody watching stdout would see. Now the message only promises a terminal on darwin, and otherwise points the user at `geocoding_progress.txt`, which is already written unconditionally.

## Test plan
- [x] `pytest tests/test_route_analyzer.py -q` — 57 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)