### PR TITLE
Explore epic: prune strategies, fold coverage browser, add duration+area targeting (#487 #488 #490 #491)

### DIFF
--- a/app/api/stats_bp.py
+++ b/app/api/stats_bp.py
@@ -53,6 +53,15 @@ def _seconds_to_hours(s):
     return s / 3600.0
 
 
+def _default_speed_mph():
+    """Configured fallback average speed (#490), for callers converting a
+    duration target to a distance budget when the rider has no ride history
+    to average — e.g. the Explore page's duration-based route target."""
+    from src.config_manager import ConfigManager
+    default_kmh = ConfigManager.get_instance().get('exploration.default_speed_kmh', 18)
+    return round(default_kmh * 0.621371, 1)
+
+
 def _activity_local_start(a):
     """
     Return an activity's start as a naive datetime in the *ride's own*
@@ -247,7 +256,8 @@ def get_stats():
     all_activities = _load_activities_for_stats()
     if not all_activities:
         return jsonify({'status': 'no_data',
-                        'message': 'No activities cached. Fetch activities from Strava first.'})
+                        'message': 'No activities cached. Fetch activities from Strava first.',
+                        'default_speed_mph': _default_speed_mph()})
 
     activities = _filter_activities_by_period(all_activities, period)
 
@@ -295,6 +305,7 @@ def get_stats():
             'period': period,
             'total_activities_in_cache': len(all_activities),
             'summary': _compute_summary(activities),
+            'default_speed_mph': _default_speed_mph(),
             'records': _compute_records(activities),
             'by_type': by_type,
             'by_week': by_week,

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -8,6 +8,7 @@ ors:
 exploration:
   ors_timeout_seconds: 15
   route_cache_ttl_seconds: 600
+  default_speed_kmh: 18  # Fallback for duration→distance conversion (#490) when the rider has no cached ride history to average
 
   oauth_callback_host: "localhost"  # Host for OAuth callback server
   oauth_callback_port: 8000  # Port for OAuth callback server

--- a/static/css/pages/explore.css
+++ b/static/css/pages/explore.css
@@ -6,22 +6,6 @@
         @media (max-width: 767px) {
             #explore-map { height: 350px; }
         }
-        .coverage-stat {
-            text-align: center;
-            padding: var(--space-2);
-        }
-        .coverage-stat .stat-value {
-            font-size: var(--font-size-xl);
-            font-weight: 700;
-            color: var(--color-primary);
-        }
-        .coverage-stat .stat-label {
-            font-size: var(--font-size-xs);
-            color: var(--color-text-muted);
-            text-transform: uppercase;
-            letter-spacing: 0.05em;
-        }
-        .tile-visited { fill-opacity: 0.4; stroke-width: 1; }
         .route-badge {
             display: inline-flex;
             align-items: center;

--- a/static/js/api-client.js
+++ b/static/js/api-client.js
@@ -191,6 +191,14 @@ class APIClient {
     }
 
     /**
+     * Get cached-activity summary stats, including avg_speed_mph — used to
+     * convert a rider's duration target into a distance budget (#490).
+     */
+    async getStats() {
+        return this.fetch('/stats');
+    }
+
+    /**
      * Get all routes with optional filters
      */
     async getRoutes(filters = {}) {

--- a/static/js/exploration-worker.js
+++ b/static/js/exploration-worker.js
@@ -21,7 +21,7 @@
  *       grids at once — each grid's zones are found independently (tile
  *       adjacency only makes sense within a single zoom's coordinate space),
  *       then the best zones from each are merged into one route per quadrant.
- *   - optimizeFor: 'tiles' | 'distance' | 'efficiency' | 'infill' | 'frontier'
+ *   - optimizeFor: 'tiles' | 'efficiency'
  *
  * Output messages (streamed):
  *   {type: 'route', route: {direction, waypoints, stats}}  — one per generated route
@@ -52,7 +52,7 @@ const GRID_LABELS = { 14: 'squadrats', 17: 'squadratinhos' };
  * still splits into a distinct route per direction rather than collapsing
  * into a single zone/route.
  */
-function scanGrid(coverageData, start, reachRadius, optimizeFor) {
+function scanGrid(coverageData, start, reachRadius) {
     const bounds = coverageData.bounds;
     if (!bounds) throw new Error('Coverage data has no bounds');
     const zoom = coverageData.zoom || 14;
@@ -61,17 +61,7 @@ function scanGrid(coverageData, start, reachRadius, optimizeFor) {
     const visitedSet = new Set(Object.keys(coverageData.visited || {}));
     const unvisited = allTiles.filter(t => !visitedSet.has(t.key));
 
-    // #404 / #406: filter unvisited set before bucketing based on mode.
-    let candidates = unvisited;
-    if (optimizeFor === 'infill') {
-        // Infill: tiles with ≥ 2 visited 4-neighbours (interior gaps).
-        candidates = unvisited.filter(t => countVisitedNeighbours(t, visitedSet) >= 2);
-    } else if (optimizeFor === 'frontier') {
-        // Frontier: tiles with ≥ 1 visited neighbour, sorted by low surrounding density.
-        candidates = unvisited.filter(t => countVisitedNeighbours(t, visitedSet) >= 1);
-    }
-
-    const reachableTiles = candidates.filter(
+    const reachableTiles = unvisited.filter(
         t => haversineKm(start.lat, start.lon, t.lat, t.lon) <= reachRadius
     );
 
@@ -83,16 +73,6 @@ function scanGrid(coverageData, start, reachRadius, optimizeFor) {
     return { zoom, unvisited, reachableTiles, buckets, visitedSet };
 }
 
-/** Count how many of the 4 cardinal neighbours of tile `t` are in `visitedSet`. */
-function countVisitedNeighbours(t, visitedSet) {
-    return [
-        `${t.x},${t.y - 1}`,
-        `${t.x},${t.y + 1}`,
-        `${t.x - 1},${t.y}`,
-        `${t.x + 1},${t.y}`,
-    ].filter(k => visitedSet.has(k)).length;
-}
-
 function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData, coverageDataSecondary, optimizeFor, corridorConstraint }) {
     const isRoundTrip = routeType === 'round_trip' || !end;
     // Default to 'loop' for round trips when the caller doesn't specify —
@@ -102,8 +82,8 @@ function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData
     const reachRadius = distanceKm / (isRoundTrip ? 4 : 3);
 
     reportProgress('Scanning tile grid…');
-    const primary = scanGrid(coverageData, start, reachRadius, optimizeFor, corridorConstraint);
-    const secondary = coverageDataSecondary ? scanGrid(coverageDataSecondary, start, reachRadius, optimizeFor, corridorConstraint) : null;
+    const primary = scanGrid(coverageData, start, reachRadius);
+    const secondary = coverageDataSecondary ? scanGrid(coverageDataSecondary, start, reachRadius) : null;
     const grids = secondary ? [primary, secondary] : [primary];
 
     const totalUnvisited = grids.reduce((sum, g) => sum + g.unvisited.length, 0);
@@ -113,12 +93,6 @@ function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData
 
     const totalReachable = grids.reduce((sum, g) => sum + g.reachableTiles.length, 0);
     if (totalReachable === 0) {
-        // Graceful empty-result messages for infill/frontier modes (#404/#406).
-        if (optimizeFor === 'infill') {
-            reportProgress('No infill tiles found — yard interior may already be complete');
-        } else if (optimizeFor === 'frontier') {
-            reportProgress('No frontier tiles found — yard may be fully isolated');
-        }
         const zoneCount = grids.reduce((sum, g) => sum + floodFillZones(g.unvisited).length, 0);
         return {
             totalRoutes: 0,
@@ -240,30 +214,18 @@ function estimateCorridorOverlap(zone, start, visitedSet, zoom) {
 /**
  * Order zones by the user's chosen priority before capping to the top few
  * per direction:
- *   - 'tiles'    : biggest contiguous unexplored areas first (default)
- *   - 'distance' : closest to the start point first (shortest route)
- *   - 'efficiency': most new tiles per km of travel to reach them
- *   - 'infill'   : smallest zones first (interior gaps are typically smaller)
- *   - 'frontier' : zones with lower surrounding density ranked higher
+ *   - 'tiles'      : biggest contiguous unexplored areas first (default)
+ *   - 'efficiency' : most new tiles per km of travel to reach them
  * After primary sort, a secondary overlap penalty (#410) nudges tied zones
  * toward paths that re-cover fewer visited tiles.
  */
 function scoreZones(zones, optimizeFor) {
     const scored = [...zones];
-    if (optimizeFor === 'distance') {
-        scored.sort((a, b) => a.distanceFromStart - b.distanceFromStart);
-    } else if (optimizeFor === 'efficiency') {
+    if (optimizeFor === 'efficiency') {
         scored.sort((a, b) =>
             (b.tiles.length / Math.max(b.distanceFromStart, 0.1)) -
             (a.tiles.length / Math.max(a.distanceFromStart, 0.1))
         );
-    } else if (optimizeFor === 'infill') {
-        // Smallest zones first — infill gaps are typically tight clusters.
-        scored.sort((a, b) => a.tiles.length - b.tiles.length);
-    } else if (optimizeFor === 'frontier') {
-        // Low-density neighbourhoods ranked first (#406).
-        // visitedSet is not available here, so proxy with zone size (smaller = sparser border).
-        scored.sort((a, b) => a.tiles.length - b.tiles.length);
     } else {
         scored.sort((a, b) => b.tiles.length - a.tiles.length);
     }

--- a/static/js/exploration-worker.js
+++ b/static/js/exploration-worker.js
@@ -22,6 +22,10 @@
  *       adjacency only makes sense within a single zoom's coordinate space),
  *       then the best zones from each are merged into one route per quadrant.
  *   - optimizeFor: 'tiles' | 'efficiency'
+ *   - areaBounds: [south, west, north, east] | null (#491) — rider-drawn
+ *       target area. When present, further restricts reachable tiles to
+ *       those inside the box, in addition to (not instead of) the reach
+ *       radius derived from distanceKm.
  *
  * Output messages (streamed):
  *   {type: 'route', route: {direction, waypoints, stats}}  — one per generated route
@@ -52,7 +56,7 @@ const GRID_LABELS = { 14: 'squadrats', 17: 'squadratinhos' };
  * still splits into a distinct route per direction rather than collapsing
  * into a single zone/route.
  */
-function scanGrid(coverageData, start, reachRadius) {
+function scanGrid(coverageData, start, reachRadius, areaBounds) {
     const bounds = coverageData.bounds;
     if (!bounds) throw new Error('Coverage data has no bounds');
     const zoom = coverageData.zoom || 14;
@@ -61,9 +65,18 @@ function scanGrid(coverageData, start, reachRadius) {
     const visitedSet = new Set(Object.keys(coverageData.visited || {}));
     const unvisited = allTiles.filter(t => !visitedSet.has(t.key));
 
-    const reachableTiles = unvisited.filter(
+    let reachableTiles = unvisited.filter(
         t => haversineKm(start.lat, start.lon, t.lat, t.lon) <= reachRadius
     );
+    // #491: rider-drawn target area, additional to (not instead of) the
+    // reach radius — a drawn box narrows which reachable tiles count,
+    // it doesn't override how far the route is allowed to travel.
+    if (areaBounds) {
+        const [south, west, north, east] = areaBounds;
+        reachableTiles = reachableTiles.filter(
+            t => t.lat >= south && t.lat <= north && t.lon >= west && t.lon <= east
+        );
+    }
 
     const buckets = { NE: [], SE: [], SW: [], NW: [] };
     for (const t of reachableTiles) {
@@ -73,7 +86,7 @@ function scanGrid(coverageData, start, reachRadius) {
     return { zoom, unvisited, reachableTiles, buckets, visitedSet };
 }
 
-function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData, coverageDataSecondary, optimizeFor, corridorConstraint }) {
+function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData, coverageDataSecondary, optimizeFor, corridorConstraint, areaBounds }) {
     const isRoundTrip = routeType === 'round_trip' || !end;
     // Default to 'loop' for round trips when the caller doesn't specify —
     // matches the pre-#489 behaviour of drawing from whichever quadrant the
@@ -82,8 +95,8 @@ function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData
     const reachRadius = distanceKm / (isRoundTrip ? 4 : 3);
 
     reportProgress('Scanning tile grid…');
-    const primary = scanGrid(coverageData, start, reachRadius);
-    const secondary = coverageDataSecondary ? scanGrid(coverageDataSecondary, start, reachRadius) : null;
+    const primary = scanGrid(coverageData, start, reachRadius, areaBounds);
+    const secondary = coverageDataSecondary ? scanGrid(coverageDataSecondary, start, reachRadius, areaBounds) : null;
     const grids = secondary ? [primary, secondary] : [primary];
 
     const totalUnvisited = grids.reduce((sum, g) => sum + g.unvisited.length, 0);

--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -43,6 +43,8 @@ document.addEventListener('DOMContentLoaded', () => {
         if (e.key === 'Enter') { e.preventDefault(); searchEndLocation(); }
     });
     initDistanceSlider();
+    initDurationSlider();
+    document.getElementById('target-type-select').addEventListener('change', onTargetTypeChange);
     initTooltips();
     updateWorkflowState();
 });
@@ -71,6 +73,72 @@ function initDistanceSlider() {
 function updateDistanceDisplay(kmValue) {
     document.getElementById('distance-value').textContent =
         window.formatDistance ? window.formatDistance(parseFloat(kmValue), 1) : `${kmValue} km`;
+}
+
+// ── Duration-based target (#490) ────────────────────────────────
+//
+// Duration is converted to a distance budget using the rider's own
+// historical average speed (GET /api/stats → summary.avg_speed_mph),
+// falling back to a configured default (exploration.default_speed_kmh in
+// config.yaml, surfaced as default_speed_mph) when there's no ride history
+// to average. The worker pipeline is unaware of duration — it only ever
+// receives a computed distanceKm, same as the distance-slider path.
+
+let _avgSpeedKmhPromise = null;
+
+async function getAvgSpeedKmh() {
+    if (!_avgSpeedKmhPromise) {
+        _avgSpeedKmhPromise = (async () => {
+            const FALLBACK_KMH = 18;
+            try {
+                const stats = await api.getStats();
+                const summaryMph = stats.data && stats.data.summary && stats.data.summary.avg_speed_mph;
+                const defaultMph = (stats.data && stats.data.default_speed_mph) || stats.default_speed_mph;
+                const mph = (summaryMph && summaryMph > 0) ? summaryMph : defaultMph;
+                return (mph && mph > 0) ? mph * 1.60934 : FALLBACK_KMH;
+            } catch (e) {
+                return FALLBACK_KMH;
+            }
+        })();
+    }
+    return _avgSpeedKmhPromise;
+}
+
+function onTargetTypeChange() {
+    const isDuration = document.getElementById('target-type-select').value === 'duration';
+    document.getElementById('distance-target-group').classList.toggle('d-none', isDuration);
+    document.getElementById('duration-target-group').classList.toggle('d-none', !isDuration);
+    if (isDuration) updateDurationHint();
+}
+
+function initDurationSlider() {
+    const slider = document.getElementById('duration-slider');
+    document.getElementById('duration-value').textContent = slider.value;
+    slider.addEventListener('input', () => {
+        document.getElementById('duration-value').textContent = slider.value;
+        updateDurationHint();
+    });
+}
+
+async function updateDurationHint() {
+    const hintEl = document.getElementById('duration-speed-hint');
+    hintEl.textContent = 'Estimating distance from your average speed…';
+    const minutes = parseFloat(document.getElementById('duration-slider').value);
+    const speedKmh = await getAvgSpeedKmh();
+    const distanceKm = (minutes / 60) * speedKmh;
+    const distanceLabel = window.formatDistance ? window.formatDistance(distanceKm, 1) : `${distanceKm.toFixed(1)} km`;
+    const speedLabel = window.formatSpeed ? window.formatSpeed(speedKmh, 1) : `${speedKmh.toFixed(1)} km/h`;
+    hintEl.textContent = `≈ ${distanceLabel} at your average ${speedLabel}`;
+}
+
+/** Resolve the current distance-slider or duration-slider control into a distanceKm target for the worker. */
+async function resolveTargetDistanceKm() {
+    if (document.getElementById('target-type-select').value === 'duration') {
+        const minutes = parseFloat(document.getElementById('duration-slider').value);
+        const speedKmh = await getAvgSpeedKmh();
+        return (minutes / 60) * speedKmh;
+    }
+    return parseFloat(document.getElementById('distance-slider').value);
 }
 
 // ── Map setup ───────────────────────────────────────────────────
@@ -514,7 +582,7 @@ async function generateRoute() {
     Object.keys(_newTileRectsByDirection).forEach(k => delete _newTileRectsByDirection[k]);
 
     const startPos = startMarker.getLatLng();
-    const distanceKm = parseFloat(document.getElementById('distance-slider').value);
+    const distanceKm = await resolveTargetDistanceKm();
     const optimizeFor = document.getElementById('optimize-for-select').value;
 
     let routeCount = 0;

--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -19,6 +19,13 @@ let coverageData = null;
 let coverageDataSecondary = null;
 let explorationWorker = null;
 
+// #491: rider-drawn target area — [south, west, north, east] | null.
+let selectedAreaBounds = null;
+let isDrawingArea = false;
+let drawAreaRect = null;
+let _drawStartLatLng = null;
+let _skipNextMapClick = false;
+
 // Phase-1 candidate lists per direction, for iterative refinement.
 // { NE: [zoneList, ...], SE: [...], ... }
 let _phase1Candidates = {};
@@ -45,6 +52,8 @@ document.addEventListener('DOMContentLoaded', () => {
     initDistanceSlider();
     initDurationSlider();
     document.getElementById('target-type-select').addEventListener('change', onTargetTypeChange);
+    document.getElementById('draw-area-btn').addEventListener('click', toggleDrawArea);
+    document.getElementById('clear-area-btn').addEventListener('click', clearArea);
     initTooltips();
     updateWorkflowState();
 });
@@ -156,7 +165,44 @@ function initMap() {
     routeLayer = L.featureGroup().addTo(map);
     waypointMarkers = L.layerGroup().addTo(map);
 
+    // #491: click-and-drag to draw a target-area rectangle. Only active
+    // while "Draw area" is toggled on; otherwise these are no-ops and the
+    // map behaves as before (pan/click-to-set-start).
+    map.on('mousedown', (e) => {
+        if (!isDrawingArea) return;
+        _drawStartLatLng = e.latlng;
+        if (drawAreaRect) { map.removeLayer(drawAreaRect); drawAreaRect = null; }
+        drawAreaRect = L.rectangle(L.latLngBounds(e.latlng, e.latlng), {
+            color: '#0d6efd', weight: 2, fillOpacity: 0.08, dashArray: '4,4',
+        }).addTo(map);
+    });
+    map.on('mousemove', (e) => {
+        if (!isDrawingArea || !_drawStartLatLng || !drawAreaRect) return;
+        drawAreaRect.setBounds(L.latLngBounds(_drawStartLatLng, e.latlng));
+    });
+    map.on('mouseup', (e) => {
+        if (!isDrawingArea || !_drawStartLatLng) return;
+        const drawnBounds = L.latLngBounds(_drawStartLatLng, e.latlng);
+        _drawStartLatLng = null;
+        _skipNextMapClick = true; // the browser fires 'click' right after this mouseup
+
+        if (!drawnBounds.isValid() || drawnBounds.getNorthEast().equals(drawnBounds.getSouthWest())) {
+            // Degenerate rectangle (no drag distance) — treat as a cancel.
+            if (drawAreaRect) { map.removeLayer(drawAreaRect); drawAreaRect = null; }
+        } else {
+            selectedAreaBounds = [
+                drawnBounds.getSouth(), drawnBounds.getWest(),
+                drawnBounds.getNorth(), drawnBounds.getEast(),
+            ];
+            document.getElementById('clear-area-btn').classList.remove('d-none');
+            document.getElementById('area-status').textContent = 'Area selected — routes stay within it';
+        }
+        setDrawAreaMode(false);
+    });
+
     map.on('click', (e) => {
+        if (_skipNextMapClick) { _skipNextMapClick = false; return; }
+        if (isDrawingArea) return;
         clearHighlight();
         const routeType = document.getElementById('route-type-select').value;
         // In point-to-point mode: first click sets end if unset, else update start.
@@ -166,6 +212,29 @@ function initMap() {
             setStart(e.latlng.lat, e.latlng.lng);
         }
     });
+}
+
+/** Enter or exit rectangle-draw mode (#491), disabling map panning while active
+ *  so a click-drag draws a box instead of moving the map. */
+function setDrawAreaMode(active) {
+    isDrawingArea = active;
+    document.getElementById('draw-area-btn').classList.toggle('active', active);
+    map.dragging[active ? 'disable' : 'enable']();
+    map.getContainer().style.cursor = active ? 'crosshair' : '';
+    if (active) {
+        document.getElementById('area-status').textContent = 'Click and drag on the map to draw an area…';
+    }
+}
+
+function toggleDrawArea() {
+    setDrawAreaMode(!isDrawingArea);
+}
+
+function clearArea() {
+    if (drawAreaRect) { map.removeLayer(drawAreaRect); drawAreaRect = null; }
+    selectedAreaBounds = null;
+    document.getElementById('clear-area-btn').classList.add('d-none');
+    document.getElementById('area-status').textContent = '';
 }
 
 function setStart(lat, lon, label = null) {
@@ -656,6 +725,7 @@ async function generateRoute() {
         coverageData,
         coverageDataSecondary: mode === 'both' ? coverageDataSecondary : null,
         optimizeFor,
+        areaBounds: selectedAreaBounds,
     });
 }
 

--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -10,8 +10,6 @@
 
 const api = new APIClient('/api');
 let map = null;
-let tileLayer = null;
-let tileLayerSecondary = null;
 let newTilesLayer = null;   // green highlight for tiles a route will claim
 let routeLayer = null;
 let waypointMarkers = null;
@@ -25,13 +23,12 @@ let explorationWorker = null;
 // { NE: [zoneList, ...], SE: [...], ... }
 let _phase1Candidates = {};
 
-const ZOOM_LABELS = { 14: 'Squadrats', 17: 'Squadratinhos' };
-
 document.addEventListener('DOMContentLoaded', () => {
     initMap();
     initWorker();
-    document.getElementById('load-coverage-btn').addEventListener('click', loadCoverage);
-    document.getElementById('coverage-type-select').addEventListener('change', loadCoverage);
+    document.getElementById('coverage-type-select').addEventListener('change', () => {
+        if (startMarker) loadCoverage();
+    });
     document.getElementById('clear-cache-btn').addEventListener('click', clearCache);
     document.getElementById('generate-route-btn').addEventListener('click', generateRoute);
     document.getElementById('workout-combo-btn').addEventListener('click', generateWorkoutCombo);
@@ -48,7 +45,6 @@ document.addEventListener('DOMContentLoaded', () => {
     initDistanceSlider();
     initTooltips();
     updateWorkflowState();
-    loadCoverage();
 });
 
 // ── Bootstrap tooltips (#360 help icon) ────────────────────────
@@ -85,9 +81,7 @@ function initMap() {
         attribution: '&copy; OpenStreetMap contributors',
         maxZoom: 18,
     }).addTo(map);
-    tileLayer = L.layerGroup().addTo(map);
-    tileLayerSecondary = L.layerGroup().addTo(map);
-    newTilesLayer = L.layerGroup().addTo(map);  // above coverage, below routes
+    newTilesLayer = L.layerGroup().addTo(map);  // below routes
     // FeatureGroup, not LayerGroup — routeLayer.getBounds() (used to fit the
     // map after routes are generated) only exists on FeatureGroup in Leaflet
     // 1.9.4; LayerGroup lacks it despite otherwise sharing the same API.
@@ -114,6 +108,9 @@ function setStart(lat, lon, label = null) {
     }).addTo(map).bindPopup('Start').openPopup();
     document.getElementById('start-display').textContent = label || `${lat.toFixed(4)}, ${lon.toFixed(4)}`;
     updateWorkflowState();
+    // #488: coverage loads silently against the new start point instead of
+    // requiring a separate "Load Coverage" step.
+    loadCoverage();
 }
 
 function setEnd(lat, lon, label = null) {
@@ -166,9 +163,8 @@ function updateWorkflowState() {
     const isPtp = document.getElementById('route-type-select').value === 'point_to_point';
     const ready = coverageReady && startReady && (!isPtp || !!endMarker);
 
-    document.getElementById('workflow-step-1').classList.toggle('workflow-step-done', coverageReady);
-    document.getElementById('workflow-step-2').classList.toggle('workflow-step-done', startReady);
-    document.getElementById('workflow-step-3').classList.toggle('workflow-step-done', ready);
+    document.getElementById('workflow-step-1').classList.toggle('workflow-step-done', startReady);
+    document.getElementById('workflow-step-2').classList.toggle('workflow-step-done', ready);
 
     if (!explorationWorker) return; // unsupported-worker state already disables the button with its own message
 
@@ -185,8 +181,8 @@ function updateWorkflowState() {
     const statusEl = document.getElementById('worker-status');
     if (!ready) {
         const missing = [];
-        if (!coverageReady) missing.push('load your coverage');
         if (!startReady) missing.push('set a start point');
+        if (startReady && !coverageReady) missing.push('wait for coverage to finish loading');
         if (isPtp && !endMarker) missing.push('set an end point');
         statusEl.textContent = `Next: ${missing.join(' and ')} to generate routes.`;
     } else {
@@ -214,8 +210,8 @@ async function searchLocation() {
             if (typeof showToast === 'function') showToast(result.message || 'Location not found', 'warning');
             return;
         }
-        setStart(result.lat, result.lon, result.display_name);
         map.setView([result.lat, result.lon], 12);
+        setStart(result.lat, result.lon, result.display_name);
     } catch (e) {
         statusEl.textContent = previousText;
         if (typeof showToast === 'function') showToast(e.message || 'Location search failed', 'error');
@@ -267,8 +263,8 @@ async function useMyLocation() {
     navigator.geolocation.getCurrentPosition(
         (position) => {
             const { latitude, longitude } = position.coords;
-            setStart(latitude, longitude);
             map.setView([latitude, longitude], 13);
+            setStart(latitude, longitude);
             btn.disabled = false;
         },
         (err) => {
@@ -329,9 +325,10 @@ async function loadCoverage() {
         coverageData = results[0];
         coverageDataSecondary = results[1] || null;
 
-        renderStats(coverageData, coverageDataSecondary);
-        renderTiles(coverageData, coverageDataSecondary);
-        fitToCoverage(coverageData);
+        // #488: coverage is loaded to feed the route generator, not to browse
+        // on the map — clear any stale "new tile" highlight from a previous
+        // start point/grid rather than rendering the full visited-tile grid.
+        newTilesLayer.clearLayers();
         statusEl.textContent = `Updated ${new Date(coverageData.computed_at + 'Z').toLocaleTimeString()}`;
     } catch (e) {
         statusEl.textContent = `Error: ${e.message}`;
@@ -341,143 +338,12 @@ async function loadCoverage() {
     }
 }
 
-/**
- * Riders' visited tiles can span disconnected regions (home turf plus the
- * occasional trip elsewhere). Fitting to the bounds of ALL of them zooms out
- * to a near-world view. Instead, bucket tiles into coarse cells, find the
- * cell with the most tiles, and fit to that cluster (plus its neighbors so a
- * cluster split across a cell boundary isn't cropped).
- */
-function findDensityCluster(visited, zoom) {
-    if (!visited || typeof visited !== 'object') return null;
-    const n = Math.pow(2, zoom || 14);
-    const points = Object.keys(visited).map((key) => {
-        const [x, y] = key.split(',').map(Number);
-        const lon = (x + 0.5) / n * 360 - 180;
-        const lat = Math.atan(Math.sinh(Math.PI * (1 - 2 * (y + 0.5) / n))) * 180 / Math.PI;
-        return { lat, lon };
-    });
-    if (points.length === 0) return null;
-
-    const BUCKET_DEG = 0.5; // ~55km cells
-    const buckets = new Map();
-    for (const p of points) {
-        const bx = Math.floor(p.lon / BUCKET_DEG);
-        const by = Math.floor(p.lat / BUCKET_DEG);
-        const key = `${bx},${by}`;
-        buckets.set(key, (buckets.get(key) || 0) + 1);
-    }
-
-    let best = null;
-    for (const [key, count] of buckets) {
-        if (!best || count > best.count) {
-            const [bx, by] = key.split(',').map(Number);
-            best = { bx, by, count };
-        }
-    }
-    if (!best) return null;
-
-    const minLat = (best.by - 1) * BUCKET_DEG;
-    const maxLat = (best.by + 2) * BUCKET_DEG;
-    const minLon = (best.bx - 1) * BUCKET_DEG;
-    const maxLon = (best.bx + 2) * BUCKET_DEG;
-
-    let south = Infinity, west = Infinity, north = -Infinity, east = -Infinity;
-    for (const p of points) {
-        if (p.lat >= minLat && p.lat <= maxLat && p.lon >= minLon && p.lon <= maxLon) {
-            south = Math.min(south, p.lat);
-            west = Math.min(west, p.lon);
-            north = Math.max(north, p.lat);
-            east = Math.max(east, p.lon);
-        }
-    }
-    if (!isFinite(south)) return null;
-    return [[south, west], [north, east]];
-}
-
-function fitToCoverage(data) {
-    if (map.getZoom() >= 10) return; // user already navigated (search, click, or "Use location") — don't override
-
-    const cluster = findDensityCluster(data.visited, data.zoom);
-    if (cluster) {
-        map.fitBounds(cluster, { padding: [20, 20], maxZoom: 13 });
-        return;
-    }
-    if (!data.bounds) return;
-    const [south, west, north, east] = data.bounds;
-    map.fitBounds([[south, west], [north, east]], { padding: [20, 20], maxZoom: 13 });
-}
-
-function renderStats(primary, secondary) {
-    const labelEls = document.querySelectorAll('#coverage-stats .stat-label');
-    if (secondary) {
-        document.getElementById('stat-tiles-visited').textContent =
-            `${primary.visited_count.toLocaleString()} / ${secondary.visited_count.toLocaleString()}`;
-        document.getElementById('stat-coverage-pct').textContent =
-            `${primary.coverage_pct}% / ${secondary.coverage_pct}%`;
-        document.getElementById('stat-total-tiles').textContent =
-            `${primary.total_in_bounds.toLocaleString()} / ${secondary.total_in_bounds.toLocaleString()}`;
-        labelEls.forEach(el => {
-            if (!el.dataset.baseLabel) el.dataset.baseLabel = el.textContent;
-            el.textContent = `${el.dataset.baseLabel} (Sq / Sqi)`;
-        });
-    } else {
-        document.getElementById('stat-tiles-visited').textContent = primary.visited_count.toLocaleString();
-        document.getElementById('stat-coverage-pct').textContent = primary.coverage_pct + '%';
-        document.getElementById('stat-total-tiles').textContent = primary.total_in_bounds.toLocaleString();
-        labelEls.forEach(el => {
-            if (el.dataset.baseLabel) el.textContent = el.dataset.baseLabel;
-        });
-    }
-}
-
-// Squadrats-matching colors: visited = warm orange fill, outline slightly darker
-const TILE_STYLE_VISITED   = { color: '#c8813a', weight: 0.5, fillColor: '#e8a84c', fillOpacity: 0.55 };
-const TILE_STYLE_SECONDARY = { color: '#c8813a', weight: 0.5, fillColor: '#e8a84c', fillOpacity: 0.55 };
-const TILE_STYLE_BOTH_PRIMARY = { color: '#c8813a', weight: 1,   fillColor: '#e8a84c', fillOpacity: 0.35 };
 // New tiles a route will claim: bright Squadrats-green
 const TILE_STYLE_NEW = { color: '#2e7d32', weight: 0.5, fillColor: '#4caf50', fillOpacity: 0.65 };
 
-function renderTiles(primary, secondary) {
-    tileLayer.clearLayers();
-    tileLayerSecondary.clearLayers();
-    newTilesLayer.clearLayers();
-
-    // In single-grid mode show a solid orange fill. In "both" mode the
-    // squadrat grid gets a lighter orange outline so the squadratinho
-    // grid can show on top with full fill.
-    const primaryStyle = secondary ? TILE_STYLE_BOTH_PRIMARY : TILE_STYLE_VISITED;
-
-    drawTileGrid(tileLayer, primary.visited, primary.zoom, primaryStyle);
-    if (secondary) {
-        drawTileGrid(tileLayerSecondary, secondary.visited, secondary.zoom, TILE_STYLE_SECONDARY);
-    }
-}
-
-function drawTileGrid(layerGroup, visited, zoom, style) {
-    if (!visited || typeof visited !== 'object') return;
-    const n = Math.pow(2, zoom || 14);
-
-    for (const key of Object.keys(visited)) {
-        const [x, y] = key.split(',').map(Number);
-        const west = x / n * 360 - 180;
-        const east = (x + 1) / n * 360 - 180;
-        const northRad = Math.atan(Math.sinh(Math.PI * (1 - 2 * y / n)));
-        const southRad = Math.atan(Math.sinh(Math.PI * (1 - 2 * (y + 1) / n)));
-        const north = northRad * 180 / Math.PI;
-        const south = southRad * 180 / Math.PI;
-
-        const rect = L.rectangle([[south, west], [north, east]], {
-            ...style,
-            interactive: false,
-        });
-        layerGroup.addLayer(rect);
-    }
-}
-
 /**
  * Render green highlight rectangles for the new (unvisited) tiles a route
- * will claim, using the same tile-boundary math as drawTileGrid.
+ * will claim, computing each tile's lat/lon boundary from its zoom-level key.
  * newTilesByZoom: [{zoom, tiles: [{x, y}]}]
  *
  * When `direction` is given, any rectangles previously rendered for that

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -102,12 +102,28 @@
                                 <div class="small text-muted mt-1" id="end-display">Click map or search to set</div>
                             </div>
                             <div class="mb-2">
+                                <label class="form-label small mb-0" for="target-type-select">Target</label>
+                                <select class="form-select form-select-sm" id="target-type-select" aria-label="Route target — distance or duration">
+                                    <option value="distance" selected>Distance</option>
+                                    <option value="duration">Duration</option>
+                                </select>
+                            </div>
+                            <div class="mb-2" id="distance-target-group">
                                 <label class="form-label small mb-0" for="distance-slider">Distance (<span id="distance-unit-label"></span>)</label>
                                 <div class="d-flex align-items-center gap-2">
                                     <input type="range" class="form-range" id="distance-slider" min="10" max="150" value="40" step="5"
                                            aria-label="Target route distance">
                                     <span class="small fw-bold tabular-nums" id="distance-value">40</span>
                                 </div>
+                            </div>
+                            <div class="mb-2 d-none" id="duration-target-group">
+                                <label class="form-label small mb-0" for="duration-slider">Duration (minutes)</label>
+                                <div class="d-flex align-items-center gap-2">
+                                    <input type="range" class="form-range" id="duration-slider" min="15" max="360" value="90" step="15"
+                                           aria-label="Target route duration in minutes">
+                                    <span class="small fw-bold tabular-nums" id="duration-value">90</span>
+                                </div>
+                                <div class="small text-muted mt-1" id="duration-speed-hint"></div>
                             </div>
                             <div class="mb-2">
                                 <label class="form-label small mb-0" for="optimize-for-select">Optimize for</label>

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -123,10 +123,7 @@
                                 <label class="form-label small mb-0" for="optimize-for-select">Optimize for</label>
                                 <select class="form-select form-select-sm" id="optimize-for-select" aria-label="Route optimization priority">
                                     <option value="tiles" selected>Most new tiles</option>
-                                    <option value="distance">Shortest route</option>
                                     <option value="efficiency">Efficiency (new tiles/km)</option>
-                                    <option value="infill" title="Target unvisited tiles surrounded by visited tiles — patches interior gaps in your yard">Yard — infill gaps</option>
-                                    <option value="frontier" title="Target tiles on the edge of your visited footprint — expands into sparse areas">Yard — expand frontier</option>
                                 </select>
                             </div>
                             <div class="mb-2">

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -102,6 +102,20 @@
                                 <div class="small text-muted mt-1" id="end-display">Click map or search to set</div>
                             </div>
                             <div class="mb-2">
+                                <label class="form-label small mb-0">Target area <span class="text-muted">(optional)</span></label>
+                                <div class="d-flex flex-wrap gap-2 align-items-center">
+                                    <button type="button" class="btn btn-sm btn-outline-secondary" id="draw-area-btn"
+                                            aria-label="Draw a target area on the map — click and drag">
+                                        <i class="bi bi-bounding-box" aria-hidden="true"></i> Draw area
+                                    </button>
+                                    <button type="button" class="btn btn-sm btn-outline-secondary d-none" id="clear-area-btn"
+                                            aria-label="Clear the drawn target area">
+                                        <i class="bi bi-x-lg" aria-hidden="true"></i> Clear
+                                    </button>
+                                    <span class="text-muted small" id="area-status"></span>
+                                </div>
+                            </div>
+                            <div class="mb-2">
                                 <label class="form-label small mb-0" for="target-type-select">Target</label>
                                 <select class="form-select form-select-sm" id="target-type-select" aria-label="Route target — distance or duration">
                                     <option value="distance" selected>Distance</option>

--- a/templates/explore.html
+++ b/templates/explore.html
@@ -34,35 +34,9 @@
                 <div class="card mb-3">
                     <div class="card-body py-3 px-3">
 
-                        <!-- Step 1: Coverage -->
+                        <!-- Step 1: Start point (coverage loads silently in the background once this is set — #488) -->
                         <span class="workflow-step small mb-2 d-flex" id="workflow-step-1">
-                            <span class="workflow-step-num">1</span> Load your coverage
-                        </span>
-                        <div class="control-step d-flex flex-wrap gap-2 align-items-center">
-                            <label class="form-label small mb-0 me-1" for="coverage-type-select">Coverage</label>
-                            <i class="bi bi-question-circle text-muted me-1" tabindex="0" role="img"
-                               data-bs-toggle="tooltip" data-bs-placement="top"
-                               title="Squadrats = zoom-14 tiles (~1.2 km² each). Squadratinhos = zoom-17 tiles (~0.15 km² each). Covering more tiles means you've ridden more unique roads."
-                               aria-label="What are Squadrats and Squadratinhos?"></i>
-                            <select class="form-select form-select-sm max-w-180px" id="coverage-type-select" aria-label="Coverage grid granularity — also controls which grid the route generator targets">
-                                <option value="14" selected>Squadrats</option>
-                                <option value="17">Squadratinhos</option>
-                                <option value="both">Both</option>
-                            </select>
-                            <button class="btn btn-sm btn-primary" id="load-coverage-btn">
-                                <i class="bi bi-arrow-clockwise" aria-hidden="true"></i> Load Coverage
-                            </button>
-                            <button class="btn btn-sm btn-outline-danger" id="clear-cache-btn">
-                                <i class="bi bi-trash" aria-hidden="true"></i> Clear Cache
-                            </button>
-                            <span class="text-muted small" id="coverage-status"></span>
-                        </div>
-
-                        <hr>
-
-                        <!-- Step 2: Start point -->
-                        <span class="workflow-step small mb-2 d-flex" id="workflow-step-2">
-                            <span class="workflow-step-num">2</span> Set a start point
+                            <span class="workflow-step-num">1</span> Set a start point
                         </span>
                         <div class="control-step">
                             <label class="form-label small mb-0" for="location-search-input">Search, or click the map</label>
@@ -80,13 +54,29 @@
                                 </button>
                             </div>
                             <div class="small text-muted mt-1" id="start-display">Click map or search to set</div>
+                            <div class="d-flex flex-wrap gap-2 align-items-center mt-2">
+                                <label class="form-label small mb-0 me-1" for="coverage-type-select">Coverage grid</label>
+                                <i class="bi bi-question-circle text-muted me-1" tabindex="0" role="img"
+                                   data-bs-toggle="tooltip" data-bs-placement="top"
+                                   title="Squadrats = zoom-14 tiles (~1.2 km² each). Squadratinhos = zoom-17 tiles (~0.15 km² each). Covering more tiles means you've ridden more unique roads."
+                                   aria-label="What are Squadrats and Squadratinhos?"></i>
+                                <select class="form-select form-select-sm max-w-180px" id="coverage-type-select" aria-label="Coverage grid granularity — also controls which grid the route generator targets">
+                                    <option value="14" selected>Squadrats</option>
+                                    <option value="17">Squadratinhos</option>
+                                    <option value="both">Both</option>
+                                </select>
+                                <button class="btn btn-sm btn-outline-danger" id="clear-cache-btn">
+                                    <i class="bi bi-trash" aria-hidden="true"></i> Clear Cache
+                                </button>
+                            </div>
+                            <span class="text-muted small" id="coverage-status"></span>
                         </div>
 
                         <hr>
 
-                        <!-- Step 3: Generate -->
-                        <span class="workflow-step small mb-2 d-flex" id="workflow-step-3">
-                            <span class="workflow-step-num">3</span> Generate routes
+                        <!-- Step 2: Generate -->
+                        <span class="workflow-step small mb-2 d-flex" id="workflow-step-2">
+                            <span class="workflow-step-num">2</span> Generate routes
                         </span>
                         <div class="control-step">
                             <div class="mb-2">
@@ -180,10 +170,6 @@
                         <!-- Coverage legend (#360) -->
                         <div class="d-flex flex-wrap gap-3 small text-muted mt-2 px-1" id="coverage-legend">
                             <span class="d-inline-flex align-items-center gap-1">
-                                <span class="legend-swatch legend-swatch-caution"></span>
-                                Visited tile
-                            </span>
-                            <span class="d-inline-flex align-items-center gap-1">
                                 <span class="legend-swatch legend-swatch-good"></span>
                                 New tile this route adds
                             </span>
@@ -191,28 +177,6 @@
                                 <span class="legend-line-swatch"></span>
                                 Dashed = quick preview, solid = real road route (colored by direction)
                             </span>
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Coverage stats (#367: below the map) -->
-                <div class="row g-2 mb-2" id="coverage-stats">
-                    <div class="col-4">
-                        <div class="card coverage-stat">
-                            <div class="stat-value tabular-nums" id="stat-tiles-visited">—</div>
-                            <div class="stat-label">Tiles Visited</div>
-                        </div>
-                    </div>
-                    <div class="col-4">
-                        <div class="card coverage-stat">
-                            <div class="stat-value tabular-nums" id="stat-coverage-pct">—</div>
-                            <div class="stat-label">Coverage</div>
-                        </div>
-                    </div>
-                    <div class="col-4">
-                        <div class="card coverage-stat">
-                            <div class="stat-value tabular-nums" id="stat-total-tiles">—</div>
-                            <div class="stat-label">Total in View</div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Implements the remaining scope of the Explore Route Generator epic (#492), in its suggested order:

- **#487** — Prunes `optimizeFor` from five strategies (tiles/distance/efficiency/infill/frontier) down to two (tiles/efficiency). The other three saw little differentiated use and added branches the work below would otherwise have to thread through.
- **#488** — Folds the standalone tile-coverage browser into route-gen feedback. Coverage now loads silently once a start point is set instead of a separate "Load Coverage" step; drops the general stats panel, density-cluster fit-to-view, and full visited-tile grid overlay. Only the green "tiles this route claims" highlight remains — the Squadrats browser extension already covers general coverage browsing on RideWithGPS/Strava.
- **#490** — Adds a duration-based route target alongside distance. A "Target" selector toggles between the distance slider and a new duration slider (minutes); duration converts to a distance budget using the rider's historical average speed (reusing `GET /api/stats`, no new endpoint), falling back to a configured `exploration.default_speed_kmh` when there's no ride history.
- **#491** — Lets the rider draw a target-area rectangle on the map instead of relying only on start point + computed radius. Hand-rolled click-and-drag control (no new Leaflet dependency); the worker's `scanGrid()` intersects reachable tiles with the drawn box in addition to the existing reach-radius constraint.

## Test plan
- [x] `node --check` on all modified JS files
- [x] `pytest tests/test_exploration_service.py` (28 passed)
- [x] `pytest tests/test_stats_bp_local_time.py` (8 passed)
- [x] Playwright against the local dev server for each change:
  - #488: start-point selection triggers automatic coverage load, removed markup (load-coverage-btn, coverage-stats) absent, no console errors
  - #490: target toggle shows/hides the right group, duration-speed-hint reflects fallback speed and updates live, Generate Routes resolves duration → distance with no errors
  - #491: draw toggle, drag-to-rectangle, area-status text, Clear button, and that normal start-point clicks still work immediately after a draw completes
- [ ] Manual verification against real ride history/coverage data not done — this dev environment has no cached Strava activities (empty coverage grid, `bounds: None`), so live route generation end-to-end (tile scanning past the empty-coverage guard) wasn't exercised — consistent with the same limitation noted in #503.

🤖 Generated with [Claude Code](https://claude.com/claude-code)