### PR TITLE
Fix home/work location settings not persisting across deploys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+config/runtime_overrides.env
 config/credentials.json
 config/.token_encryption_key
 config/.cache_encryption_key

--- a/app/credentials/env_helpers.py
+++ b/app/credentials/env_helpers.py
@@ -3,23 +3,40 @@
 Extracted verbatim from launch.py (_env_path, _read_env, _write_env).
 Used by strava_bp and core_bp to persist credentials without touching
 unrelated environment keys.
+
+Runtime writes (Strava reconnect, ORS key, home/work location — anything set
+through the web UI after the container is already running) go to
+``config/runtime_overrides.env`` instead of the project's ``.env``. ``.env``
+is only injected into the container at creation time via docker-compose's
+``env_file:`` and is never bind-mounted, so writes to it from inside a
+running container are lost on the next redeploy. ``config/`` *is*
+bind-mounted and already carries the correct container-writable ownership
+(it holds ``credentials.json``), so runtime overrides persist there instead.
+``read_env()`` merges both files, with the runtime overrides taking
+precedence, so callers don't need to know which file a given key lives in.
 """
 
 from pathlib import Path
 
+RUNTIME_OVERRIDES_FILENAME = 'runtime_overrides.env'
+
 
 def env_path() -> Path:
-    """Return the canonical path to the project .env file."""
+    """Return the canonical path to the project .env file (read-only at runtime)."""
     return Path('.env')
 
 
-def read_env() -> dict:
-    """Parse .env file into a dict.  Returns ``{}`` when the file is absent."""
-    ef = env_path()
-    if not ef.exists():
+def runtime_env_path() -> Path:
+    """Return the path to the container-writable runtime overrides file."""
+    return Path('config') / RUNTIME_OVERRIDES_FILENAME
+
+
+def _parse_env_file(path: Path) -> dict:
+    """Parse a key=value env file into a dict.  Returns ``{}`` when absent."""
+    if not path.exists():
         return {}
     result: dict = {}
-    for line in ef.read_text(encoding='utf-8').splitlines():
+    for line in path.read_text(encoding='utf-8').splitlines():
         line = line.strip()
         if line and not line.startswith('#') and '=' in line:
             key, _, value = line.partition('=')
@@ -27,9 +44,16 @@ def read_env() -> dict:
     return result
 
 
+def read_env() -> dict:
+    """Return .env merged with runtime overrides (overrides take precedence)."""
+    merged = _parse_env_file(env_path())
+    merged.update(_parse_env_file(runtime_env_path()))
+    return merged
+
+
 def write_env(data: dict) -> None:
-    """Write *data* key=value pairs to .env, preserving existing unrelated keys."""
-    ef = env_path()
+    """Write *data* key=value pairs to the runtime overrides file under config/."""
+    ef = runtime_env_path()
     existing: dict = {}
     lines_out: list = []
 

--- a/src/config_manager.py
+++ b/src/config_manager.py
@@ -93,6 +93,12 @@ class ConfigManager:
             yaml.YAMLError: If config file has invalid YAML syntax
         """
         load_dotenv()
+        # Runtime overrides written via the Settings UI (write_env() in
+        # app/credentials/env_helpers.py) live under config/, not .env — .env
+        # is only injected at container creation and isn't bind-mounted, so
+        # in-container writes to it don't survive a redeploy. override=True
+        # so a value saved through the UI wins over a stale .env entry.
+        load_dotenv(Path('config') / 'runtime_overrides.env', override=True)
 
         if not self.config_file.exists():
             raise FileNotFoundError(f"Configuration file not found: {self.config_file}")

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -192,7 +192,7 @@
                         <div class="collapse" id="location-card-body">
                             <div class="card-body">
                                 <p class="small text-muted mb-3">
-                                    Used to find your commute route and local weather. Saved to <code>.env</code> on this
+                                    Used to find your commute route and local weather. Saved on this
                                     server — never committed to the repo.
                                 </p>
 


### PR DESCRIPTION
## Summary
- `write_env()` (used by the Settings-page Home/Work location save, Strava reconnect, and ORS key save) wrote to `.env`, which `docker-compose.yml` only injects into the container at creation via `env_file:` — it's never bind-mounted. Writes made from inside a running container landed on the container's ephemeral writable layer and were lost on the next redeploy's container recreation.
- Runtime writes now go to `config/runtime_overrides.env`, under the `config/` volume that's already bind-mounted and correctly owned by the container's mapped uid (it already holds `credentials.json`).
- `ConfigManager._load_config()` loads that file with `override=True` on init/reload so saved values take effect immediately and survive restarts.
- `read_env()` merges `.env` and the runtime overrides file (overrides win) so existing `os.getenv(...) or read_env().get(...)` fallback callers are unaffected.
- Fixed stale Settings-page copy that named `.env` specifically.

## Test plan
- [x] `pytest tests/test_config_manager.py tests/test_commute_service.py tests/test_api.py` — all passing
- [ ] After merge + GHCR rebuild, redeploy on pi4 and confirm a Home/Work location save in Settings survives `podman-compose restart ride-optimizer`

🤖 Generated with [Claude Code](https://claude.com/claude-code)