### PR TITLE
Drop unverified tile count from Phase-1 directional route labels

### DIFF
--- a/static/js/explore.js
+++ b/static/js/explore.js
@@ -1053,7 +1053,7 @@ function renderRoute(route, index) {
         weight: 3,
         dashArray: '8, 8',
         opacity: 0.8,
-    }).bindPopup(`${routeDirLabel(route)} — ${distanceLabel}, ${newTilesLabel(route.stats)}`);
+    }).bindPopup(`${routeDirLabel(route)} — ${distanceLabel}`);
     line.on('click', (e) => { L.DomEvent.stopPropagation(e); highlightRoute(route.direction); });
     routeLayer.addLayer(line);
     addArrows(coords, palette.light);
@@ -1069,13 +1069,6 @@ function routeDirLabel(route) {
     return `${DIRECTION_LABELS[route.direction]}${shapeTag}`;
 }
 
-function newTilesLabel(stats) {
-    if (stats.breakdown && stats.breakdown.length > 0) {
-        return stats.breakdown.map(b => `${b.count} new ${b.label}`).join(' + ');
-    }
-    return `${stats.unvisited} new tiles`;
-}
-
 function addRouteListItem(route, index, targetDistanceKm, extraLabel = '') {
     const palette = _paletteFor(route.direction);
     const color = palette.base;
@@ -1089,7 +1082,7 @@ function addRouteListItem(route, index, targetDistanceKm, extraLabel = '') {
     badge.innerHTML = `
         <div class="d-flex align-items-center gap-2 w-100">
             <span class="swatch"></span>
-            <span class="route-label">${routeDirLabel(route)} · ${distanceLabel} · ${newTilesLabel(route.stats)}${extraLabel ? ' ' + extraLabel : ''}${route.windLabel ? ' · ' + route.windLabel : ''}</span>
+            <span class="route-label">${routeDirLabel(route)} · ${distanceLabel}${extraLabel ? ' ' + extraLabel : ''}${route.windLabel ? ' · ' + route.windLabel : ''}</span>
             <button class="btn btn-xs btn-outline-primary ms-auto plot-road-btn" data-direction="${dir}"
                     aria-label="Plot road route for ${DIRECTION_LABELS[dir]}">
                 <i class="bi bi-map" aria-hidden="true"></i> Plot road route


### PR DESCRIPTION
## Summary
- Phase-1 candidate route badges/popups on the Explore page no longer show a new-tile count — that figure was a geometric estimate from the straight-line waypoint preview and could diverge once the route was actually plotted onto roads.
- Distance stays on the first pass (already a reasonable estimate).
- The road-verified tile count still appears once "Plot road route" resolves, via the existing `route-phase2-info` panel driven by `findNewTilesForRoute`.
- No change to quadrant generation, colors, or other route attributes.

Closes #537

## Test plan
- [x] Reviewed all call sites of `newTilesLabel()` removed cleanly, no other references remain
- [ ] Manual: generate directional routes on Explore page, confirm badges/popups show direction + distance only, then confirm tile count appears after "Plot road route"