### PR TITLE
Fix explore routes plotting far short of target distance

### DIFF
--- a/static/js/exploration-worker.js
+++ b/static/js/exploration-worker.js
@@ -193,6 +193,15 @@ function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData
             tiles: zones.flatMap(z => z.tiles.map(t => ({ x: t.x, y: t.y }))),
         }));
 
+        // Leftover pool zones that Phase 1 didn't select (budget-capped or
+        // below the tiles/km bar) — passed through so Phase 2 (explore.js
+        // refineRoute) can pull one in if the plotted road route comes back
+        // short of the distance target, instead of only being able to pad
+        // with a straight-line displacement that may not follow any road.
+        const leftoverCandidates = pool
+            .filter(z => !selected.includes(z))
+            .map(z => ({ lat: z.point.lat, lon: z.point.lon }));
+
         totalRoutes++;
         self.postMessage({
             type: 'route',
@@ -210,6 +219,7 @@ function optimize({ start, end, distanceKm, mode, routeType, shape, coverageData
                     distanceKm: routeDistance(start, ordered, end),
                 },
             },
+            candidates: leftoverCandidates,
         });
     });
 

--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -1079,6 +1079,16 @@ async function refineRoute(baseWaypoints, targetKm, surfacePref, candidateList, 
         }
     }
 
+    // #526 — if candidates and displacement padding were exhausted without
+    // ever getting close to the target (e.g. the padding direction runs
+    // into water or a road-network dead end), don't silently hand back a
+    // route that's a small fraction of the requested distance. Over-length
+    // stuck results are still returned above (getting a longer ride than
+    // asked isn't nearly as broken as a near-zero-length one).
+    if (result && result.distance_km / targetKm < 1 - TOLERANCE) {
+        return null;
+    }
+
     return result;
 }
 


### PR DESCRIPTION
## Summary
- `exploration-worker.js` never sent a `candidates` field in its `postMessage`, so Phase 2's "add next candidate zone" recovery path in `refineRoute` was always dead code.
- `refineRoute` returned its result unconditionally even when it never got close to the target distance (e.g. padding direction hits water or a road-network dead end), silently plotting/exporting a route a tiny fraction of the requested distance (0.6mi vs a 24.9mi target).

## Fix
- Worker now forwards leftover (unselected) candidate zones from the pool so refinement can insert a real nearby unvisited zone instead of only a straight-line displacement point.
- `refineRoute` now rejects (`return null`) a result that's still well under target after exhausting all recovery options, instead of returning a near-zero-length route as if it succeeded.

## Test plan
- [x] `node --check` on both modified files
- [x] `pytest` full suite — 1225 passed, 11 skipped, 5 pre-existing Windows-permission-model failures unrelated to this change
- [ ] Manual verification on Pi after deploy: generate a loop route near water/dead-end road network and confirm no near-zero-length route is plotted/exportable

🤖 Generated with [Claude Code](https://claude.com/claude-code)