### PR TITLE
CI: build arm64-only container image (amd64 has no consumer)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -107,7 +107,12 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
+          # amd64 disabled (#516) — only the Pi4 (arm64) actually deploys this
+          # image; local dev runs bare `python launch.py`, not the container.
+          # Re-enable by uncommenting below if an amd64 deployment target
+          # (self-hosted x86 server, local podman-compose testing) shows up.
+          # platforms: linux/amd64,linux/arm64
+          platforms: linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
## Summary
- Only the Pi4 (`arm64`) actually pulls and runs this GHCR image (`docs/DEPLOYMENT.md`); local dev runs bare `python launch.py`/`wsgi.py`, never the container.
- Comments out `linux/amd64` in `docker-publish.yml`'s `platforms:` line, cutting build time roughly in half. Kept as a comment (not deleted) so re-enabling is a one-line uncomment.
- Filed #516 to track re-enabling if a non-Pi deployment target or local container-testing need ever shows up.

## Test plan
- [x] YAML validated (`python -c "import yaml; yaml.safe_load(...)"`)
- [ ] CI run on this PR will validate the build-only (no-push) path still succeeds with arm64-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)