### PR TITLE
Close #451, #452, #453, #482 (already shipped) and refresh issue priorities

### DIFF
--- a/ISSUE_PRIORITIES.md
+++ b/ISSUE_PRIORITIES.md
@@ -1,6 +1,6 @@
 # Issue Prioritization
 
-**Last Updated:** 2026-07-17 12:53:06 UTC / 2026-07-17 12:53:06 GMT
+**Last Updated:** 2026-07-17 23:18:44 UTC / 2026-07-17 23:18:44 GMT
 
 This file reflects the current state of GitHub issues organized by release milestone and priority within each release.
 
@@ -19,27 +19,16 @@ This file reflects the current state of GitHub issues organized by release miles
 **Priority within this release determines work order. Complete P0/P1 issues before moving to future releases.**
 
 ### 🔴 P0 - CRITICAL
-- #477 - route_analyzer.py::_open_geocoding_terminal is macOS-only, silently no-ops on Windows/Linux
-- #459 - Lost-update races in read-modify-write JSON flows (plan storage, TrainerRoad cache)
+**No P0 issues** ✅
 
 ### 🔴 P1 - HIGH
-- #493 - Explore: plotted road routes can claim zero of their highlighted new tiles — never verified against the actual route
-- #489 - Explore: replace implicit round-trip with explicit route shape (Loop / Out-and-back / Point-to-point)
+**No P1 issues** ✅
 
 ### 🟡 P2 - MEDIUM
-- #492 - Epic: Explore Route Generator — Shape/Duration/Area Targeting, Trim Coverage-Browser Scope
-- #491 - Explore: let rider draw/select a target area instead of only start-point + radius
-- #490 - Explore: add duration-based route target alongside distance
-- #488 - Explore: fold full-map coverage browsing into route-generation feedback; drop standalone browse mode
-- #487 - Explore: audit and prune optimizeFor strategy sprawl (tiles/distance/efficiency/infill/frontier)
-- #481 - /api/exploration/roads: unbounded bbox can OOM the Pi via osmnx, and road_network.graphml cache ignores requested bounds (wrong results after panning)
-- #451 - Exploration route generator: extend overlap penalty to tiles claimed within the in-progress tour
+**No P2 issues** ✅
 
 ### 🟢 P3 - LOW
-- #482 - /api/exploration/route: waypoints not validated (500s on malformed input, no count cap → ORS quota burn) and route memo cache grows unbounded
-- #453 - Exploration route generator: wind-aware outbound/return orientation (headwind out, tailwind back)
-- #452 - Exploration route generator: detect and label unavoidable out-and-back routes
-- #430 - Coverage tracker should include Garmin activities, not just Strava
+- #514 - Offload background analysis batch jobs to Pi Zero W cluster (ClusterHAT)
 
 ### 📋 P4 - FUTURE
 **No P4 issues** ✅
@@ -50,7 +39,26 @@ This file reflects the current state of GitHub issues organized by release miles
 
 These issues need to be assigned to a release milestone and prioritized.
 
-**All issues are assigned to releases** ✅
+### 🔴 P0 - CRITICAL
+None
+
+### 🔴 P1 - HIGH
+None
+
+### 🟡 P2 - MEDIUM
+None
+
+### 🟢 P3 - LOW
+- #516 - Re-enable amd64 in docker-publish.yml if a non-Pi deployment target appears
+
+### 📋 P4 - FUTURE
+None
+
+### ⚠️ Unprioritized (No P-label)
+- #526 - Add HTTPS/TLS to Pi deployment (required for geolocation and other secure-context APIs)
+- #525 - Explore tab: exclude over-water tiles from new-tile scoring/generation
+- #519 - Recommend routes based on scheduled TrainerRoad outdoor workouts, not just basic commute patterns
+- #518 - Indoor-workout weather trigger: only checks cold + rain — add max forecast temp and air quality
 
 ---
 


### PR DESCRIPTION
## Summary
- #451, #452, #453 (exploration route generator overlap/out-and-back/wind orientation) and #482 (exploration route validation/caching hardening) were all fixed and merged already, in #522 (commit 156290d) and #524 (commit 34ec717) respectively.
- Each PR's body only auto-linked one issue number to close (#450 and #481 respectively), so these four stayed open on GitHub despite the fix landing on `main`.
- Closed all four via `gh issue close` with a comment pointing to the merge commit and passing tests.
- Regenerated `ISSUE_PRIORITIES.md` via `scripts/update-issue-priorities.sh` — it was also stale on `main`, still listing several other already-resolved issues (#477, #459, #493, #489, #492, #490, #488, #487, #481, #430) from before recent merges.

## Test plan
- [x] `pytest tests/test_exploration_service.py -q` — 34 passed, confirming the merged #451/#452/#453/#482 fixes are intact on `main`.
- [x] Verified via `gh issue view` that #451/#452/#453/#482 are now closed with links to the fixing commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)