### PR TITLE
Harden exploration roads/route endpoints against bad input and unbounded caches

### DIFF
--- a/app/api/planner_bp.py
+++ b/app/api/planner_bp.py
@@ -13,6 +13,7 @@ Routes:
   GET  /api/geocode
 """
 
+import math
 from datetime import datetime
 
 from flask import Blueprint, current_app, jsonify, request
@@ -23,6 +24,22 @@ from src.secure_logger import SecureLogger
 logger = SecureLogger(__name__)
 
 bp = Blueprint('planner', __name__, url_prefix='/api')
+
+# Largest bbox span (degrees) accepted by bbox-based exploration endpoints.
+# Matches what the Explore UI can realistically request on-screen; anything
+# larger risks a huge Overpass download / graph build (#481).
+MAX_BBOX_DEGREES = 0.5
+
+
+def _validate_bbox(south, west, north, east):
+    """Return an error message string if the bbox is malformed or too large, else None."""
+    if south >= north:
+        return 'south must be less than north'
+    if west >= east:
+        return 'west must be less than east'
+    if (north - south) > MAX_BBOX_DEGREES or (east - west) > MAX_BBOX_DEGREES:
+        return f'bounding box too large (max {MAX_BBOX_DEGREES} degrees per side)'
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -145,6 +162,9 @@ def exploration_tiles():
         }), 400
 
     if all(v is not None for v in (south, west, north, east)):
+        bbox_error = _validate_bbox(south, west, north, east)
+        if bbox_error:
+            return jsonify({'status': 'error', 'message': bbox_error}), 400
         result = svc.get_tile_coverage((south, west, north, east), zoom=zoom)
     else:
         result = svc.get_tile_coverage_all(zoom=zoom)
@@ -167,6 +187,10 @@ def exploration_roads():
     if any(v is None for v in (south, west, north, east)):
         return jsonify({'status': 'error', 'message': 'south, west, north, east are required'}), 400
 
+    bbox_error = _validate_bbox(south, west, north, east)
+    if bbox_error:
+        return jsonify({'status': 'error', 'message': bbox_error}), 400
+
     result = svc.get_road_coverage((south, west, north, east))
     status_code = 200 if result.get('status') == 'success' else 500
     return jsonify(result), status_code
@@ -180,6 +204,30 @@ def exploration_invalidate():
     return jsonify({'status': 'success', 'message': 'Coverage caches invalidated'})
 
 
+MAX_ROUTE_WAYPOINTS = 50
+
+
+def _validate_waypoints(waypoints):
+    """Return an error message string if waypoints are malformed, else None."""
+    if not waypoints or not isinstance(waypoints, list) or len(waypoints) < 2:
+        return 'waypoints must be a list of at least 2 [lat, lon] pairs'
+    if len(waypoints) > MAX_ROUTE_WAYPOINTS:
+        return f'waypoints list too large (max {MAX_ROUTE_WAYPOINTS})'
+    for wp in waypoints:
+        if not isinstance(wp, (list, tuple)) or len(wp) != 2:
+            return 'each waypoint must be a [lat, lon] pair'
+        lat, lon = wp
+        if isinstance(lat, bool) or isinstance(lon, bool) or not isinstance(lat, (int, float)) or not isinstance(lon, (int, float)):
+            return 'each waypoint must be a [lat, lon] pair of numbers'
+        if not (math.isfinite(lat) and math.isfinite(lon)):
+            return 'waypoint coordinates must be finite numbers'
+        if not (-90 <= lat <= 90):
+            return 'waypoint latitude must be between -90 and 90'
+        if not (-180 <= lon <= 180):
+            return 'waypoint longitude must be between -180 and 180'
+    return None
+
+
 @bp.route('/exploration/route', methods=['POST'])
 @limiter.limit("20 per minute")
 def exploration_route():
@@ -187,8 +235,9 @@ def exploration_route():
     svc = current_app.container.get_exploration_service()
     data = request.get_json(silent=True) or {}
     waypoints = data.get('waypoints')
-    if not waypoints or not isinstance(waypoints, list) or len(waypoints) < 2:
-        return jsonify({'status': 'error', 'message': 'waypoints must be a list of at least 2 [lat, lon] pairs'}), 400
+    waypoints_error = _validate_waypoints(waypoints)
+    if waypoints_error:
+        return jsonify({'status': 'error', 'message': waypoints_error}), 400
     surface_preference = data.get('surface_preference', 'any')
     if surface_preference not in ('any', 'paved', 'unpaved'):
         return jsonify({'status': 'error', 'message': 'surface_preference must be any, paved, or unpaved'}), 400

--- a/app/services/exploration_service.py
+++ b/app/services/exploration_service.py
@@ -26,6 +26,10 @@ _PAVED_SURFACE_VALUES = {0, 1, 2, 3, 4, 5, 6}    # asphalt, concrete, paved, ...
 _UNPAVED_SURFACE_VALUES = {7, 8, 9, 10, 11, 12}   # gravel, dirt, grass, ...
 # Values outside both sets are treated as unknown.
 
+# Cap on retained route-memo entries (#482) — each entry holds a full route
+# polyline, so an unbounded dict is a slow memory leak on a long-running Pi.
+MAX_ROUTE_CACHE_ENTRIES = 200
+
 
 class ExplorationService:
 
@@ -66,6 +70,22 @@ class ExplorationService:
 
     def invalidate_caches(self):
         self._tracker.invalidate_caches()
+
+    def _store_route_cache(self, cache_key: tuple, result: dict, expires_at: float) -> None:
+        """Store a route memo entry, evicting expired entries first and then
+        the oldest entries if still over the cap (#482)."""
+        now = time.monotonic()
+        expired = [k for k, (_, exp) in self._route_cache.items() if exp <= now]
+        for k in expired:
+            del self._route_cache[k]
+
+        self._route_cache[cache_key] = (result, expires_at)
+
+        if len(self._route_cache) > MAX_ROUTE_CACHE_ENTRIES:
+            # dicts preserve insertion order — oldest entries were inserted first.
+            overflow = len(self._route_cache) - MAX_ROUTE_CACHE_ENTRIES
+            for k in list(self._route_cache.keys())[:overflow]:
+                del self._route_cache[k]
 
     def verify_tile_claims(
         self,
@@ -194,7 +214,7 @@ class ExplorationService:
             logger.error("Failed to parse ORS response: %s", exc, exc_info=True)
             return {"status": "error", "message": "Unexpected ORS response format"}
 
-        self._route_cache[cache_key] = (result, time.monotonic() + ttl)
+        self._store_route_cache(cache_key, result, time.monotonic() + ttl)
         return result
 
     # ── helpers ──────────────────────────────────────────────────

--- a/src/coverage_tracker.py
+++ b/src/coverage_tracker.py
@@ -25,6 +25,7 @@ TILE_ZOOM = 14              # "squadrat" granularity (squadrat.at / squadrat.com
 SQUADRATINHO_ZOOM = 17      # "squadratinho" granularity — each squadrat = 8x8 squadratinhos
 INTERPOLATION_INTERVAL_M = 80
 EARTH_RADIUS_M = 6_371_000
+MAX_ROAD_NETWORK_CACHES = 20  # cap on retained road_network_<hash>.graphml files
 
 
 @dataclass
@@ -56,6 +57,13 @@ class TileCoverage:
             "computed_at": self.computed_at,
             "zoom": self.zoom,
         }
+
+
+def _bbox_cache_key(bounds: Tuple[float, float, float, float]) -> str:
+    """Stable short hash for a (rounded) bbox, used to key per-bbox caches."""
+    rounded = tuple(round(v, 5) for v in bounds)
+    raw = ",".join(str(v) for v in rounded)
+    return hashlib.sha1(raw.encode("utf-8")).hexdigest()[:16]
 
 
 def lat_lon_to_tile(lat: float, lon: float, zoom: int = TILE_ZOOM) -> Tuple[int, int]:
@@ -451,7 +459,7 @@ class CoverageTracker:
             return {"status": "error", "message": "Road coverage requires osmnx and shapely"}
 
         south, west, north, east = bounds
-        graph_cache = self.cache_dir / "road_network.graphml"
+        graph_cache = self.cache_dir / f"road_network_{_bbox_cache_key(bounds)}.graphml"
 
         if graph_cache.exists():
             try:
@@ -471,6 +479,8 @@ class CoverageTracker:
                     simplify=True,
                 )
                 ox.save_graphml(G, graph_cache)
+                secure_chmod(graph_cache)
+                self._evict_old_road_network_caches()
             except Exception as exc:
                 logger.error("Failed to fetch road network: %s", exc)
                 return {"status": "error", "message": str(exc)}
@@ -558,6 +568,20 @@ class CoverageTracker:
         except OSError as exc:
             logger.warning("Failed to write tile cache: %s", exc)
 
+    def _evict_old_road_network_caches(self) -> None:
+        """Keep at most MAX_ROAD_NETWORK_CACHES road_network_*.graphml files,
+        evicting the least-recently-modified ones beyond that cap."""
+        caches = sorted(
+            self.cache_dir.glob("road_network_*.graphml"),
+            key=lambda p: p.stat().st_mtime,
+            reverse=True,
+        )
+        for p in caches[MAX_ROAD_NETWORK_CACHES:]:
+            try:
+                p.unlink()
+            except OSError:
+                pass
+
     def invalidate_caches(self) -> None:
         """Remove all coverage caches (call after new activities are fetched)."""
         self._activities_cache = None
@@ -566,10 +590,16 @@ class CoverageTracker:
                 p.unlink()
             except OSError:
                 pass
-        graph_cache = self.cache_dir / "road_network.graphml"
-        if graph_cache.exists():
+        for p in self.cache_dir.glob("road_network_*.graphml"):
             try:
-                graph_cache.unlink()
+                p.unlink()
+            except OSError:
+                pass
+        # Legacy unkeyed cache filename from before bbox-keyed caching (#481).
+        legacy_cache = self.cache_dir / "road_network.graphml"
+        if legacy_cache.exists():
+            try:
+                legacy_cache.unlink()
             except OSError:
                 pass
         logger.info("Coverage caches invalidated")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -214,13 +214,13 @@ class TestExplorationTilesAPI:
 
     def test_bounded_request_with_zoom(self, client):
         response = client.get(
-            '/api/exploration/tiles?south=41.0&west=-88.0&north=42.0&east=-87.0&zoom=17'
+            '/api/exploration/tiles?south=41.0&west=-88.0&north=41.4&east=-87.6&zoom=17'
         )
         assert response.status_code == 200
         data = response.get_json()
         assert data['status'] == 'success'
         assert data['zoom'] == 17
-        assert data['bounds'] == [41.0, -88.0, 42.0, -87.0]
+        assert data['bounds'] == [41.0, -88.0, 41.4, -87.6]
 
 
 @pytest.mark.unit
@@ -283,6 +283,111 @@ class TestExplorationVerifyTilesAPI:
             'tiles': [{'x': 1, 'y': 1, 'zoom': 14}],
         })
         assert response.status_code == 400
+
+
+@pytest.mark.unit
+class TestExplorationBboxValidation:
+    """Tests for #481 — bbox sanity checks on /api/exploration/tiles and /api/exploration/roads."""
+
+    def test_tiles_inverted_bounds_rejected(self, client):
+        response = client.get(
+            '/api/exploration/tiles?south=42.0&west=-88.0&north=41.0&east=-87.0'
+        )
+        assert response.status_code == 400
+
+    def test_tiles_oversized_bbox_rejected(self, client):
+        response = client.get(
+            '/api/exploration/tiles?south=30.0&west=-100.0&north=45.0&east=-70.0'
+        )
+        assert response.status_code == 400
+
+    def test_tiles_bbox_within_limit_accepted(self, client):
+        response = client.get(
+            '/api/exploration/tiles?south=41.0&west=-88.0&north=41.4&east=-87.6'
+        )
+        assert response.status_code == 200
+
+    def test_roads_inverted_bounds_rejected(self, client):
+        response = client.get(
+            '/api/exploration/roads?south=42.0&west=-88.0&north=41.0&east=-87.0'
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data['status'] == 'error'
+
+    def test_roads_oversized_bbox_rejected(self, client):
+        response = client.get(
+            '/api/exploration/roads?south=30.0&west=-100.0&north=45.0&east=-70.0'
+        )
+        assert response.status_code == 400
+        data = response.get_json()
+        assert data['status'] == 'error'
+        assert 'too large' in data['message'].lower()
+
+    def test_roads_missing_bounds_rejected(self, client):
+        response = client.get('/api/exploration/roads?south=41.0&west=-88.0')
+        assert response.status_code == 400
+
+
+@pytest.mark.unit
+class TestExplorationRouteWaypointValidation:
+    """Tests for #482 — per-waypoint validation and count cap on /api/exploration/route."""
+
+    def test_too_few_waypoints_rejected(self, client):
+        response = client.post('/api/exploration/route', json={'waypoints': [[40.0, -74.0]]})
+        assert response.status_code == 400
+
+    def test_missing_waypoints_rejected(self, client):
+        response = client.post('/api/exploration/route', json={})
+        assert response.status_code == 400
+
+    def test_non_pair_waypoint_rejected(self, client):
+        response = client.post('/api/exploration/route', json={
+            'waypoints': [[1, 2], 'x'],
+        })
+        assert response.status_code == 400
+
+    def test_null_coordinate_rejected(self, client):
+        response = client.post('/api/exploration/route', json={
+            'waypoints': [[None, None], [1, 2]],
+        })
+        assert response.status_code == 400
+
+    def test_out_of_range_latitude_rejected(self, client):
+        response = client.post('/api/exploration/route', json={
+            'waypoints': [[95.0, -74.0], [40.0, -73.0]],
+        })
+        assert response.status_code == 400
+
+    def test_out_of_range_longitude_rejected(self, client):
+        response = client.post('/api/exploration/route', json={
+            'waypoints': [[40.0, -200.0], [41.0, -73.0]],
+        })
+        assert response.status_code == 400
+
+    def test_non_numeric_coordinate_rejected(self, client):
+        response = client.post('/api/exploration/route', json={
+            'waypoints': [["a", "b"], [41.0, -73.0]],
+        })
+        assert response.status_code == 400
+
+    def test_too_many_waypoints_rejected(self, client):
+        response = client.post('/api/exploration/route', json={
+            'waypoints': [[40.0 + i * 0.001, -74.0] for i in range(51)],
+        })
+        assert response.status_code == 400
+        data = response.get_json()
+        assert 'too large' in data['message'].lower()
+
+    def test_valid_waypoints_pass_validation(self, client):
+        """Without an ORS API key configured, valid waypoints still get past
+        input validation and fail later with a config error, not a 400."""
+        response = client.post('/api/exploration/route', json={
+            'waypoints': [[40.0, -74.0], [40.1, -74.1]],
+        })
+        assert response.status_code == 500
+        data = response.get_json()
+        assert 'not configured' in data['message'].lower()
 
 
 @pytest.mark.unit

--- a/tests/test_coverage_tracker.py
+++ b/tests/test_coverage_tracker.py
@@ -12,12 +12,14 @@ from src.coverage_tracker import (
     TileCoverage,
     lat_lon_to_tile,
     tile_to_bounds,
+    _bbox_cache_key,
     _haversine_m,
     _interpolate_points,
     _segment_tiles,
     _activity_tiles,
     TILE_ZOOM,
     SQUADRATINHO_ZOOM,
+    MAX_ROAD_NETWORK_CACHES,
 )
 
 
@@ -382,3 +384,85 @@ class TestCoverageTracker:
         ]
         result = tracker.get_tile_coverage_all()
         assert result.visited_count == 0
+
+
+# ── road_network cache keying / eviction (#481) ──────────────────
+
+class TestBboxCacheKey:
+    def test_different_bounds_give_different_keys(self):
+        k1 = _bbox_cache_key((40.0, -75.0, 41.0, -74.0))
+        k2 = _bbox_cache_key((10.0, 10.0, 11.0, 11.0))
+        assert k1 != k2
+
+    def test_same_bounds_give_same_key(self):
+        k1 = _bbox_cache_key((40.0, -75.0, 41.0, -74.0))
+        k2 = _bbox_cache_key((40.0, -75.0, 41.0, -74.0))
+        assert k1 == k2
+
+    def test_rounding_collapses_near_identical_bounds(self):
+        k1 = _bbox_cache_key((40.000001, -75.0, 41.0, -74.0))
+        k2 = _bbox_cache_key((40.000002, -75.0, 41.0, -74.0))
+        assert k1 == k2
+
+
+class TestRoadNetworkCacheEviction:
+    @pytest.fixture
+    def mock_config(self):
+        config = MagicMock()
+        config.get = MagicMock(side_effect=lambda key, default=None: default)
+        return config
+
+    @pytest.fixture
+    def tracker(self, mock_config, tmp_path):
+        t = CoverageTracker(mock_config)
+        t.cache_dir = tmp_path
+        return t
+
+    def test_get_road_coverage_keys_cache_by_bbox(self, tracker):
+        """Different bboxes must not collide on a single fixed cache filename (#481)."""
+        tracker._activities_cache = []
+
+        import pandas as pd
+        edges_df = pd.DataFrame({"geometry": [], "length": []})
+
+        def fake_save_graphml(G, path):
+            Path(path).write_text("fake-graph")
+
+        mock_ox = MagicMock()
+        mock_ox.graph_from_bbox.return_value = MagicMock()
+        mock_ox.save_graphml.side_effect = fake_save_graphml
+        mock_ox.load_graphml.side_effect = OSError("no cache yet")
+        mock_ox.graph_to_gdfs.side_effect = lambda G, nodes=False, edges=True: edges_df
+
+        mock_shapely_geometry = MagicMock(LineString=MagicMock(), Point=MagicMock())
+        mock_shapely_strtree = MagicMock(STRtree=MagicMock())
+
+        with patch.dict("sys.modules", {
+            "osmnx": mock_ox,
+            "shapely": MagicMock(),
+            "shapely.geometry": mock_shapely_geometry,
+            "shapely.strtree": mock_shapely_strtree,
+        }):
+            r1 = tracker.get_road_coverage((40.0, -75.0, 41.0, -74.0))
+            r2 = tracker.get_road_coverage((10.0, 10.0, 11.0, 11.0))
+
+        assert r1.get("status") == "success"
+        assert r2.get("status") == "success"
+        cache_files = list(tracker.cache_dir.glob("road_network_*.graphml"))
+        assert len(cache_files) == 2
+
+    def test_evict_old_road_network_caches_caps_count(self, tracker):
+        for i in range(MAX_ROAD_NETWORK_CACHES + 5):
+            p = tracker.cache_dir / f"road_network_fake{i}.graphml"
+            p.write_text("x")
+        tracker._evict_old_road_network_caches()
+        remaining = list(tracker.cache_dir.glob("road_network_*.graphml"))
+        assert len(remaining) == MAX_ROAD_NETWORK_CACHES
+
+    def test_invalidate_caches_removes_all_bbox_keyed_graphs(self, tracker):
+        for i in range(3):
+            (tracker.cache_dir / f"road_network_fake{i}.graphml").write_text("x")
+        (tracker.cache_dir / "road_network.graphml").write_text("legacy")
+        tracker.invalidate_caches()
+        remaining = list(tracker.cache_dir.glob("road_network*.graphml"))
+        assert remaining == []

--- a/tests/test_exploration_service.py
+++ b/tests/test_exploration_service.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from app.services.exploration_service import ExplorationService, _SURFACE_TO_PROFILE
+from app.services.exploration_service import ExplorationService, _SURFACE_TO_PROFILE, MAX_ROUTE_CACHE_ENTRIES
 from src.coverage_tracker import (
     TileCoverage,
     TILE_ZOOM,
@@ -391,6 +391,48 @@ class TestComputeRoute:
                 service_with_key._route_cache[k] = (result, time.monotonic() - 1)
             service_with_key.compute_route([[41.98, -87.65], [41.99, -87.64]])
         assert mock_get.call_count == 2
+
+    def test_route_cache_evicts_expired_entries_on_write(self, service_with_key):
+        """Expired memo entries must not accumulate forever (#482)."""
+        raw = {
+            "features": [{
+                "geometry": {"coordinates": [[-87.65, 41.98], [-87.64, 41.99]]},
+                "properties": {
+                    "summary": {"distance": 1000.0, "duration": 300.0},
+                    "extras": {},
+                },
+            }],
+        }
+        with patch("src.ors_client.get_route", return_value=raw):
+            service_with_key.compute_route([[41.98, -87.65], [41.99, -87.64]])
+            assert len(service_with_key._route_cache) == 1
+
+            # Expire the existing entry, then trigger another write.
+            for k in list(service_with_key._route_cache.keys()):
+                result, _ = service_with_key._route_cache[k]
+                service_with_key._route_cache[k] = (result, time.monotonic() - 1)
+
+            service_with_key.compute_route([[40.0, -80.0], [40.1, -80.1]])
+
+        # The expired entry should have been evicted, leaving only the new one.
+        assert len(service_with_key._route_cache) == 1
+
+    def test_route_cache_caps_total_entries(self, service_with_key):
+        """Once over the cap, oldest entries are evicted rather than growing forever (#482)."""
+        raw = {
+            "features": [{
+                "geometry": {"coordinates": [[-87.65, 41.98], [-87.64, 41.99]]},
+                "properties": {
+                    "summary": {"distance": 1000.0, "duration": 300.0},
+                    "extras": {},
+                },
+            }],
+        }
+        with patch("src.ors_client.get_route", return_value=raw):
+            for i in range(MAX_ROUTE_CACHE_ENTRIES + 10):
+                service_with_key.compute_route([[41.0, -87.0 - i * 0.001], [41.1, -87.1 - i * 0.001]])
+
+        assert len(service_with_key._route_cache) == MAX_ROUTE_CACHE_ENTRIES
 
 
 # ── surface_breakdown reduction ──────────────────────────────────


### PR DESCRIPTION
## Summary
- Fixes #481, #482.
- **#481**: the road-network graph cache (`src/coverage_tracker.py::get_road_coverage()`) was a single fixed filename shared across every requested bbox — whatever bbox was requested first got cached, and every subsequent request for different bounds silently scored against the stale graph (e.g. panning the Explore map to a new area returned the old area's roads). Keys the cache filename by a SHA1 hash of the (rounded) requested bbox, caps retained graphs at 20 (evicting oldest by mtime), and adds bbox sanity validation (`south < north`, `west < east`, no side larger than ~0.5°) to both `/api/exploration/roads` and `/api/exploration/tiles` — the endpoints are unauthenticated on the LAN, and an unbounded bbox could trigger a country-sized osmnx/Overpass fetch that OOMs a Pi 4.
- **#482**: `/api/exploration/route` only checked that `waypoints` was a list of length ≥2, so malformed entries (non-numeric, out-of-range, `null`) raised unhandled TypeError/ValueError → 500s downstream in `ExplorationService.compute_route()`. Adds per-waypoint validation (each must be a `[lat, lon]` pair of finite numbers in range) returning 400 on failure, caps waypoints at 50 to bound ORS quota usage (the unroutable-waypoint retry loop can issue up to ~10 follow-up calls per request), and evicts expired/excess entries from the route memo cache on write so it stops growing unbounded on a long-running Pi deployment.

## Test plan
- [x] Extended existing test files rather than adding new ones: `tests/test_coverage_tracker.py` (bbox key hashing, cache-file separation per bbox, eviction cap, invalidate-caches cleanup), `tests/test_exploration_service.py` (route-cache eviction of expired and oldest entries), `tests/test_api.py` (bbox validation on `/api/exploration/tiles` and `/api/exploration/roads`, waypoint validation on `/api/exploration/route` including the exact malformed-input cases from the issue)
- [x] Full suite: 1208 passed, 5 pre-existing failures unrelated to this change (Windows POSIX-permission-bit assertions)
- [x] One pre-existing test (`test_bounded_request_with_zoom`) used a 1° bbox and was shrunk to fit the new 0.5° cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)