### PR TITLE
gunicorn: gthread worker to stop slow requests from blocking everything

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -2,6 +2,12 @@ import os
 
 bind = f"{os.getenv('BIND_HOST', '127.0.0.1')}:{os.getenv('APP_PORT', '8083')}"
 workers = int(os.getenv('GUNICORN_WORKERS', '1'))
+# gthread instead of a second worker process: a slow/blocked request (e.g. a
+# hanging Strava call) no longer serializes every other request behind it,
+# without doubling the base memory footprint the way a second process would
+# on the Pi's 512MB container limit.
+worker_class = 'gthread'
+threads = int(os.getenv('GUNICORN_THREADS', '4'))
 timeout = int(os.getenv('GUNICORN_TIMEOUT', '60'))
 keepalive = 5
 accesslog = '-'


### PR DESCRIPTION
## Summary
- Switches the single sync worker to `gthread` (4 threads, same process/memory footprint) so a slow or blocked request (e.g. a hanging Strava API call during analysis, per the auth failures currently on pi4) no longer serializes every other request — static assets, page loads — behind it.
- Follow-up to the templates/ Dockerfile hotfix in #510; addressed the "site is up but slow" report after that fix landed.

## Test plan
- [x] CI test suite
- [ ] After merge/redeploy, confirm concurrent requests (page + JS/CSS) no longer stall behind a slow analysis call

🤖 Generated with [Claude Code](https://claude.com/claude-code)