### PR TITLE
Fix stale roadless-tile comments (#525 follow-up)

### DIFF
--- a/static/js/exploration-worker.js
+++ b/static/js/exploration-worker.js
@@ -16,9 +16,9 @@
  *       different corridors (loop) or deliberately retrace the same one
  *       (out_and_back). Ignored when routeType is 'point_to_point'.
  *   - coverageData: {visited: {"x,y": {...}}, total_in_bounds, bounds, zoom,
- *       roadless?: [{x, y}]} — roadless (#525) lists tiles with no nearby
- *       bike-network road, i.e. not bikeable or walkable (open water and
- *       other unreachable terrain); excluded from new-tile targeting.
+ *       roadless?: [{x, y}]} — roadless (#525) lists tiles that fall inside
+ *       open water (OSM natural=water polygons), i.e. not bikeable or
+ *       walkable; excluded from new-tile targeting.
  *       Absent/empty when the roadless lookup wasn't available.
  *   - coverageDataSecondary: same shape as coverageData, at a different zoom | null
  *       When present ("Both" grid mode), routes are optimized against both
@@ -74,9 +74,9 @@ function scanGrid(coverageData, start, reachRadius, areaBounds) {
 
     const allTiles = buildTileSet(bounds, zoom);
     const visitedSet = new Set(Object.keys(coverageData.visited || {}));
-    // #525: exclude tiles with no bike-network road nearby — not bikeable
-    // or walkable (open water and other unreachable terrain) — from "new
-    // tile" targeting. Best-effort: empty/absent when the roadless lookup failed.
+    // #525: exclude tiles that are open water (not bikeable or walkable)
+    // from "new tile" targeting. Best-effort: empty/absent when the
+    // roadless lookup failed.
     const roadlessSet = new Set((coverageData.roadless || []).map(t => `${t.x},${t.y}`));
     const unvisited = allTiles.filter(t => !visitedSet.has(t.key) && !roadlessSet.has(t.key));
 


### PR DESCRIPTION
## Summary
- The #525 fix (0f9472b, f2a8555) is already merged to main and fully wired end-to-end (Overpass `natural=water` polygon lookup → `/api/exploration/roadless-tiles` → `explore.js` → `exploration-worker.js`, which excludes those tiles from new-tile scoring).
- Two comments in `exploration-worker.js` still described the original (later replaced) osmnx bike-network-graph-absence heuristic instead of the actual water-polygon check landed in f2a8555. This updates them to match current behavior.

## Test plan
- [x] `pytest tests/test_coverage_tracker.py tests/test_api.py` — 123 passed
- [x] Full suite: 1241 passed, 5 pre-existing failures unrelated to this change (Windows POSIX file-permission checks)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>