### PR TITLE
Exploration route generator: cheapest-insertion construction + overlap, out-and-back, and wind orientation

### DIFF
--- a/app/api/weather_bp.py
+++ b/app/api/weather_bp.py
@@ -78,6 +78,11 @@ def get_weather():
                 'description': weather_data.get('conditions', 'Unknown'),
                 'wind_speed': round(wind_speed_mph),
                 'wind_direction': weather_data.get('wind_direction_cardinal', 'N'),
+                # Numeric form for wind-relative calculations (#453) — the
+                # cardinal/mph fields above are display-only and too coarse
+                # (16-point compass, rounded mph) for headwind/tailwind math.
+                'wind_direction_deg': weather_data.get('wind_direction_deg'),
+                'wind_speed_kph': weather_data.get('wind_speed_kph'),
                 'humidity': weather_data.get('humidity', 0),
                 'precipitation_probability': weather_data.get('precipitation_mm', 0),
                 'comfort_score': int(weather_data.get('comfort_score', 0.5) * 100)

--- a/app/services/exploration_service.py
+++ b/app/services/exploration_service.py
@@ -6,6 +6,7 @@ management following the existing service patterns (constructor + initialize).
 """
 
 from src.secure_logger import SecureLogger
+import math
 import time
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -214,6 +215,7 @@ class ExplorationService:
         duration_min = round(summary["duration"] / 60, 1)
 
         surface_breakdown = ExplorationService._reduce_surface_extras(props.get("extras", {}))
+        is_out_and_back = ExplorationService._is_out_and_back(coordinates)
 
         return {
             "status": "success",
@@ -221,7 +223,49 @@ class ExplorationService:
             "distance_km": distance_km,
             "duration_min": duration_min,
             "surface_breakdown": surface_breakdown,
+            "is_out_and_back": is_out_and_back,
         }
+
+    # Fraction of return-leg points that must fall within OUT_AND_BACK_RADIUS_M
+    # of some outbound-leg point for the route to be flagged as out-and-back (#452).
+    OUT_AND_BACK_OVERLAP_THRESHOLD = 0.7
+    OUT_AND_BACK_RADIUS_M = 150
+
+    @staticmethod
+    def _is_out_and_back(coordinates: List[List[float]]) -> bool:
+        """Detect a route whose return leg substantially retraces its outbound leg.
+
+        Splits the polyline in half and checks what fraction of return-leg
+        points land within ~150m of some outbound-leg point. Real road
+        geometry rarely retraces exactly, so this is a proximity match against
+        the whole outbound half rather than a point-by-point mirror check —
+        that's what lets a genuine loop (distinct corridors both ways) read as
+        low-overlap even if the two halves end up near each other briefly.
+        """
+        if len(coordinates) < 4:
+            return False
+
+        mid = len(coordinates) // 2
+        outbound, return_leg = coordinates[:mid], coordinates[mid:]
+        if not outbound or not return_leg:
+            return False
+
+        # Coarse degrees-per-meter conversion is fine at the ~150m scale this
+        # threshold operates at — no need for full haversine per point pair.
+        lat_ref = coordinates[0][0]
+        deg_per_m_lat = 1 / 111_320
+        deg_per_m_lon = 1 / (111_320 * max(0.01, abs(math.cos(math.radians(lat_ref)))))
+        radius_deg_lat = ExplorationService.OUT_AND_BACK_RADIUS_M * deg_per_m_lat
+        radius_deg_lon = ExplorationService.OUT_AND_BACK_RADIUS_M * deg_per_m_lon
+
+        near_count = 0
+        for r_lat, r_lon in return_leg:
+            for o_lat, o_lon in outbound:
+                if abs(r_lat - o_lat) <= radius_deg_lat and abs(r_lon - o_lon) <= radius_deg_lon:
+                    near_count += 1
+                    break
+
+        return (near_count / len(return_leg)) >= ExplorationService.OUT_AND_BACK_OVERLAP_THRESHOLD
 
     @staticmethod
     def _reduce_surface_extras(extras: dict) -> Dict[str, Any]:

--- a/static/js/exploration-worker.js
+++ b/static/js/exploration-worker.js
@@ -26,9 +26,13 @@
  *       target area. When present, further restricts reachable tiles to
  *       those inside the box, in addition to (not instead of) the reach
  *       radius derived from distanceKm.
+ *   - windDirectionDeg/windSpeedKph: number | null (#453) — current wind, if
+ *       available. Used only as a tie-break between otherwise-equal-yield
+ *       tour orientations (headwind out, tailwind back) for round trips with
+ *       ≥2 zones; ignored for point-to-point routes or when unavailable.
  *
  * Output messages (streamed):
- *   {type: 'route', route: {direction, waypoints, stats}}  — one per generated route
+ *   {type: 'route', route: {direction, waypoints, windLabel, stats}}  — one per generated route
  *   {type: 'done', totalRoutes, stats}                     — sent once, after all routes
  *   {type: 'error', message}                                — fatal error
  */
@@ -86,7 +90,7 @@ function scanGrid(coverageData, start, reachRadius, areaBounds) {
     return { zoom, unvisited, reachableTiles, buckets, visitedSet };
 }
 
-function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData, coverageDataSecondary, optimizeFor, corridorConstraint, areaBounds }) {
+function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData, coverageDataSecondary, optimizeFor, corridorConstraint, areaBounds, windDirectionDeg, windSpeedKph }) {
     const isRoundTrip = routeType === 'round_trip' || !end;
     // Default to 'loop' for round trips when the caller doesn't specify —
     // matches the pre-#489 behaviour of drawing from whichever quadrant the
@@ -113,10 +117,13 @@ function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData
         };
     }
 
-    // Per grid, top candidate zones per quadrant. When merging two grids,
-    // cap each grid's contribution so the combined waypoint count per route
-    // stays reasonable (TSP brute-force applies up to 8 points).
-    const perGridCap = secondary ? 4 : 6;
+    // Per grid, candidate zone pool per quadrant. When merging two grids,
+    // cap each grid's contribution so the combined pool the insertion
+    // construction searches over stays a reasonable size.
+    const perGridCap = secondary ? 8 : 12;
+    // Seeds each quadrant's running claimed-tiles set (#451) with the real
+    // ride history, keyed by zoom since tile coordinate spaces differ per grid.
+    const visitedSetsByZoom = new Map(grids.map(g => [g.zoom, g.visitedSet]));
 
     let totalRoutes = 0;
     QUADRANTS.forEach((dir, i) => {
@@ -131,7 +138,7 @@ function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData
         const scanDirs = effectiveShape === 'loop' ? [dir, nextQuadrant(dir)] : [dir];
         const zoneCap = effectiveShape === 'out_and_back' ? 1 : perGridCap;
 
-        const gridCandidates = grids.map(g => {
+        const pool = grids.flatMap(g => {
             const bucketTiles = scanDirs.flatMap(d => g.buckets[d]);
             const dirZones = floodFillZones(bucketTiles).map(z => ({
                 ...z,
@@ -139,39 +146,52 @@ function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData
             }));
             const scored = scoreZones(dirZones, optimizeFor);
             const penalised = applyOverlapPenalty(scored, start, g.visitedSet, g.zoom);
-            return {
+            return penalised.slice(0, zoneCap).map(z => ({
+                ...z,
                 zoom: g.zoom,
-                candidates: penalised.slice(0, zoneCap),
-            };
-        });
-
-        const allCandidates = gridCandidates.flatMap(
-            gc => gc.candidates.map(z => ({ ...z, zoom: gc.zoom }))
-        );
-        if (allCandidates.length === 0) return;
-
-        // For each zone find the corner that claims the most tiles at once,
-        // inset ~5 m toward the zone centroid so GPS uncertainty is absorbed.
-        const points = allCandidates.map(z =>
-            bestCornerPoint(z.tiles, z.zoom, start.lat, start.lon)
-        );
-        const ordered = solveTSP(start, points, end);
-
-        const breakdown = gridCandidates
-            .filter(gc => gc.candidates.length > 0)
-            .map(gc => ({
-                zoom: gc.zoom,
-                label: GRID_LABELS[gc.zoom] || `zoom ${gc.zoom}`,
-                count: gc.candidates.reduce((sum, z) => sum + z.tiles.length, 0),
+                point: bestCornerPoint(z.tiles, g.zoom, start.lat, start.lon),
             }));
+        });
+        if (pool.length === 0) return;
+
+        const selected = constructInsertionTour(start, end, pool, distanceKm, optimizeFor, visitedSetsByZoom);
+
+        // #453: once outbound/return phases exist (≥2 zones, round trip),
+        // prefer whichever traversal direction faces the wind on the way out
+        // and rides it on the way back. Reversing the visit order doesn't
+        // change which zones/tiles are claimed — only which end of the tour
+        // is "outbound" — so this is a pure tie-break, never a factor in
+        // which zones got selected above.
+        let windLabel = null;
+        if (isRoundTrip && selected.length > 1 && windDirectionDeg != null && windSpeedKph != null) {
+            const forwardBearing = bearingDeg(start.lat, start.lon, selected[0].point.lat, selected[0].point.lon);
+            const reverseBearing = bearingDeg(start.lat, start.lon, selected[selected.length - 1].point.lat, selected[selected.length - 1].point.lon);
+            const forwardHeadwind = headwindComponent(windSpeedKph, windDirectionDeg, forwardBearing);
+            const reverseHeadwind = headwindComponent(windSpeedKph, windDirectionDeg, reverseBearing);
+            if (reverseHeadwind > forwardHeadwind) selected.reverse();
+            const chosenHeadwind = Math.max(forwardHeadwind, reverseHeadwind);
+            if (chosenHeadwind > 0) {
+                windLabel = `↰ headwind out, tailwind back · ${Math.round(windSpeedKph)} km/h`;
+            }
+        }
+        const ordered = selected.map(z => z.point);
+
+        const byZoom = new Map();
+        for (const z of selected) {
+            if (!byZoom.has(z.zoom)) byZoom.set(z.zoom, []);
+            byZoom.get(z.zoom).push(z);
+        }
+        const breakdown = [...byZoom.entries()].map(([zoom, zones]) => ({
+            zoom,
+            label: GRID_LABELS[zoom] || `zoom ${zoom}`,
+            count: zones.reduce((sum, z) => sum + z.tiles.length, 0),
+        }));
 
         // Collect per-zoom new tile lists for map highlighting.
-        const newTilesByZoom = gridCandidates
-            .filter(gc => gc.candidates.length > 0)
-            .map(gc => ({
-                zoom: gc.zoom,
-                tiles: gc.candidates.flatMap(z => z.tiles.map(t => ({ x: t.x, y: t.y }))),
-            }));
+        const newTilesByZoom = [...byZoom.entries()].map(([zoom, zones]) => ({
+            zoom,
+            tiles: zones.flatMap(z => z.tiles.map(t => ({ x: t.x, y: t.y }))),
+        }));
 
         totalRoutes++;
         self.postMessage({
@@ -180,10 +200,11 @@ function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData
                 direction: dir,
                 shape: effectiveShape,
                 waypoints: ordered,
+                windLabel,
                 newTilesByZoom,
                 stats: {
                     waypoints: ordered.length,
-                    zones: allCandidates.length,
+                    zones: selected.length,
                     unvisited: breakdown.reduce((sum, b) => sum + b.count, 0),
                     breakdown: secondary ? breakdown : null,
                     distanceKm: routeDistance(start, ordered, end),
@@ -203,25 +224,46 @@ function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData
 // 0 disables the penalty entirely; raise to 1.0+ to strongly avoid overlap.
 const OVERLAP_PENALTY_WEIGHT = 0.5;
 
+function latLonToTileXY(lat, lon, zoom) {
+    const n = Math.pow(2, zoom);
+    const x = Math.floor((lon + 180) / 360 * n);
+    const y = Math.floor((1 - Math.asinh(Math.tan(lat * Math.PI / 180)) / Math.PI) / 2 * n);
+    return { x, y };
+}
+
+/**
+ * Sample the tile keys a straight-line corridor between two points crosses,
+ * at ~1 sample per 250m. Shared by the historical overlap estimate below and
+ * by the in-progress-tour overlap tracking in constructInsertionTour (#451).
+ */
+function sampleCorridorTileKeys(latA, lonA, latB, lonB, zoom) {
+    const distKm = haversineKm(latA, lonA, latB, lonB);
+    const steps = Math.max(2, Math.round(distKm * 4));
+    const keys = [];
+    for (let i = 1; i < steps; i++) {
+        const t = i / steps;
+        const { x, y } = latLonToTileXY(latA + (latB - latA) * t, lonA + (lonB - lonA) * t, zoom);
+        keys.push(`${x},${y}`);
+    }
+    return keys;
+}
+
+function countKeysInSet(keys, set) {
+    let count = 0;
+    for (const k of keys) if (set.has(k)) count++;
+    return count;
+}
+
 /**
  * Estimate how many visited tiles lie along the straight-line corridor from
  * `start` to the zone centroid by sampling the tile grid at intervals.
  * Uses only the already-loaded visitedSet — no extra API calls.
  */
 function estimateCorridorOverlap(zone, start, visitedSet, zoom) {
-    const steps = Math.max(2, Math.round(zone.distanceFromStart * 4)); // ~1 sample per 250m
-    const dlat = (zone.centroid.lat - start.lat) / steps;
-    const dlon = (zone.centroid.lon - start.lon) / steps;
-    let overlap = 0;
-    for (let i = 1; i < steps; i++) {
-        const lat = start.lat + dlat * i;
-        const lon = start.lon + dlon * i;
-        const n = Math.pow(2, zoom);
-        const x = Math.floor((lon + 180) / 360 * n);
-        const y = Math.floor((1 - Math.asinh(Math.tan(lat * Math.PI / 180)) / Math.PI) / 2 * n);
-        if (visitedSet.has(`${x},${y}`)) overlap++;
-    }
-    return overlap;
+    return countKeysInSet(
+        sampleCorridorTileKeys(start.lat, start.lon, zone.centroid.lat, zone.centroid.lon, zoom),
+        visitedSet
+    );
 }
 
 /**
@@ -263,6 +305,19 @@ function bearingDeg(lat1, lon1, lat2, lon2) {
     const y = Math.sin(dLambda) * Math.cos(phi2);
     const x = Math.cos(phi1) * Math.sin(phi2) - Math.sin(phi1) * Math.cos(phi2) * Math.cos(dLambda);
     return (Math.atan2(y, x) * 180 / Math.PI + 360) % 360;
+}
+
+/**
+ * Headwind component (positive) / tailwind (negative) of `windSpeed` for a
+ * bearing of `travelBearing`, given wind blowing FROM `windDirection` (#453).
+ * Mirrors WindImpactCalculator.calculate_wind_component (src/weather_fetcher.py)
+ * so client and server agree on what counts as a headwind.
+ */
+function headwindComponent(windSpeed, windDirection, travelBearing) {
+    let relative = (windDirection - travelBearing) % 360;
+    if (relative > 180) relative -= 360;
+    if (relative < -180) relative += 360;
+    return windSpeed * Math.cos(relative * Math.PI / 180);
 }
 
 function quadrantFor(bearing) {
@@ -421,6 +476,114 @@ function floodFillZones(tiles) {
         zones.push({ tiles: zone, centroid });
     }
     return zones;
+}
+
+// ── Reward-weighted cheapest-insertion tour construction (#450) ─
+
+// How far over the target distance the constructed tour may run before a
+// candidate insertion is rejected for blowing the budget.
+const INSERTION_DISTANCE_TOLERANCE = 1.15;
+// A candidate must add at least this many new tiles per km of extra travel
+// to be worth inserting at all — below this, further zones stop being added
+// even if the distance budget has room left.
+const MIN_TILES_PER_KM = 0.15;
+
+/**
+ * Build a tour by greedy cheapest insertion instead of distance-minimizing
+ * TSP (#450). Minimizing distance is the wrong objective when the goal is
+ * maximizing distinct tiles per distance budget: when candidates sit roughly
+ * along one ray from `start`, the distance-optimal tour is "farthest zone,
+ * straight back," which retraces already-claimed tiles on the return leg.
+ *
+ * Seeds the tour with the single farthest candidate, then repeatedly inserts
+ * whichever remaining candidate scores highest — tiles gained per km of
+ * extra travel the insertion costs — at whichever position in the tour is
+ * cheapest, stopping once no candidate clears the minimum tiles/km floor or
+ * the next insertion would exceed the distance budget.
+ *
+ * `visitedSetsByZoom` (Map<zoom, Set<tileKey>>) seeds a running "claimed
+ * tiles" set per zoom (#451): after each insertion, the tiles along that
+ * leg's approach/departure corridor are added to the running set, so a later
+ * candidate whose approach path would retrace a corridor an earlier leg in
+ * *this same tour* already claimed is penalised the same way retracing
+ * historically-ridden tiles already is — not just against ride history.
+ */
+function constructInsertionTour(start, end, candidates, distanceKm, optimizeFor, visitedSetsByZoom) {
+    if (candidates.length === 0) return [];
+
+    const budgetKm = distanceKm * INSERTION_DISTANCE_TOLERANCE;
+    const closePoint = end || start;
+
+    const claimedByZoom = new Map();
+    const claimedSetFor = (zoom) => {
+        if (!claimedByZoom.has(zoom)) {
+            claimedByZoom.set(zoom, new Set(visitedSetsByZoom?.get(zoom) || []));
+        }
+        return claimedByZoom.get(zoom);
+    };
+    const claimLeg = (fromPoint, toPoint, zoom) => {
+        const claimed = claimedSetFor(zoom);
+        for (const k of sampleCorridorTileKeys(fromPoint.lat, fromPoint.lon, toPoint.lat, toPoint.lon, zoom)) {
+            claimed.add(k);
+        }
+    };
+    const legOverlap = (fromPoint, toPoint, zoom) =>
+        countKeysInSet(sampleCorridorTileKeys(fromPoint.lat, fromPoint.lon, toPoint.lat, toPoint.lon, zoom), claimedSetFor(zoom));
+
+    const remaining = [...candidates];
+    let seedIdx = 0;
+    for (let i = 1; i < remaining.length; i++) {
+        if (remaining[i].distanceFromStart > remaining[seedIdx].distanceFromStart) seedIdx = i;
+    }
+    const seed = remaining.splice(seedIdx, 1)[0];
+    let tour = [seed];
+    claimLeg(start, seed.point, seed.zoom);
+    claimLeg(seed.point, closePoint, seed.zoom);
+
+    // 'efficiency' weighs candidates strictly by tiles gained per km of
+    // insertion cost. 'tiles' (default) still needs cost to compare
+    // candidates and enforce the budget, but favors raw new-tile count more
+    // strongly by discounting cost's influence on the score.
+    const costExponent = optimizeFor === 'efficiency' ? 1 : 0.4;
+
+    while (remaining.length > 0) {
+        let best = null;
+        for (let i = 0; i < remaining.length; i++) {
+            const cand = remaining[i];
+            for (let pos = 0; pos <= tour.length; pos++) {
+                const prev = pos === 0 ? start : tour[pos - 1].point;
+                const next = pos === tour.length ? closePoint : tour[pos].point;
+                const insertCost = haversineKm(prev.lat, prev.lon, cand.point.lat, cand.point.lon) +
+                    haversineKm(cand.point.lat, cand.point.lon, next.lat, next.lon) -
+                    haversineKm(prev.lat, prev.lon, next.lat, next.lon);
+
+                const overlap = legOverlap(prev, cand.point, cand.zoom) + legOverlap(cand.point, next, cand.zoom);
+                const effectiveTiles = Math.max(cand.tiles.length - OVERLAP_PENALTY_WEIGHT * overlap, 0.1);
+
+                const tilesPerKm = effectiveTiles / Math.max(insertCost, 0.01);
+                if (tilesPerKm < MIN_TILES_PER_KM) continue;
+
+                const score = effectiveTiles / Math.pow(Math.max(insertCost, 0.01), costExponent);
+                if (!best || score > best.score) {
+                    best = { i, pos, score, prev, next };
+                }
+            }
+        }
+        if (!best) break;
+
+        const trial = [...tour];
+        trial.splice(best.pos, 0, remaining[best.i]);
+        if (routeDistance(start, trial.map(z => z.point), end) > budgetKm) break;
+
+        const chosen = remaining[best.i];
+        claimLeg(best.prev, chosen.point, chosen.zoom);
+        claimLeg(chosen.point, best.next, chosen.zoom);
+
+        tour = trial;
+        remaining.splice(best.i, 1);
+    }
+
+    return tour;
 }
 
 // ── TSP (brute-force for ≤8 points) ─────────────────────────────

--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -30,6 +30,32 @@ let _skipNextMapClick = false;
 // { NE: [zoneList, ...], SE: [...], ... }
 let _phase1Candidates = {};
 
+// #453: current wind, fetched once per session and reused across route
+// generations rather than re-fetched per click.
+let _sessionWind = undefined; // undefined = not yet fetched, null = unavailable
+
+/**
+ * Fetch current wind conditions once per session for the worker's
+ * headwind-out/tailwind-back tie-break (#453). Failure is silent — the
+ * worker falls back to its current (non-wind-aware) behavior when wind is
+ * unavailable, matching the acceptance criteria.
+ */
+async function getSessionWind() {
+    if (_sessionWind !== undefined) return _sessionWind;
+    try {
+        const res = await api.getWeather();
+        const current = res && res.current;
+        if (current && current.wind_direction_deg != null && current.wind_speed_kph != null) {
+            _sessionWind = { windDirectionDeg: current.wind_direction_deg, windSpeedKph: current.wind_speed_kph };
+        } else {
+            _sessionWind = null;
+        }
+    } catch {
+        _sessionWind = null;
+    }
+    return _sessionWind;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     initMap();
     initWorker();
@@ -714,6 +740,7 @@ async function generateRoute() {
     const shape = document.getElementById('route-type-select').value; // 'loop' | 'out_and_back' | 'point_to_point'
     const routeType = shape === 'point_to_point' ? 'point_to_point' : 'round_trip';
     const endPos = (routeType === 'point_to_point' && endMarker) ? endMarker.getLatLng() : null;
+    const wind = await getSessionWind();
 
     explorationWorker.postMessage({
         start: { lat: startPos.lat, lon: startPos.lng },
@@ -726,6 +753,8 @@ async function generateRoute() {
         coverageDataSecondary: mode === 'both' ? coverageDataSecondary : null,
         optimizeFor,
         areaBounds: selectedAreaBounds,
+        windDirectionDeg: wind ? wind.windDirectionDeg : null,
+        windSpeedKph: wind ? wind.windSpeedKph : null,
     });
 }
 
@@ -828,6 +857,7 @@ async function generateWorkoutCombo() {
     };
 
     statusEl.textContent = 'Generating workout-combo routes…';
+    const wind = await getSessionWind();
     explorationWorker.postMessage({
         start: { lat: startLat, lon: startLon },
         end: null,
@@ -839,6 +869,8 @@ async function generateWorkoutCombo() {
         coverageDataSecondary: mode === 'both' ? coverageDataSecondary : null,
         optimizeFor,
         corridorConstraint: { coordinates: coords, maxDetourKm: 1.5 },
+        windDirectionDeg: wind ? wind.windDirectionDeg : null,
+        windSpeedKph: wind ? wind.windSpeedKph : null,
     });
 }
 
@@ -909,7 +941,7 @@ function addRouteListItem(route, index, targetDistanceKm, extraLabel = '') {
     badge.innerHTML = `
         <div class="d-flex align-items-center gap-2 w-100">
             <span class="swatch"></span>
-            <span class="route-label">${routeDirLabel(route)} · ${distanceLabel} · ${newTilesLabel(route.stats)}${extraLabel ? ' ' + extraLabel : ''}</span>
+            <span class="route-label">${routeDirLabel(route)} · ${distanceLabel} · ${newTilesLabel(route.stats)}${extraLabel ? ' ' + extraLabel : ''}${route.windLabel ? ' · ' + route.windLabel : ''}</span>
             <button class="btn btn-xs btn-outline-primary ms-auto plot-road-btn" data-direction="${dir}"
                     aria-label="Plot road route for ${DIRECTION_LABELS[dir]}">
                 <i class="bi bi-map" aria-hidden="true"></i> Plot road route
@@ -1186,11 +1218,18 @@ async function plotRoadRoute(direction, route, targetDistanceKm, color, badgeEl)
             ? `${sb.paved_pct}% paved · ${sb.unpaved_pct}% unpaved · ${sb.unknown_pct}% unknown`
             : '';
         const tilesText = claimed == null ? '' : `· ${claimed.length} new tile${claimed.length === 1 ? '' : 's'}`;
+        // #452: distinguish a route that efficiently covers new tiles both
+        // ways from one where ORS genuinely found no alternate road for the
+        // return leg — both look identical on the map/card otherwise.
+        const outAndBackBadge = v.result.is_out_and_back
+            ? '<span class="badge bg-secondary-subtle text-secondary-emphasis" title="No alternate road found nearby for the return leg">Out-and-back</span>'
+            : '';
         const dataKey = `${direction}-${suffix}`;
         return `
             <div class="d-flex align-items-center gap-2 flex-wrap mt-4px">
                 <span class="text-muted small">${label} ${v.distLabel} · ${v.result.duration_min} min
                     ${surfText ? `· ${surfText}` : ''} ${tilesText}</span>
+                ${outAndBackBadge}
                 <button class="btn btn-xs btn-outline-secondary export-gpx-btn ms-auto"
                         data-variant="${dataKey}"
                         aria-label="Export GPX ${label}">

--- a/tests/test_exploration_service.py
+++ b/tests/test_exploration_service.py
@@ -430,3 +430,33 @@ class TestReduceSurfaceExtras:
         sb = ExplorationService._reduce_surface_extras(extras)
         assert sb["paved_pct"] == 0
         assert sb["unpaved_pct"] == 100
+
+
+class TestIsOutAndBack:
+    """#452: flag routes whose return leg substantially retraces the outbound leg."""
+
+    def test_identical_retrace_is_out_and_back(self):
+        outbound = [[40.0 + i * 0.001, -73.0] for i in range(10)]
+        coordinates = outbound + list(reversed(outbound))
+        assert ExplorationService._is_out_and_back(coordinates) is True
+
+    def test_distinct_loop_corridors_not_out_and_back(self):
+        # Outbound heads due north, return heads due east then south — no
+        # shared corridor, so this should read as a genuine loop.
+        outbound = [[40.0 + i * 0.001, -73.0] for i in range(10)]
+        return_leg = [[40.009, -73.0 + i * 0.001] for i in range(1, 6)] + \
+                     [[40.009 - i * 0.001, -72.995] for i in range(1, 6)]
+        coordinates = outbound + return_leg
+        assert ExplorationService._is_out_and_back(coordinates) is False
+
+    def test_too_few_points_is_not_out_and_back(self):
+        assert ExplorationService._is_out_and_back([[40.0, -73.0], [40.001, -73.0]]) is False
+
+    def test_partial_overlap_below_threshold_not_flagged(self):
+        # Only the first couple of return points land near the outbound leg;
+        # most of the return leg diverges onto a different corridor.
+        outbound = [[40.0 + i * 0.001, -73.0] for i in range(10)]
+        return_leg = [[40.009, -73.0], [40.008, -73.0]] + \
+                     [[40.0 + i * 0.001, -72.9] for i in range(8)]
+        coordinates = outbound + return_leg
+        assert ExplorationService._is_out_and_back(coordinates) is False


### PR DESCRIPTION
## Summary
- Fixes #450, #451, #452, #453.
- **#450** (reopened — was auto-closed without the fix actually landing): replaces the top-N-zone-selection + distance-minimizing TSP construction in `exploration-worker.js` with a reward-weighted cheapest-insertion tour builder. Minimizing distance was the wrong objective for maximizing new-tile coverage per km — it produced "farthest zone, straight back" out-and-back spikes. The new construction seeds with the farthest reachable zone, then greedily inserts whichever remaining candidate yields the most new tiles per km of detour, subject to a distance budget and a minimum tiles/km floor.
- **#451**: the insertion loop now tracks a running "claimed tiles" set per zoom, seeded from ride history and updated after every leg inserted into the tour — so a later candidate that would retrace a corridor an earlier leg in the *same tour* already used gets penalized, not just retraces of historically-ridden tiles.
- **#452**: `ExplorationService._is_out_and_back()` compares the outbound/return polyline halves; when ≥70% of return-leg points land within 150m of an outbound-leg point, `compute_route()` returns `is_out_and_back: true` and `explore.js` renders an "Out-and-back" badge on the route card instead of presenting it identically to a genuine loop.
- **#453**: `explore.js` fetches current wind once per session via `api.getWeather()` and passes it to the worker, which uses it as a pure tie-break to orient equal-yield tours toward headwind-out/tailwind-back — it never affects which zones get selected, only visit order. This required adding two numeric fields (`wind_direction_deg`, `wind_speed_kph`) to `/api/weather`, since the existing response only exposed a display-only cardinal direction and rounded mph.

## Test plan
- [x] `pytest tests/test_exploration_service.py -q` — 32 passed (4 new tests for `_is_out_and_back`: identical retrace flagged, distinct loop corridors not flagged, too-few-points not flagged, partial overlap below threshold not flagged)
- [x] `pytest -q -m "not slow and not e2e"` — 1189 passed, 5 pre-existing failures unrelated to this change (Windows POSIX-permission-bit assertions)
- [x] No JS test framework exists in this repo, so the insertion construction, overlap tracking, and wind tie-break were verified with hand-rolled Node smoke tests exercising `constructInsertionTour` and `optimize()` directly (multi-zone insertion beats naive out-and-back, single/empty-candidate edge cases, wind-driven tour reversal in both directions) — caught and fixed a real bug this way (a variable-ordering typo was producing `NaN` route distances) before it reached the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)